### PR TITLE
Improve error message for inputs mapping

### DIFF
--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -734,10 +734,10 @@ class FlowExecutor:
         # Return all not found mapping relations in one exception to provide better debug experience.
         if notfound_mapping_relations:
             raise MappingSourceNotFound(
-                f"Unable to find the following mapping relations: {', '.join(notfound_mapping_relations)}. "
-                "Ensure that the keys and values in your input mapping align with those in your input data. "
-                "If a mapping relation starts with '${data', it might have been generated from the YAML input file. "
-                "In this case, you may need to assign it manually based on your input data."
+                f"Couldn't find these mapping relations: {', '.join(notfound_mapping_relations)}. "
+                "Please make sure your input mapping keys and values match your YAML input section and input data. "
+                "If a mapping value has a '${data' prefix, it might be generated from the YAML input section, "
+                "and you may need to manually assign input mapping based on your input data."
             )
         # For PRS scenario, apply_inputs_mapping will be used for exec_line and line_number is not necessary.
         if LINE_NUMBER_KEY in inputs:

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
@@ -64,10 +64,10 @@ class TestFlowExecutor:
                     "answer": "${data.output}",
                 },
                 MappingSourceNotFound,
-                "Unable to find the following mapping relations: ${baseline.output}, ${data.output}. "
-                "Ensure that the keys and values in your input mapping align with those in your input data. "
-                "If a mapping relation starts with '${data', it might have been generated from the YAML input file. "
-                "In this case, you may need to assign it manually based on your input data.",
+                "Couldn't find these mapping relations: ${baseline.output}, ${data.output}. "
+                "Please make sure your input mapping keys and values match your YAML input section and input data. "
+                "If a mapping value has a '${data' prefix, it might be generated from the YAML input section, "
+                "and you may need to manually assign input mapping based on your input data."
             ),
         ],
     )


### PR DESCRIPTION
- Improve error message for inputs mapping with gpt4. (That's user facing message)
- Move in test_flow_executor.py for unit test
- Remove apply_inputs_mapping_legacy, that should be in ADO repo.