### PR TITLE
feat: private interface for vs extension to generate tools meta

### DIFF
--- a/docs/reference/pf-command-reference.md
+++ b/docs/reference/pf-command-reference.md
@@ -20,6 +20,7 @@ Manage promptflow flow flows.
 | --- | --- |
 | [pf flow init](#pf-flow-init) | Initialize a prompt flow directory. |
 | [pf flow test](#pf-flow-test) | Test the prompt flow or flow node. |
+| [pf flow build](#pf-flow-build) | Build a flow for further sharing or deployment. |
 | [pf flow serve](#pf-flow-serve) | Serving a flow as an endpoint. |
 
 ### pf flow init

--- a/src/promptflow/promptflow/_cli/_pf/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf/_flow.py
@@ -161,16 +161,6 @@ pf flow validate --source <path_to_flow>
         epilog=epilog,
         add_params=[
             add_param_source,
-            lambda parser: parser.add_argument(  # noqa: E731
-                "--flow-tools-json-path",
-                type=str,
-                help=argparse.SUPPRESS,
-            ),
-            lambda parser: parser.add_argument(  # noqa: E731
-                "--tools-only",
-                action=argparse.BooleanOptionalAction,
-                help=argparse.SUPPRESS,
-            ),
         ],
         subparsers=subparsers,
         help_message="Validate a flow. Will raise error if the flow is not valid.",
@@ -438,9 +428,10 @@ def validate_flow(args):
 
     validation_result = pf_client.flows.validate(
         flow=args.source,
-        flow_tools_json_path=args.flow_tools_json_path,
-        tools_only=args.tools_only,
     )
     if validation_result:
         print(json.dumps(validation_result, indent=4))
         exit(1)
+    else:
+        print("Flow is valid.")
+        exit(0)

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -6,7 +6,7 @@ import json
 from importlib.metadata import version
 from os import PathLike
 from pathlib import Path
-from typing import Iterable, List, Union
+from typing import Iterable, List, Tuple, Union
 
 import yaml
 
@@ -133,9 +133,13 @@ class FlowOperations:
         chat_inputs = [item for item in flow.inputs.values() if item.is_chat_input]
         chat_outputs = [item for item in flow.outputs.values() if item.is_chat_output]
         chat_history_input_name = next(
-            iter([input_name for input_name, value in flow.inputs.items() if value.is_chat_history]), None)
-        if not chat_history_input_name and CHAT_HISTORY in flow.inputs and \
-                flow.inputs[CHAT_HISTORY].is_chat_history is not False:
+            iter([input_name for input_name, value in flow.inputs.items() if value.is_chat_history]), None
+        )
+        if (
+            not chat_history_input_name
+            and CHAT_HISTORY in flow.inputs
+            and flow.inputs[CHAT_HISTORY].is_chat_history is not False
+        ):
             chat_history_input_name = CHAT_HISTORY
         is_chat_flow, error_msg = True, ""
         if len(chat_inputs) != 1:
@@ -439,8 +443,7 @@ class FlowOperations:
         else:
             yield flow_dag_path
 
-    @classmethod
-    def validate(cls, flow: Union[str, PathLike], *, raise_error: bool = False, **kwargs) -> dict:
+    def validate(self, flow: Union[str, PathLike], *, raise_error: bool = False, **kwargs) -> dict:
         """
         Validate flow.
 
@@ -468,7 +471,7 @@ class FlowOperations:
         # TODO: check path existence of additional_includes in FlowSchema
         validation_result = FlowSchema(context={BASE_PATH_CONTEXT_KEY: flow_dag_path.parent}).validate(flow_dag_obj)
 
-        with cls._resolve_additional_includes(flow_dag_path) as new_flow_dag_path:
+        with self._resolve_additional_includes(flow_dag_path) as new_flow_dag_path:
             flow_tools = generate_flow_tools_json(
                 flow_directory=new_flow_dag_path.parent,
                 dump=False,
@@ -507,3 +510,75 @@ class FlowOperations:
 
         # TODO: convert return value to a ValidationResult object
         return validation_result
+
+    def _generate_tools_meta(
+        self,
+        flow: Union[str, PathLike],
+        *,
+        source_name: str = None,
+    ) -> Tuple[dict, dict]:
+        """Generate flow tools meta for a specific flow or a specific node in the flow.
+
+        This is a private interface for vscode extension, so do not change the interface unless necessary.
+        Sample output:
+        (
+            {
+                "convert_to_dict.py": {
+                    "type": "python",
+                    "inputs": {
+                        "input_str": {
+                            "type": [
+                                "string"
+                            ]
+                        }
+                    },
+                    "source": "convert_to_dict.py",
+                    "function": "convert_to_dict"
+                }
+            },
+            {
+                "summarize_text_content__variant_1.jinja2": "File not found: summarize_text_content__variant_1.jinja2"
+            }
+        )
+
+        Usage:
+        from promptflow import PFClient
+        PFClient().flows._generate_tools_meta(flow="flow.dag.yaml", source_name="convert_to_dict.py")
+
+        :param flow: path to the flow directory or flow dag to export
+        :type flow: Union[str, PathLike]
+        :param source_name: source name to generate tools meta. If not specified, generate tools meta for all sources.
+        :type source_name: str
+        :return: dict of tools meta and dict of tools errors
+        :rtype: Tuple[dict, dict]
+        """
+        flow_path = Path(flow)
+        if flow_path.is_dir() and (flow_path / DAG_FILE_NAME).is_file():
+            flow_dag_path = flow_path / DAG_FILE_NAME
+        else:
+            flow_dag_path = flow_path
+
+        if not flow_dag_path.is_file():
+            raise ValueError(f"Flow dag file {flow_dag_path.as_posix()} does not exist.")
+
+        with self._resolve_additional_includes(flow_dag_path) as new_flow_dag_path:
+            flow_tools = generate_flow_tools_json(
+                flow_directory=new_flow_dag_path.parent,
+                dump=False,
+                raise_error=False,
+                include_errors_in_output=True,
+            )
+
+        # TODO: do you need flow.tools.json['package']?
+        flow_tools_meta = flow_tools.pop("code", {})
+        if source_name:
+            if source_name not in flow_tools_meta:
+                raise ValueError(f"Source {source_name} does not exist in flow {flow_dag_path.as_posix()}")
+            flow_tools_meta = {source_name: flow_tools_meta[source_name]}
+
+        tools_errors = {}
+        nodes_with_error = [node_name for node_name, message in flow_tools_meta.items() if isinstance(message, str)]
+        for node_name in nodes_with_error:
+            tools_errors[node_name] = flow_tools_meta.pop(node_name)
+
+        return flow_tools_meta, tools_errors

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -487,19 +487,13 @@ class FlowOperations:
                     tools_errors[node_name] = flow_tools["code"].pop(node_name)
 
         # generate flow tools json
-        flow_tools_json_path = kwargs.pop("flow_tools_json_path", None)
-        if not flow_tools_json_path:
-            flow_tools_json_path = flow_dag_path.parent / PROMPT_FLOW_DIR_NAME / FLOW_TOOLS_JSON
-        else:
-            flow_tools_json_path = Path(flow_tools_json_path)
+        flow_tools_json_path = flow_dag_path.parent / PROMPT_FLOW_DIR_NAME / FLOW_TOOLS_JSON
 
         flow_tools_json_path.parent.mkdir(parents=True, exist_ok=True)
         with open(flow_tools_json_path, "w", encoding=DEFAULT_ENCODING) as f:
             json.dump(flow_tools, f, indent=4)
 
-        if kwargs.pop("tools_only", False):
-            validation_result = tools_errors
-        elif tools_errors:
+        if tools_errors:
             validation_result["tool-meta"] = tools_errors
 
         if validation_result and raise_error:

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_local_operations.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_local_operations.py
@@ -321,3 +321,56 @@ class TestFlowLocalOperations:
                 "type": "llm",
             },
         }
+
+    def test_flow_generate_tools_meta(self, pf) -> None:
+        source = f"{FLOWS_DIR}/web_classification_invalid"
+
+        tools_meta, tools_error = pf.flows._generate_tools_meta(source)
+        assert tools_meta == {
+            "classify_with_llm.jinja2": {
+                "inputs": {
+                    "examples": {"type": ["string"]},
+                    "text_content": {"type": ["string"]},
+                    "url": {"type": ["string"]},
+                },
+                "source": "classify_with_llm.jinja2",
+                "type": "llm",
+            },
+            "convert_to_dict.py": {
+                "function": "convert_to_dict",
+                "inputs": {"input_str": {"type": ["string"]}},
+                "source": "convert_to_dict.py",
+                "type": "python",
+            },
+            "fetch_text_content_from_url.py": {
+                "function": "fetch_text_content_from_url",
+                "inputs": {"url": {"type": ["string"]}},
+                "source": "fetch_text_content_from_url.py",
+                "type": "python",
+            },
+            "summarize_text_content__variant_1.jinja2": {
+                "inputs": {"text": {"type": ["string"]}},
+                "source": "summarize_text_content__variant_1.jinja2",
+                "type": "llm",
+            },
+        }
+
+        assert "Failed to load python module from file" in tools_error.pop("prepare_examples.py", "")
+        assert "Meta file not found" in tools_error.pop("summarize_text_content.jinja2", "")
+        assert tools_error == {}
+
+        tools_meta, tools_error = pf.flows._generate_tools_meta(source, source_name="summarize_text_content.jinja2")
+        assert tools_meta == {}
+        assert "Meta file not found" in tools_error.pop("summarize_text_content.jinja2", "")
+        assert tools_error == {}
+
+        tools_meta, tools_error = pf.flows._generate_tools_meta(source, source_name="fetch_text_content_from_url.py")
+        assert tools_meta == {
+            "fetch_text_content_from_url.py": {
+                "function": "fetch_text_content_from_url",
+                "inputs": {"url": {"type": ["string"]}},
+                "source": "fetch_text_content_from_url.py",
+                "type": "python",
+            },
+        }
+        assert tools_error == {}


### PR DESCRIPTION
# Description

Use a private SDK interface `pf_client.flows._generate_tools_meta` instead of `pf flow validate` with private parameters for vs code extension to generate tools meta.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
