### PR TITLE
update tools_continuous_delivery to support merge main trigger, filter tools folder.

### DIFF
--- a/.github/workflows/tools_continuous_delivery.yml
+++ b/.github/workflows/tools_continuous_delivery.yml
@@ -6,6 +6,8 @@ on:
       - main
     paths:
       - 'src/promptflow-tools/**'
+      - '!README.*'
+      - '!src/promptflow-tools/tests/**'
 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Auto Trigger release when pr merged, and only tools folder changed.

"src/promptflow/**"

Test in personal repo:
![image](https://github.com/microsoft/promptflow/assets/20365062/ac896ac7-722e-4936-ade8-99350a502c5b)
![image](https://github.com/microsoft/promptflow/assets/20365062/b1611739-135c-4ac3-b68e-7542ff7fff3d)

![image](https://github.com/microsoft/promptflow/assets/20365062/65c49f6d-15f3-4940-93bc-bf567d7251af)
