### PR TITLE
[Executor][Internal]Apply default input value in flow executor

### DIFF
--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -11,12 +11,6 @@ class InvalidCustomLLMTool(ValidationException):
     pass
 
 
-class FlowExecutionError(SystemErrorException):
-    """Base System Exceptions for flow execution"""
-
-    pass
-
-
 class ValueTypeUnresolved(ValidationException):
     pass
 
@@ -101,11 +95,15 @@ class InputNotFound(InvalidFlowRequest):
     pass
 
 
-class InputNotFoundFromAncestorNodeOutput(FlowExecutionError):
+class InvalidAggregationInput(SystemErrorException):
     pass
 
 
-class NoNodeExecutedError(FlowExecutionError):
+class InputNotFoundFromAncestorNodeOutput(SystemErrorException):
+    pass
+
+
+class NoNodeExecutedError(SystemErrorException):
     pass
 
 

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -416,6 +416,11 @@ class FlowExecutor:
     def _validate_aggregation_inputs(aggregated_flow_inputs: Mapping[str, Any], aggregation_inputs: Mapping[str, Any]):
         """Validate the aggregation inputs according to the flow inputs."""
         for key, value in aggregated_flow_inputs.items():
+            if key in aggregation_inputs:
+                raise InvalidAggregationInput(
+                    message_format="Input '{input_key}' appear in both flow aggregation input and aggregation input.",
+                    input_key=key,
+                )
             if not isinstance(value, list):
                 raise InvalidAggregationInput(
                     message_format="Flow aggregation input {input_key} should be one list.", input_key=key

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
@@ -408,14 +408,13 @@ class TestFlowExecutor:
         assert result == expected_inputs
 
     @pytest.mark.parametrize(
-        "aggregated_flow_inputs, aggregation_inputs, error_code, error_message",
+        "aggregated_flow_inputs, aggregation_inputs, error_message",
         [
             (
                 {},
                 {
                     "input1": "value1",
                 },
-                InvalidAggregationInput,
                 "Aggregation input input1 should be one list.",
             ),
             (
@@ -423,22 +422,27 @@ class TestFlowExecutor:
                     "input1": "value1",
                 },
                 {},
-                InvalidAggregationInput,
                 "Flow aggregation input input1 should be one list.",
             ),
             (
                 {"input1": ["value1_1", "value1_2"]},
                 {"input_2": ["value2_1"]},
-                InvalidAggregationInput,
                 "Whole aggregation inputs should have the same length. "
                 "Current key length mapping are: {'input1': 2, 'input_2': 1}",
             ),
+            (
+                {
+                    "input1": "value1",
+                },
+                {
+                    "input1": "value1",
+                },
+                "Input 'input1' appear in both flow aggregation input and aggregation input.",
+            ),
         ],
     )
-    def test_validate_aggregation_inputs_error(
-        self, aggregated_flow_inputs, aggregation_inputs, error_code, error_message
-    ):
-        with pytest.raises(error_code) as e:
+    def test_validate_aggregation_inputs_error(self, aggregated_flow_inputs, aggregation_inputs, error_message):
+        with pytest.raises(InvalidAggregationInput) as e:
             FlowExecutor._validate_aggregation_inputs(aggregated_flow_inputs, aggregation_inputs)
         assert str(e.value) == error_message
 

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
@@ -4,7 +4,10 @@ from unittest.mock import Mock, patch
 import pytest
 
 from promptflow import tool
