### PR TITLE
ci: compliance check

### DIFF
--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -21,6 +21,8 @@ pool:
 
 steps:
 - checkout: self
+
+# https://eng.ms/docs/microsoft-security/cloud-ecosystem-security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/sdl-azdo-extension/PoliCheck-build-task
 - task: PoliCheck@2
   inputs:
     targetType: 'F'
@@ -28,6 +30,7 @@ steps:
     optionsPE: '1'
     optionsUEPATH: '$(sourceLocation)/scripts/compliance-check/user_exclusion.xml'
     result: '$(sourceLocation)/scripts/compliance-check/result.tsv'
+    optionsXCLASS: 'Geopolitical'
 
 - task: PowerShell@2
   inputs:
@@ -43,3 +46,8 @@ steps:
     targetPath: '$(sourceLocation)/scripts/compliance-check/result.tsv'
     artifactName: 'compliance-check-result'
     publishLocation: 'pipeline'
+
+- task: CredScan@3
+  displayName: 'CredScan'
+  inputs:
+    scanFolder: '$(sourceLocation)'

--- a/docs/cloud/azureai/quick-start.md
+++ b/docs/cloud/azureai/quick-start.md
@@ -17,7 +17,7 @@ Benefits of use Azure AI comparison to just run locally:
 3. A python environment, `python=3.9` is recommended.
 4. Install `promptflow` with extra dependencies and `promptflow-tools`.
 ```sh
-pip install promptflow[azure] promptflow-tools --extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
+pip install promptflow[azure] promptflow-tools
 ```
 5. Get the sample flows. 
    - Get access to the flow sample repository.

--- a/docs/how-to-guides/quick-start.md
+++ b/docs/how-to-guides/quick-start.md
@@ -11,7 +11,7 @@ This guide will walk you through the main user journey of prompt flow code-first
 1. A python environment, `python=3.9` is recommended.
 2. Install `promptflow` and `promptflow-tools`.
 ```sh
-pip install promptflow promptflow-tools --extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
+pip install promptflow promptflow-tools
 ```
 3. Get the sample flows. 
    - Get access to the flow sample repository.

--- a/examples/connections/requirements.txt
+++ b/examples/connections/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools
 python-dotenv

--- a/examples/flows/chat/basic-chat/requirements.txt
+++ b/examples/flows/chat/basic-chat/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/chat/chat-with-pdf/requirements.txt
+++ b/examples/flows/chat/chat-with-pdf/requirements.txt
@@ -4,6 +4,5 @@ openai
 jinja2
 python-dotenv
 tiktoken
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow[azure]
 promptflow-tools

--- a/examples/flows/chat/chat-with-wikipedia/requirements.txt
+++ b/examples/flows/chat/chat-with-wikipedia/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools
 bs4

--- a/examples/flows/evaluation/eval-basic/requirements.txt
+++ b/examples/flows/evaluation/eval-basic/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/evaluation/eval-classification-accuracy/requirements.txt
+++ b/examples/flows/evaluation/eval-classification-accuracy/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/evaluation/eval-entity-match-rate/requirements.txt
+++ b/examples/flows/evaluation/eval-entity-match-rate/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/evaluation/eval-groundedness/flow.dag.yaml
+++ b/examples/flows/evaluation/eval-groundedness/flow.dag.yaml
@@ -38,7 +38,7 @@ inputs:
       Paraphrasing (IWP2005) . William Fedus, Ian Goodfellow, and Andrew M Dai.
       2018. Maskgan: Better text generation via \ufb01lling in the.arXiv
       preprint arXiv:1801.07736 . Dan Hendrycks and Kevin Gimpel. 2016. Bridging
-      nonlinearities and stochastic regularizers with gaus- sian error linear
+      nonlinearities and stochastic regularizers with gaussian error linear
       units. CoRR , abs\/1606.08415. Felix Hill, Kyunghyun Cho, and Anna
       Korhonen. 2016. Learning distributed representations of sentences from
       unlabelled data. In Proceedings of the 2016 Conference of the North

--- a/examples/flows/evaluation/eval-groundedness/requirements.txt
+++ b/examples/flows/evaluation/eval-groundedness/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/evaluation/eval-perceived-intelligence/flow.dag.yaml
+++ b/examples/flows/evaluation/eval-perceived-intelligence/flow.dag.yaml
@@ -38,7 +38,7 @@ inputs:
       Paraphrasing (IWP2005) . William Fedus, Ian Goodfellow, and Andrew M Dai.
       2018. Maskgan: Better text generation via \ufb01lling in the.arXiv
       preprint arXiv:1801.07736 . Dan Hendrycks and Kevin Gimpel. 2016. Bridging
-      nonlinearities and stochastic regularizers with gaus- sian error linear
+      nonlinearities and stochastic regularizers with gaussian error linear
       units. CoRR , abs\/1606.08415. Felix Hill, Kyunghyun Cho, and Anna
       Korhonen. 2016. Learning distributed representations of sentences from
       unlabelled data. In Proceedings of the 2016 Conference of the North

