### PR TITLE
LKBug: a utilization tool to create bug work item for pf commands 

### DIFF
--- a/examples/utils/lkbug/data.jsonl
+++ b/examples/utils/lkbug/data.jsonl
@@ -1,0 +1,1 @@
+{"log_path": "output_1689493245.txt"}

--- a/examples/utils/lkbug/error_details.jinja2
+++ b/examples/utils/lkbug/error_details.jinja2
@@ -1,0 +1,2 @@
+I'm sending you some commands and corresponding error message. Please summarize it and suggest a bug title for the issue. The summarize title should less than 15 words. 
+The error is : {{errormsg}}

--- a/examples/utils/lkbug/flow.dag.yaml
+++ b/examples/utils/lkbug/flow.dag.yaml
@@ -1,0 +1,29 @@
+inputs:
+  log_path:
+    type: string
+outputs:
+  suggest_title:
+    type: string
+    reference: ${error_summary.output}
+nodes:
+- name: read_log
+  type: python
+  source:
+    type: code
+    path: read_log.py
+  inputs:
+    log_path: ${inputs.log_path}
+- name: error_summary
+  type: llm
+  source:
+    type: code
+    path: error_details.jinja2
+  inputs:
+    deployment_name: text-davinci-003
+    max_tokens: '128'
+    temperature: '0.2'
+    errormsg: ${read_log.output}
+  provider: AzureOpenAI
+  connection: azure_open_ai_connection
+  api: completion
+node_variants: {}

--- a/examples/utils/lkbug/inputs.json
+++ b/examples/utils/lkbug/inputs.json
@@ -1,0 +1,1 @@
+{"log_path":"output_1689475770.txt"}

--- a/examples/utils/lkbug/lkbug.sh
+++ b/examples/utils/lkbug/lkbug.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# Usage: ./script.sh <command> [<output_file>]
+
+command_to_run=$1
+
+# Check if output file was provided; otherwise use a timestamp-based filename
+if [ -z "$2" ]; then
+  output_file="output_$(date +%s).txt"
+else
+  output_file=$2
+fi
+
+echo "${command_to_run}" > ${output_file}
+# Execute the command and redirect its output to the file
+${command_to_run} >> ${output_file} 2>&1
+
+# generate a file named data.jsonl , the content is a jsonl format data of {"log_path": "xxx"}, the xxx should be the output_file
+echo "{\"log_path\": \"${output_file}\"}" > data.jsonl
+
+# execute a command "pf run create --flow . --data data.jsonl --type batch" , read the output of the data, there should be a line with name "output_path", find the value of output_path
+#flow_command="pf run create --flow . --data data.jsonl --type batch"
+#${flow_command}
+flow_output=$(pf run create --flow . --data data.jsonl --type batch)
+
+#echo "$flow_output"
+# Find the line with the key "output_path" and retrieve its value
+output_line=$(echo "$flow_output" | grep "output_path" -m 1)
+
+output_dir=$(echo "$output_line" | awk -F': ' '{print $2}'| sed 's/,$//' | sed 's/"//g')
+
+
+output_data="${output_dir}\\outputs.jsonl"
+#echo "$output_data"
+
+suggest_title=$(python ./parse_output.py ${output_data} | tr -d "\"\'\r\n")
+# Output the value of "suggest_title"
+echo "$suggest_title"
+
+username=$(az account show --query 'user.name')
+
+description=$(cat "$output_file" | tr -d "\"\'")
+
+#fetch package version information
+pip_list_output=$(pip list)
+pakcage_info=$(echo "$pip_list_output" | grep "prompt")
+#echo "package information"
+#echo "$pakcage_info"
+
+#fetch OS Info
+if [[ "$OSTYPE" == "linux-gnu" ]]; then
+    OSType="Linux"
+elif [[ "$OSTYPE" == "msys" || "$OSTYPE" == "cygwin" || "$OSTYPE" == "win32" ]]; then
+    OSType="Windows"
+else
+    OSType="Unknown"
+fi
+
+#echo "OS Information: $OSType"
+
+SystemInfo="package information: $pakcage_info \r\n OS Information: $OSType"
+#echo "$SystemInfo"
+
+#echo "$description"
+
+item_cmd="az boards work-item create --title '$suggest_title' --type Bug --assigned-to $username --area 'Vienna\\Pipelines\\SDK' --iteration 'Vienna\\Gallium' --discussion '$description' --fields Microsoft.VSTS.TCM.SystemInfo='$SystemInfo' Microsoft.VSTS.TCM.ReproSteps='$command_to_run'"
+
+eval "$item_cmd"
+
+#echo "$item_cmd"

--- a/examples/utils/lkbug/parse_output.py
+++ b/examples/utils/lkbug/parse_output.py
@@ -1,0 +1,15 @@
+import json
+import sys
+
+# Get the file path from command-line arguments
+file_path = sys.argv[1]
+
+# Read the JSON file
+with open(file_path) as json_file:
+    data = json.load(json_file)
+
+# Extract the value of "suggest_title"
+suggest_title = data["suggest_title"].replace("\"", "")
+
+# Output the value of "suggest_title"
+print(suggest_title)

--- a/examples/utils/lkbug/read_log.py
+++ b/examples/utils/lkbug/read_log.py
@@ -1,0 +1,12 @@
+from promptflow import tool
+
+
+@tool
+def read_log(log_path: str):
+    try:
+        with open(log_path, 'r') as file:
+            data = file.read()
+        return data
+    except Exception as e:
+        print("input is not valid, error: {}".format(e))
+        return ""

--- a/examples/utils/lkbug/requirements.txt
+++ b/examples/utils/lkbug/requirements.txt
@@ -1,0 +1,6 @@
+--extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
+promptflow-sdk[azure,builtins]==0.0.99056313
+prompt-flow-tools==0.0.2
+python-dotenv
+langchain
+jinja2


### PR DESCRIPTION
(Just for FHL fun, not ready to merge)
See the lkbug.sh , the idea is when we test CLI samples, it's not easy to create bug quickly. The tool aim to make the create bug work easier. When you find some bug in command, eg "pf abc def" failed. Use this script to run: lkbug.sh "pf abc def" , it will:
(Assume you've installed AzureCLI and Azure dev-ops extension)
1. Execute the command and fetch the error message
2. Send the error message and command to LLM (through pf run create with a predefined promt-flow), and get the suggested bug title.
3. Fetch the package information , OS information
4. Create a bug and assigned to yourself first, with pre-defined area and project. 

It's still in a draft, things can be improved:

- The flow local run is leveraging the pf run create, better to export flow as an app, or use pf flow test to reduce the input/output prepare.
- Haven't design the flow to submit SDK bugs
- Make it run anywhere in the repo
- Support a mode to direct create bug instead of execute the command