-from promptflow.contracts.flow import Flow
+from promptflow.contracts.flow import Flow, FlowInputDefinition
+from promptflow.contracts.tool import ValueType
+from promptflow.executor._errors import InvalidAggregationInput
+from promptflow.executor._line_execution_process_pool import get_available_max_worker_count
 from promptflow.executor.flow_executor import (
     EmptyInputAfterMapping,
     EmptyInputListError,
@@ -12,12 +15,11 @@ from promptflow.executor.flow_executor import (
     LineNumberNotAlign,
     MappingSourceNotFound,
     NoneInputsMappingIsNotSupported,
-    enable_streaming_for_llm_tool,
     _ensure_node_result_is_serializable,
     _inject_stream_options,
+    enable_streaming_for_llm_tool,
 )
 from promptflow.tools.aoai import AzureOpenAI, chat, completion
-from promptflow.executor._line_execution_process_pool import get_available_max_worker_count
 
 
 @pytest.mark.unittest
@@ -148,9 +150,12 @@ class TestFlowExecutor:
 
     @pytest.mark.parametrize("inputs_mapping", [{"question": "${data.question}"}, {}])
     def test_complete_inputs_mapping_by_default_value(self, inputs_mapping):
-        flow = Flow(
-            id="fakeId", name=None, nodes=[], inputs={"question": None, "groundtruth": None}, outputs=None, tools=[]
-        )
+        inputs = {
+            "question": None,
+            "groundtruth": None,
+            "input_with_default_value": FlowInputDefinition(type=ValueType.INT, default="default_value"),
+        }
+        flow = Flow(id="fakeId", name=None, nodes=[], inputs=inputs, outputs=None, tools=[])
         flow_executor = FlowExecutor(
             flow=flow,
             connections=None,
@@ -159,6 +164,7 @@ class TestFlowExecutor:
             loaded_tools=None,
         )
         updated_inputs_mapping = flow_executor._complete_inputs_mapping_by_default_value(inputs_mapping)
+        assert "input_with_default_value" not in updated_inputs_mapping
         assert updated_inputs_mapping == {"question": "${data.question}", "groundtruth": "${data.groundtruth}"}
 
     @pytest.mark.parametrize(
@@ -306,6 +312,136 @@ class TestFlowExecutor:
             FlowExecutor._apply_inputs_mapping_for_all_lines(inputs, inputs_mapping)
         assert error_message == str(e.value), "Expected: {}, Actual: {}".format(error_message, str(e.value))
 
+    @pytest.mark.parametrize(
+        "flow_inputs, inputs, expected_inputs",
+        [
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                None,  # Could handle None input
+                {"input_from_default": "default_value"},
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                {},
+                {"input_from_default": "default_value"},
+            ),
+            (
+                {
+                    "input_no_default": FlowInputDefinition(type=ValueType.STRING),
+                },
+                {},
+                {},  # No default value for input.
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                {"input_from_default": "input_value", "another_key": "input_value"},
+                {"input_from_default": "input_value", "another_key": "input_value"},
+            ),
+        ],
+    )
+    def test_apply_default_value_for_input(self, flow_inputs, inputs, expected_inputs):
+        result = FlowExecutor._apply_default_value_for_input(flow_inputs, inputs)
+        assert result == expected_inputs
+
+    @pytest.mark.parametrize(
+        "flow_inputs, aggregated_flow_inputs, aggregation_inputs, expected_inputs",
+        [
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                {},
+                {},
+                {"input_from_default": ["default_value"]},
+            ),
+            (
+                {
+                    "input_no_default": FlowInputDefinition(type=ValueType.STRING),
+                },
+                {},
+                {},
+                {},  # No default value for input.
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                {"input_from_default": "input_value", "another_key": "input_value"},
+                {},
+                {"input_from_default": "input_value", "another_key": "input_value"},
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                {"another_key": ["input_value", "input_value"]},
+                {},
+                {
+                    "input_from_default": ["default_value", "default_value"],
+                    "another_key": ["input_value", "input_value"],
+                },
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
+                },
+                {},
+                {"another_key_in_aggregation_inputs": ["input_value", "input_value"]},
+                {
+                    "input_from_default": ["default_value", "default_value"],
+                },
+            ),
+        ],
+    )
+    def test_apply_default_value_for_aggregation_input(
+        self, flow_inputs, aggregated_flow_inputs, aggregation_inputs, expected_inputs
+    ):
+        result = FlowExecutor._apply_default_value_for_aggregation_input(
+            flow_inputs, aggregated_flow_inputs, aggregation_inputs
+        )
+        assert result == expected_inputs
+
+    @pytest.mark.parametrize(
+        "aggregated_flow_inputs, aggregation_inputs, error_code, error_message",
+        [
+            (
+                {},
+                {
+                    "input1": "value1",
+                },
+                InvalidAggregationInput,
+                "Aggregation input input1 should be one list.",
+            ),
+            (
+                {
+                    "input1": "value1",
+                },
+                {},
+                InvalidAggregationInput,
+                "Flow aggregation input input1 should be one list.",
+            ),
+            (
+                {"input1": ["value1_1", "value1_2"]},
+                {"input_2": ["value2_1"]},
+                InvalidAggregationInput,
+                "Whole aggregation inputs should have the same length. "
+                "Current key length mapping are: {'input1': 2, 'input_2': 1}",
+            ),
+        ],
+    )
+    def test_validate_aggregation_inputs_error(
+        self, aggregated_flow_inputs, aggregation_inputs, error_code, error_message
+    ):
+        with pytest.raises(error_code) as e:
+            FlowExecutor._validate_aggregation_inputs(aggregated_flow_inputs, aggregation_inputs)
+        assert str(e.value) == error_message
+
 
 def func_with_stream_parameter(a: int, b: int, stream=False):
     return a + b, stream
