### PR TITLE
Fix check enforcer failed

### DIFF
--- a/.github/workflows/check_enforcer.yml
+++ b/.github/workflows/check_enforcer.yml
@@ -13,48 +13,42 @@ jobs:
     name: ${{ github.event_name }}
     runs-on: ubuntu-latest
     steps:
-      - uses: octokit/request-action@v2.x
-        name: Get all check status
-        id: get_check_status
-        with:
-          route: GET /repos/{repo}/commits/{head_sha}/check-runs
-          repo: ${{ github.repository }}
-          head_sha: ${{ env.head_sha }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Dump check status
-        id: create-json
-        uses: jsdaniell/create-json@v1.2.2
-        with:
-          name: "status.json"
-          json: ${{ steps.get_check_status.outputs.data }}
-      
       - name: Summarize check status
         id: summarize_check_status
+        shell: bash
         run: |
-          jq -c '.check_runs[]' status.json | while read check_run; do
+          set -x
+          pending_count=0
+
+          while read check_run; do
             echo $check_run | jq '{name, html_url, conclusion}'
-          done
+            if [ $(echo $check_run | jq '.conclusion == "success"') == "true" ]; then
+              pending_count=$((pending_count+1))
+            fi
+          done <<<$(gh api /repos/${{ github.repository }}/commits/${{ env.head_sha }}/check-runs | jq -c '.check_runs[]')
 
-          pending_count=$(jq -c '.check_runs[].conclusion != "success" | select(.)' status.json | wc -l)
+          echo "Total not success test numbers: "$pending_count
+
           if [ $pending_count -eq 0 ]; then
-            echo "status=success" >> "$GITHUB_OUTPUT"
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/statuses/${{ env.head_sha }} \
+              -f state='success' \
+              -f target_url='https://github.com/microsoft/promptflow/actions/runs/${{ github.run_id }}' \
+              -f description='The build succeeded!' \
+              -f context='https://aka.ms/azsdk/checkenforcer' 
           else
-            echo "status=pending" >> "$GITHUB_OUTPUT"
+            gh api \
+              --method POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /repos/${{ github.repository }}/statuses/${{ env.head_sha }} \
+              -f state='pending' \
+              -f target_url='https://github.com/microsoft/promptflow/actions/runs/${{ github.run_id }}' \
+              -f description='Waiting for all checks to succeed' \
+              -f context='https://aka.ms/azsdk/checkenforcer' 
           fi
-
-      - uses: octokit/request-action@v2.x
-        name: Update the check enforcer status
-        id: update_check_enforcer_status
-        with:
-          route: POST /repos/{repo}/statuses/{head_sha}
-          repo: ${{ github.repository }}
-          head_sha: ${{ env.head_sha }}
-          # below constructs the request body
-          state: ${{ steps.summarize_check_status.outputs.status }}
-          target_url: "https://github.com/microsoft/promptflow/actions/runs/${{ github.run_id }}"
-          description: "Waiting for all checks to succeed"
-          context: "https://aka.ms/azsdk/checkenforcer"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Switch to gh api calls
check enforcer should always run to end since jq could deal with unformalized json.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.