### PR TITLE
Skip root flow run output serialization check

### DIFF
--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -158,15 +158,9 @@ class RunTracker(ThreadLocalSingleton):
         )
         self._node_runs[run_id] = run_info
 
-    def _is_root_run(self, run_info: FlowRunInfo) -> bool:
-        return run_info.run_id == run_info.root_run_id
-
     def _flow_run_postprocess(self, run_info: FlowRunInfo, output, ex: Optional[Exception]):
-        # Skip serializable check for root run output since it's a collection of flow run outputs,
-        # which already passed the check.
-        # And we will change root run output to list instead of dict, which is not compatiable
-        # with the _assert_flow_output_serializable method.
-        if output and not self._is_root_run(run_info):
+        # If output is a list, it is output of root run which already passes the serialization check.
+        if output and not isinstance(output, list):
             try:
                 self._assert_flow_output_serializable(output)
             except Exception as e:

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -158,8 +158,15 @@ class RunTracker(ThreadLocalSingleton):
         )
         self._node_runs[run_id] = run_info
 
+    def _is_root_run(self, run_info: FlowRunInfo) -> bool:
+        return run_info.run_id == run_info.root_run_id
+
     def _flow_run_postprocess(self, run_info: FlowRunInfo, output, ex: Optional[Exception]):
-        if output:
+        # Skip serializable check for root run output since it's a collection of flow run outputs,
+        # which already passed the check.
+        # And we will change root run output to list instead of dict, which is not compatiable
+        # with the _assert_flow_output_serializable method.
+        if output and not self._is_root_run(run_info):
             try:
                 self._assert_flow_output_serializable(output)
             except Exception as e:

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -677,7 +677,7 @@ class FlowExecutor:
             LineResult: Line run result
         """
         run_id = run_id or str(uuid.uuid4())
-        line_run_id = run_id if line_number is None else f"{run_id}_{line_number}"
+        line_run_id = str(uuid.uuid4()) if line_number is None else f"{run_id}_{line_number}"
         run_tracker = RunTracker(
             self._run_tracker._storage, self._run_tracker._run_mode, self._run_tracker.node_log_manager
         )

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -677,6 +677,10 @@ class FlowExecutor:
             LineResult: Line run result
         """
         run_id = run_id or str(uuid.uuid4())
+        # We need to ensure that line_run_id is different from run_id.
+        # Otherwise, the line run will be treated as a root run.
+        # TODO: Refactor to use separate data strucure for
+        # flow run and root run.
         line_run_id = str(uuid.uuid4()) if line_number is None else f"{run_id}_{line_number}"
         run_tracker = RunTracker(
             self._run_tracker._storage, self._run_tracker._run_mode, self._run_tracker.node_log_manager

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -681,7 +681,7 @@ class FlowExecutor:
         # Otherwise, the line run will be treated as a root run.
         # TODO: Refactor to use separate data strucure for
         # flow run and root run.
-        line_run_id = str(uuid.uuid4()) if line_number is None else f"{run_id}_{line_number}"
+        line_run_id = run_id if line_number is None else f"{run_id}_{line_number}"
         run_tracker = RunTracker(
             self._run_tracker._storage, self._run_tracker._run_mode, self._run_tracker.node_log_manager
         )

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -677,10 +677,6 @@ class FlowExecutor:
             LineResult: Line run result
         """
         run_id = run_id or str(uuid.uuid4())
-        # We need to ensure that line_run_id is different from run_id.
-        # Otherwise, the line run will be treated as a root run.
-        # TODO: Refactor to use separate data strucure for
-        # flow run and root run.
         line_run_id = run_id if line_number is None else f"{run_id}_{line_number}"
         run_tracker = RunTracker(
             self._run_tracker._storage, self._run_tracker._run_mode, self._run_tracker.node_log_manager


### PR DESCRIPTION
# Description

Skip root flow run output serialization check. Because it's a collection of flow run outputs which already pass the check.
And we are going to change the root run output from dict of list to list of dict, which does not fit the checking logic.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes]**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
