### PR TITLE
[Fundamental] Add GH action for promptflow release branch creation

### DIFF
--- a/.github/workflows/create_promptflow_release_branch.yml
+++ b/.github/workflows/create_promptflow_release_branch.yml
@@ -30,7 +30,14 @@ jobs:
             echo "workflow triggered by REST API, parse release version from request body..."
             release_version="${{ github.event.client_payload.release_version }}"
           fi
-          echo "configured release version: $release_version"
+
+          if [[ "$release_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(b[0-9]+)?$ ]]; then
+            echo "configured release version: $release_version"
+          else
+            echo "configured release version: $release_version"
+            exit 1
+          fi
+
 
           release_branch_name="release/promptflow/$release_version"
           echo "release branch name: $release_branch_name, checking out..."


### PR DESCRIPTION
# Description

Add a manually trigger GH action for promptflow release branch creation, this workflow will only update version in `_version.py` for now.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
