### PR TITLE
Use user agent as componentName in ErrorResponse

### DIFF
--- a/src/promptflow/promptflow/_utils/exception_utils.py
+++ b/src/promptflow/promptflow/_utils/exception_utils.py
@@ -8,7 +8,6 @@ from enum import Enum
 from traceback import TracebackException, format_tb
 from types import TracebackType
 
-from promptflow._constants import ERROR_RESPONSE_COMPONENT_NAME
 from promptflow.exceptions import PromptflowException, SystemErrorException, UserErrorException, ValidationException
 
 ADDITIONAL_INFO_USER_EXECUTION_ERROR = "ToolExecutionErrorDetails"

--- a/src/promptflow/promptflow/_utils/exception_utils.py
+++ b/src/promptflow/promptflow/_utils/exception_utils.py
@@ -107,14 +107,14 @@ class ErrorResponse:
         return user_execution_error_info
 
     def to_dict(self):
-        from promptflow._utils.utils import get_runtime_version
+        from promptflow._core.operation_context import OperationContext
 
         return {
             "error": self._error_dict,
             "correlation": None,  # TODO: to be implemented
             "environment": None,  # TODO: to be implemented
             "location": None,  # TODO: to be implemented
-            "componentName": f"{ERROR_RESPONSE_COMPONENT_NAME}/{get_runtime_version()}",
+            "componentName": OperationContext.get_instance().get_user_agent(),
             "time": datetime.utcnow().isoformat(),
         }
 

--- a/src/promptflow/promptflow/_utils/utils.py
+++ b/src/promptflow/promptflow/_utils/utils.py
@@ -168,17 +168,6 @@ def set_context(context: contextvars.Context):
         var.set(value)
 
 
-# TODO: refactor and use pf version, for EPR
-# used in exceptions.py ("componentName": f"{ERROR_RESPONSE_COMPONENT_NAME}/{get_runtime_version()}",)
-def get_runtime_version():
-    build_info = os.environ.get("BUILD_INFO", "")
-    try:
-        build_info_dict = json.loads(build_info)
-        return build_info_dict["build_number"]
-    except Exception:
-        return "unknown"
-
-
 def convert_inputs_mapping_to_param(inputs_mapping: dict):
     """Use this function to convert inputs_mapping to a string that can be passed to component as a string parameter,
     we have to do this since we can't pass a dict as a parameter to component.

--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -4,13 +4,13 @@ import re
 import pytest
 
 from promptflow._core._errors import ToolExecutionError
+from promptflow._core.operation_context import OperationContext
 from promptflow._utils.exception_utils import (
     ErrorResponse,
     ExceptionPresenter,
     JsonSerializedPromptflowException,
     infer_error_code_from_class,
 )
-from promptflow._core.operation_context import OperationContext
 from promptflow.exceptions import ErrorTarget, PromptflowException, SystemErrorException, UserErrorException
 
 
@@ -244,6 +244,7 @@ class TestErrorResponse:
         response_dct.pop("time")
         component_name = response_dct.pop("componentName", None)
         assert component_name == OperationContext.get_instance().get_user_agent()
+        assert "promptflow" in component_name
         assert response_dct == {
             "error": {
                 "code": "UserError",
@@ -263,6 +264,7 @@ class TestErrorResponse:
         response.pop("time")
         component_name = response.pop("componentName", None)
         assert component_name == OperationContext.get_instance().get_user_agent()
+        assert "promptflow" in component_name
         assert response == {
             "error": {
                 "code": "SystemError",

--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -10,7 +10,7 @@ from promptflow._utils.exception_utils import (
     JsonSerializedPromptflowException,
     infer_error_code_from_class,
 )
-from promptflow._utils.utils import get_runtime_version
+from promptflow._core.operation_context import OperationContext
 from promptflow.exceptions import ErrorTarget, PromptflowException, SystemErrorException, UserErrorException
 
 
@@ -243,7 +243,7 @@ class TestErrorResponse:
         assert response_dct["time"] is not None
         response_dct.pop("time")
         component_name = response_dct.pop("componentName", None)
-        assert component_name == f"promptflow/{get_runtime_version()}"
+        assert component_name == OperationContext.get_instance().get_user_agent()
         assert response_dct == {
             "error": {
                 "code": "UserError",
@@ -262,7 +262,7 @@ class TestErrorResponse:
         assert response["time"] is not None
         response.pop("time")
         component_name = response.pop("componentName", None)
-        assert component_name == f"promptflow/{get_runtime_version()}"
+        assert component_name == OperationContext.get_instance().get_user_agent()
         assert response == {
             "error": {
                 "code": "SystemError",


### PR DESCRIPTION
# Description

Use user agent as `componentName` field in `ErrorResponse` 

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