--- a/examples/flows/evaluation/eval-perceived-intelligence/requirements.txt
+++ b/examples/flows/evaluation/eval-perceived-intelligence/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/standard/autonomous-agent/requirements.txt
+++ b/examples/flows/standard/autonomous-agent/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools
 tiktoken

--- a/examples/flows/standard/basic-with-builtin-llm/requirements.txt
+++ b/examples/flows/standard/basic-with-builtin-llm/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools
 python-dotenv

--- a/examples/flows/standard/basic-with-connection/requirements.txt
+++ b/examples/flows/standard/basic-with-connection/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow[azure]
 promptflow-tools
 python-dotenv

--- a/examples/flows/standard/basic/requirements.txt
+++ b/examples/flows/standard/basic/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow[azure]
 promptflow-tools
 python-dotenv

--- a/examples/flows/standard/customer-intent-extraction/requirements.txt
+++ b/examples/flows/standard/customer-intent-extraction/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools
 python-dotenv

--- a/examples/flows/standard/flow-with-additional-includes/requirements.txt
+++ b/examples/flows/standard/flow-with-additional-includes/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow[azure]
 promptflow-tools
 bs4

--- a/examples/flows/standard/flow-with-symlinks/requirements.txt
+++ b/examples/flows/standard/flow-with-symlinks/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow[azure]
 promptflow-tools
 bs4

--- a/examples/flows/standard/named-entity-recognition/requirements.txt
+++ b/examples/flows/standard/named-entity-recognition/requirements.txt
@@ -1,3 +1,2 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow
 promptflow-tools

--- a/examples/flows/standard/web-classification/requirements.txt
+++ b/examples/flows/standard/web-classification/requirements.txt
@@ -1,4 +1,3 @@
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
 promptflow[azure]
 promptflow-tools
 bs4

--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,6 +1,4 @@
-# remove when we publish to pypi
---extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/
-promptflow[azure]==0.0.103036498
+promptflow[azure]
 promptflow-tools==0.1.0.b5
 python-dotenv
 bs4

--- a/scripts/compliance-check/Check-PolicheckScan.ps1
+++ b/scripts/compliance-check/Check-PolicheckScan.ps1
@@ -10,7 +10,8 @@
 
 [CmdLetbinding()]
 param (
-[string]$policheckResult
+[string]$policheckResult,
+[string]$raiseError = $true
 )
 
 $result = Get-Content -Path $policheckResult | Measure-Object -Line;

--- a/scripts/compliance-check/user_exclusion.xml
+++ b/scripts/compliance-check/user_exclusion.xml
@@ -1,12 +1,5 @@
 <PoliCheckExclusions>
   <!-- All strings must be UPPER CASE -->
-  <!--Each of these exclusions is a folder name -if \[name]\exists in the file path, it will be skipped -->
-  <!-- <Exclusion Type="FolderPathFull">ABC|XYZ</Exclusion> -->
-  <!--Each of these exclusions is a folder name -if any folder or file starts with "\[name]", it will be skipped -->
-  <!--<Exclusion Type="FolderPathStart">ABC|XYZ</Exclusion>-->
-  <!--Each of these file types will be completely skipped for the entire scan -->
-  <!--<Exclusion Type="FileType">.ABC|.XYZ</Exclusion>-->
-  <!--The specified file names will be skipped during the scan regardless which folder they are in -->
-  <Exclusion Type="FileName">INDEX-AF571BFB.JS</Exclusion>
-  <Exclusion Type="FileName">NOTICE.TXT</Exclusion>
+  <!--index-xxx.js is an auto-generated javascript file - skipped given it's not expected to be readable -->
+  <Exclusion Type="FileName">SRC\PROMPTFLOW\PROMPTFLOW\_SDK\_SERVING\STATIC\INDEX-AF571BFB.JS</Exclusion>
 </PoliCheckExclusions>

--- a/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
+++ b/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
@@ -30,7 +30,7 @@ RUN conda create -n {{env.conda_env_name}} python=3.9.16 pip=23.0.1 -q -y && \
 {% else %}
     pip install promptflow \
 {% endif %}
-    promptflow-tools --extra-index-url https://azuremlsdktestpypi.azureedge.net/promptflow/ && \
+    promptflow-tools && \
 {% endif %}
     conda run -n {{env.conda_env_name}} pip install keyrings.alt && \
     conda run -n {{env.conda_env_name}} pip cache purge && \


### PR DESCRIPTION
enable compliance check ci but it won't pass now for vulnerability issue - either `--extra-index-url` is not allowed or there are vulnerable dependencies from promptflow sdk.

Successful build with all requirements cleared: [link](https://msdata.visualstudio.com/Vienna/_build/results?buildId=101788015&view=results)
failed build with policy check failed: [link](https://msdata.visualstudio.com/Vienna/_build/results?buildId=101788648&view=results)