### PR TITLE
Adding import comment for promptflow._internal tools package

### DIFF
--- a/scripts/tool/utils/generate_tool_meta_utils.py
+++ b/scripts/tool/utils/generate_tool_meta_utils.py
@@ -8,7 +8,8 @@ from dataclasses import asdict
 from utils.tool_utils import function_to_interface
 
 from promptflow.contracts.tool import Tool, ToolType
-# Importing from promptflow._internal is necessary as this module is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import ToolProvider
 from promptflow.exceptions import ErrorTarget, UserErrorException
 

--- a/src/promptflow-tools/promptflow/tools/aoai.py
+++ b/src/promptflow-tools/promptflow/tools/aoai.py
@@ -4,7 +4,8 @@ import openai
 
 from promptflow.connections import AzureOpenAIConnection
 from promptflow.contracts.types import PromptTemplate
-# Importing from promptflow._internal is necessary as this builtin tool is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import enable_cache, ToolProvider, tool, register_apis
 from promptflow.tools.common import render_jinja_template, handle_openai_error, parse_chat, to_bool, \
     validate_functions, process_function_call, post_process_chat_api_response

--- a/src/promptflow-tools/promptflow/tools/embedding.py
+++ b/src/promptflow-tools/promptflow/tools/embedding.py
@@ -4,7 +4,8 @@ from typing import Union
 import openai
 
 from promptflow.connections import AzureOpenAIConnection, OpenAIConnection
-# Importing from promptflow._internal is necessary as this builtin tool is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import tool
 from promptflow.tools.common import handle_openai_error
 from promptflow.tools.exception import InvalidConnectionType

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -4,7 +4,8 @@ import openai
 
 from promptflow.connections import OpenAIConnection
 from promptflow.contracts.types import PromptTemplate
-# Importing from promptflow._internal is necessary as this builtin tool is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import ToolProvider, tool, register_apis
 from promptflow.tools.common import render_jinja_template, handle_openai_error, \
     parse_chat, to_bool, validate_functions, process_function_call, post_process_chat_api_response

--- a/src/promptflow-tools/promptflow/tools/serpapi.py
+++ b/src/promptflow-tools/promptflow/tools/serpapi.py
@@ -3,7 +3,8 @@ import sys
 from enum import Enum
 
 import requests
-# Importing from promptflow._internal is necessary as this builtin tool is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import ToolProvider, tool
 from promptflow.connections import SerpConnection
 from promptflow.exceptions import PromptflowException

--- a/src/promptflow-tools/promptflow/tools/template_rendering.py
+++ b/src/promptflow-tools/promptflow/tools/template_rendering.py
@@ -1,4 +1,5 @@
-# Importing from promptflow._internal is necessary as this module is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import tool
 from promptflow.tools.common import render_jinja_template
 

--- a/src/promptflow-tools/tests/conftest.py
+++ b/src/promptflow-tools/tests/conftest.py
@@ -5,7 +5,8 @@ from pathlib import Path
 
 import pytest
 from pytest_mock import MockerFixture  # noqa: E402
-# Importing from promptflow._internal is necessary as this builtin tool is promptflow internal.
+# Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
+# since the code here is in promptflow namespace as well
 from promptflow._internal import ConnectionManager
 from promptflow.tools.aoai import AzureOpenAI
 


### PR DESCRIPTION
# Description

This PR is adding comment to all the promptflow._internal reference. 
Though client could import method by "from promptflow import Tool"  but since these are internal modules, we need to use "from promptflow._internal import tool" as example.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.