@@ -403,18 +539,13 @@ class TestGetAvailableMaxWorkerCount:
     @pytest.mark.parametrize(
         "total_memory, available_memory, process_memory, expected_max_worker_count, actual_calculate_worker_count",
         [
-            (1024.0, 128.0, 64.0, 1, -3),    # available_memory - 0.3 * total_memory < 0
+            (1024.0, 128.0, 64.0, 1, -3),  # available_memory - 0.3 * total_memory < 0
             (1024.0, 307.20, 64.0, 1, 0),  # available_memory - 0.3 * total_memory = 0
-            (1024.0, 768.0, 64.0, 7, 7),    # available_memory - 0.3 * total_memory > 0
+            (1024.0, 768.0, 64.0, 7, 7),  # available_memory - 0.3 * total_memory > 0
         ],
     )
     def test_get_available_max_worker_count(
-        self,
-        total_memory,
-        available_memory,
-        process_memory,
-        expected_max_worker_count,
-        actual_calculate_worker_count
+        self, total_memory, available_memory, process_memory, expected_max_worker_count, actual_calculate_worker_count
     ):
         with patch("psutil.virtual_memory") as mock_mem:
             mock_mem.return_value.total = total_memory * 1024 * 1024
@@ -425,7 +556,7 @@ class TestGetAvailableMaxWorkerCount:
                     mock_logger.warning.return_value = None
                     max_worker_count = get_available_max_worker_count()
                     assert max_worker_count == expected_max_worker_count
-                    if (actual_calculate_worker_count < 1):
+                    if actual_calculate_worker_count < 1:
                         mock_logger.warning.assert_called_with(
                             f"Available max worker count {actual_calculate_worker_count} is less than 1, "
                             "set it to 1."

--- a/src/promptflow/tests/test_configs/flows/default_input/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/default_input/flow.dag.yaml
@@ -1,0 +1,25 @@
+inputs:
+  question:
+    type: string
+    default: input value from default
+outputs:
+  output:
+    type: string
+    reference: ${test_print_input.output}
+nodes:
+- name: test_print_input
+  type: python
+  source:
+    type: code
+    path: test_print_input.py
+  inputs:
+    input: ${inputs.question}
+- name: aggregate_node
+  type: python
+  source:
+    type: code
+    path: test_print_aggregation.py
+  inputs:
+    inputs: ${inputs.question}
+  aggregation: true
+  use_variants: false

--- a/src/promptflow/tests/test_configs/flows/default_input/test_print_aggregation.py
+++ b/src/promptflow/tests/test_configs/flows/default_input/test_print_aggregation.py
@@ -1,0 +1,7 @@
+from typing import List
+from promptflow import tool
+
+@tool
+def test_print_input(inputs: List[str]):
+    print(inputs)
+    return inputs

--- a/src/promptflow/tests/test_configs/flows/default_input/test_print_input.py
+++ b/src/promptflow/tests/test_configs/flows/default_input/test_print_input.py
@@ -1,0 +1,7 @@
+from promptflow import tool
+
+
+@tool
+def test_print_input(input: str):
+    print(input)
+    return input


### PR DESCRIPTION
# Description

- Honor flow input's default value in yaml for single node/flow/bulk run.
- For bulk run, default value should be in higher priority than default mapping. Since default value is directly assigned by customer. So, don't assign default mapping when there is default value.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
