### PR TITLE
Refine interface for llm stream enabling

### DIFF
--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -619,6 +619,7 @@ class FlowExecutor:
         try:
             if validate_inputs:
                 inputs = FlowValidator.ensure_flow_inputs_type(flow=self._flow, inputs=inputs, idx=line_number)
+            self.enable_streaming_for_llm_flow(lambda: allow_generator_output)
             output, nodes_outputs = self.traverse_nodes(inputs, context)
             output = self.stringify_generator_output(output) if not allow_generator_output else output
             run_tracker.allow_generator_types = allow_generator_output

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
@@ -12,6 +12,7 @@ from promptflow.executor.flow_executor import (
     LineNumberNotAlign,
     MappingSourceNotFound,
     NoneInputsMappingIsNotSupported,
+    OpenAIStreamOption,
     enable_streaming_for_llm_tool,
     ensure_node_result_is_serializable,
     inject_stream_options,
@@ -396,3 +397,36 @@ class TestEnsureNodeResultIsSerializable:
     def test_non_streaming_tool_should_not_be_affected(self):
         func = ensure_node_result_is_serializable(non_streaming_tool)
         assert func() == 1
+
+
+class TestOpenAIStreamOption:
+    def test_true(self):
+        # Create a StreamOption instance with a lambda function that returns True
+        stream_option = OpenAIStreamOption(lambda: True)
+        # Check that calling the instance returns True
+        assert stream_option() is True
+
+    def test_false(self):
+        # Create a StreamOption instance with a lambda function that returns False
+        stream_option = OpenAIStreamOption(lambda: False)
+        # Check that calling the instance returns False
+        assert stream_option() is False
+
+    def test_dynamically_change_should_stream(self):
+        # Create a StreamOption instance with a lambda function that returns False
+        stream_option = OpenAIStreamOption(lambda: False)
+        # Check that calling the instance returns False
+        assert stream_option() is False
+        # Dynamically change the lambda function to return True
+        stream_option.should_stream = lambda: True
+        # Check that calling the instance returns True
+        assert stream_option() is True
+
+    def test_setter(self):
+        # Create a StreamOption instance with a lambda function that returns False
+        stream_option = OpenAIStreamOption(lambda: False)
+        # Check that calling the instance returns False
+        assert stream_option() is False
+        # Try to assign an invalid value to the should_stream property
+        with pytest.raises(ValueError):
+            stream_option.should_stream = "Hello"


### PR DESCRIPTION
# Description

- This PR refactors the executor llm stream enabling logic, which allows callers to specify stream options in each call.
 - To achieve this, I have done the following:
    - Added a new class `OpeanAIStreamOption` that encapsulates the `should_stream` callback, which determines whether a llm node should be streamed or not.
    - Added a new class member `_openai_stream_option` to `FlowExecutor` that stores the current stream option for each executor instance.
    - Injected the stream option to each llm node during Executor initialization and exposed a new method `enable_streaming_for_llm_flow` that allows callers to change the stream option dynamically.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.