### PR TITLE
Handle JSONDecodeError exception when executor is resolving the inputs type convert

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugs Fixed
 - [Flow build] Fix flow build file name and environment variable name when connection name contains space.
+
+### Other Changes
 - [Executor][Internal] Add JSONDecodeError exception handle for input type parse
 
 ## 0.1.0b6 (2023.09.15)

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [Flow build] Fix flow build file name and environment variable name when connection name contains space.
 
 ### Other Changes
-- [Executor][Internal] Handle JSONDecodeError exception when executor is resolving the inputs type convert
+- [Executor][Internal] Improve error message with more details and actionable information.
 
 ## 0.1.0b6 (2023.09.15)
 

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [Flow build] Fix flow build file name and environment variable name when connection name contains space.
 
 ### Other Changes
-- [Executor][Internal] Add JSONDecodeError exception handle for input type parse
+- [Executor][Internal] Handle JSONDecodeError exception when executor is resolving the inputs type convert
 
 ## 0.1.0b6 (2023.09.15)
 

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bugs Fixed
 - [Flow build] Fix flow build file name and environment variable name when connection name contains space.
+- [Executor][Internal] Improve error message for Input convert
 
 ## 0.1.0b6 (2023.09.15)
 

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bugs Fixed
 - [Flow build] Fix flow build file name and environment variable name when connection name contains space.
-- [Executor][Internal] Improve error message for Input convert
+- [Executor][Internal] Add JSONDecodeError exception handle for input type parse
 
 ## 0.1.0b6 (2023.09.15)
 

--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -123,6 +123,10 @@ class InputTypeError(InvalidFlowRequest):
     pass
 
 
+class InputParseError(InvalidFlowRequest):
+    pass
+
+
 class InvalidConnectionType(InvalidFlowRequest):
     pass
 

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -132,12 +132,16 @@ class FlowValidator:
                 line_info = "" if idx is None else f" in line {idx} of input data"
                 msg_format = (
                     "Failed to parse the flow input. The value for flow input '{flow_input_name}'{line_info} "
-                    "was interpreted as JSON string but the value '{input_value}' is invalid for JSON parsing. "
-                    "Please make sure your inputs are properly formatted. "
+                    "was interpreted as JSON string since its type is '{value_type}'. However, the value "
+                    "'{input_value}' is invalid for JSON parsing. Please make sure your inputs are properly formatted. "
                     "For example, use double quotes instead of single quotes."
                 )
                 raise InputParseError(
-                    message_format=msg_format, flow_input_name=k, line_info=line_info, input_value=inputs[k]
+                    message_format=msg_format,
+                    flow_input_name=k,
+                    line_info=line_info,
+                    input_value=inputs[k],
+                    value_type=v.type,
                 ) from e
             except Exception as e:
                 line_info = "" if idx is None else f" in line {idx} of input data"

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -137,8 +137,7 @@ class FlowValidator:
                     "Failed to parse the flow input. The value for flow input {flow_input_info} "
                     "was interpreted as JSON string since its type is '{value_type}'. However, the value "
                     "'{input_value}' is invalid for JSON parsing. Error details: {error_type_and_message}. "
-                    "Please make sure your inputs are properly formatted. "
-                    "For example, use double quotes instead of single quotes."
+                    "Please make sure your inputs are properly formatted."
                 )
                 raise InputParseError(
                     message_format=msg_format,

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -130,30 +130,33 @@ class FlowValidator:
                     updated_inputs[k] = v.type.parse(inputs[k])
             except JSONDecodeError as e:
                 line_info = "" if idx is None else f" in line {idx} of input data"
+                flow_input_info = f"'{k}'{line_info}"
+                error_type_and_message = f"({e.__class__.__name__}) {e}"
+
                 msg_format = (
-                    "Failed to parse the flow input. The value for flow input '{flow_input_name}'{line_info} "
+                    "Failed to parse the flow input. The value for flow input {flow_input_info} "
                     "was interpreted as JSON string since its type is '{value_type}'. However, the value "
-                    "'{input_value}' is invalid for JSON parsing. Error details: {error_details}. "
+                    "'{input_value}' is invalid for JSON parsing. Error details: {error_type_and_message}. "
                     "Please make sure your inputs are properly formatted. "
                     "For example, use double quotes instead of single quotes."
                 )
                 raise InputParseError(
                     message_format=msg_format,
-                    flow_input_name=k,
-                    line_info=line_info,
+                    flow_input_info=flow_input_info,
                     input_value=inputs[k],
                     value_type=v.type,
-                    error_details=str(e),
+                    error_type_and_message=error_type_and_message,
                 ) from e
             except Exception as e:
                 line_info = "" if idx is None else f" in line {idx} of input data"
+                flow_input_info = f"'{k}'{line_info}"
                 msg_format = (
-                    "The input for flow is incorrect. The value for flow input '{flow_input_name}'{line_info} "
+                    "The input for flow is incorrect. The value for flow input {flow_input_info} "
                     "does not match the expected type '{expected_type}'. Please change flow input type "
                     "or adjust the input value in your input data."
                 )
                 raise InputTypeError(
-                    message_format=msg_format, flow_input_name=k, line_info=line_info, expected_type=v.type
+                    message_format=msg_format, flow_input_info=flow_input_info, expected_type=v.type
                 ) from e
         return updated_inputs
 

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -133,7 +133,8 @@ class FlowValidator:
                 msg_format = (
                     "Failed to parse the flow input. The value for flow input '{flow_input_name}'{line_info} "
                     "was interpreted as JSON string since its type is '{value_type}'. However, the value "
-                    "'{input_value}' is invalid for JSON parsing. Please make sure your inputs are properly formatted. "
+                    "'{input_value}' is invalid for JSON parsing. Error details: {error_details}. "
+                    "Please make sure your inputs are properly formatted. "
                     "For example, use double quotes instead of single quotes."
                 )
                 raise InputParseError(
@@ -142,6 +143,7 @@ class FlowValidator:
                     line_info=line_info,
                     input_value=inputs[k],
                     value_type=v.type,
+                    error_details=str(e),
                 ) from e
             except Exception as e:
                 line_info = "" if idx is None else f" in line {idx} of input data"

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -132,8 +132,9 @@ class FlowValidator:
                 line_info = "" if idx is None else f" in line {idx} of input data"
                 msg_format = (
                     "Failed to parse the flow input. The value for flow input '{flow_input_name}'{line_info} "
-                    "was interpreted as JSON but the value '{input_value}' is invalid JSON'. Please make sure "
-                    "your inputs are properly formatted. For example, use double quotes instead of single quotes."
+                    "was interpreted as JSON string but the value '{input_value}' is invalid for JSON parsing. "
+                    "Please make sure your inputs are properly formatted. "
+                    "For example, use double quotes instead of single quotes."
                 )
                 raise InputParseError(
                     message_format=msg_format, flow_input_name=k, line_info=line_info, input_value=inputs[k]

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -193,9 +193,9 @@ class TestValidation:
                 InputParseError,
                 (
                     "Failed to parse the flow input. The value for flow input 'key' was "
-                    "interpreted as JSON but the value '['hello']' is invalid JSON'. Please make "
-                    "sure your inputs are properly formatted. For example, use double quotes instead "
-                    "of single quotes."
+                    "interpreted as JSON string but the value '['hello']' is invalid for JSON "
+                    "parsing. Please make sure your inputs are properly formatted. For example, "
+                    "use double quotes instead of single quotes."
                 ),
             ),
         ],

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -194,9 +194,9 @@ class TestValidation:
                 (
                     "Failed to parse the flow input. The value for flow input 'key' was "
                     "interpreted as JSON string since its type is 'list'. However, the value "
-                    "'['hello']' is invalid for JSON parsing. Error details: Expecting value: "
-                    "line 1 column 2 (char 1). Please make sure your inputs are properly "
-                    "formatted. For example, use double quotes instead of single quotes."
+                    "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
+                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
+                    "properly formatted. For example, use double quotes instead of single quotes."
                 ),
             ),
         ],
@@ -251,9 +251,21 @@ class TestValidation:
                 ),
                 "InputTypeError",
             ),
+            (
+                "flow_with_list_input",
+                [{"key": "['hello']"}],
+                (
+                    "Failed to parse the flow input. The value for flow input 'key' in line 0 of input data was "
+                    "interpreted as JSON string since its type is 'list'. However, the value "
+                    "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
+                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
+                    "properly formatted. For example, use double quotes instead of single quotes."
+                ),
+                "InputParseError",
+            ),
         ],
     )
-    def test_bulk_run_input_type_invalid(self, flow_folder, batch_input, error_message, error_class, dev_connections):
+    def test_bulk_run_input_invalid(self, flow_folder, batch_input, error_message, error_class, dev_connections):
         # Bulk run - the input is from sample.json
         executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections)
         bulk_result = executor.exec_bulk(

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -14,7 +14,6 @@ from promptflow.executor._errors import (
     DuplicateNodeName,
     EmptyOutputReference,
     InputNotFound,
-    InputParseError,
     InputReferenceNotFound,
     InputTypeError,
     InvalidFlowRequest,
@@ -165,48 +164,17 @@ class TestValidation:
             FlowExecutor.create(get_yaml_file(flow_folder, WRONG_FLOW_ROOT), dev_connections)
 
     @pytest.mark.parametrize(
-        "flow_folder, line_input, error_class, error_message",
+        "flow_folder, line_input, error_class",
         [
-            (
-                "simple_flow_with_python_tool",
-                {"num11": "22"},
-                InputNotFound,
-                (
-                    "The input for flow is incorrect. The value for flow input 'num' is not "
-                    "provided in input data. Please review your input data or remove this input "
-                    "in your flow if it's no longer needed."
-                ),
-            ),
-            (
-                "simple_flow_with_python_tool",
-                {"num": "hello"},
-                InputTypeError,
-                (
-                    "The input for flow is incorrect. The value for flow input 'num' does not "
-                    "match the expected type 'int'. Please change flow input type or adjust the "
-                    "input value in your input data."
-                ),
-            ),
-            (
-                "flow_with_list_input",
-                {"key": "['hello']"},
-                InputParseError,
-                (
-                    "Failed to parse the flow input. The value for flow input 'key' was "
-                    "interpreted as JSON string since its type is 'list'. However, the value "
-                    "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
-                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
-                    "properly formatted. For example, use double quotes instead of single quotes."
-                ),
-            ),
+            ("simple_flow_with_python_tool", {"num11": "22"}, InputNotFound),
+            ("simple_flow_with_python_tool", {"num": "hello"}, InputTypeError),
         ],
     )
-    def test_flow_run_input_invalid(self, flow_folder, line_input, error_class, error_message, dev_connections):
+    def test_flow_run_input_type_invalid(self, flow_folder, line_input, error_class, dev_connections):
         # Flow run -  the input is from get_partial_line_inputs()
         executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections)
-        with pytest.raises(error_class) as exe_info:
+        with pytest.raises(error_class):
             executor.exec_line(line_input)
-        assert error_message == exe_info.value.message
 
     @pytest.mark.parametrize(
         "flow_folder, line_input, error_class, error_msg",
@@ -251,21 +219,9 @@ class TestValidation:
                 ),
                 "InputTypeError",
             ),
-            (
-                "flow_with_list_input",
-                [{"key": "['hello']"}],
-                (
-                    "Failed to parse the flow input. The value for flow input 'key' in line 0 of input data was "
-                    "interpreted as JSON string since its type is 'list'. However, the value "
-                    "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
-                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
-                    "properly formatted. For example, use double quotes instead of single quotes."
-                ),
-                "InputParseError",
-            ),
         ],
     )
-    def test_bulk_run_input_invalid(self, flow_folder, batch_input, error_message, error_class, dev_connections):
+    def test_bulk_run_input_type_invalid(self, flow_folder, batch_input, error_message, error_class, dev_connections):
         # Bulk run - the input is from sample.json
         executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections)
         bulk_result = executor.exec_bulk(

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -194,8 +194,9 @@ class TestValidation:
                 (
                     "Failed to parse the flow input. The value for flow input 'key' was "
                     "interpreted as JSON string since its type is 'list'. However, the value "
-                    "'['hello']' is invalid for JSON parsing. Please make sure your inputs are "
-                    "properly formatted. For example, use double quotes instead of single quotes."
+                    "'['hello']' is invalid for JSON parsing. Error details: Expecting value: "
+                    "line 1 column 2 (char 1). Please make sure your inputs are properly "
+                    "formatted. For example, use double quotes instead of single quotes."
                 ),
             ),
         ],

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -193,9 +193,9 @@ class TestValidation:
                 InputParseError,
                 (
                     "Failed to parse the flow input. The value for flow input 'key' was "
-                    "interpreted as JSON string but the value '['hello']' is invalid for JSON "
-                    "parsing. Please make sure your inputs are properly formatted. For example, "
-                    "use double quotes instead of single quotes."
+                    "interpreted as JSON string since its type is 'list'. However, the value "
+                    "'['hello']' is invalid for JSON parsing. Please make sure your inputs are "
+                    "properly formatted. For example, use double quotes instead of single quotes."
                 ),
             ),
         ],

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_validator.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_validator.py
@@ -2,7 +2,7 @@ import pytest
 import yaml
 
 from promptflow.contracts.flow import Flow
-from promptflow.executor._errors import InvalidFlowRequest
+from promptflow.executor._errors import InputParseError, InvalidFlowRequest
 from promptflow.executor.flow_validator import FlowValidator
 
 from ...utils import WRONG_FLOW_ROOT, get_yaml_file
@@ -85,3 +85,43 @@ class TestFlowValidator:
         print(flow.outputs)
         assert flow.outputs["content"] is not None
         assert flow.outputs.get("aggregate_content") is None
+
+    @pytest.mark.parametrize(
+        "flow_folder, inputs, index, error_type, error_message",
+        [
+            (
+                "flow_with_list_input",
+                {"key": "['hello']"},
+                None,
+                InputParseError,
+                (
+                    "Failed to parse the flow input. The value for flow input 'key' was "
+                    "interpreted as JSON string since its type is 'list'. However, the value "
+                    "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
+                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
+                    "properly formatted. For example, use double quotes instead of single quotes."
+                ),
+            ),
+            (
+                "flow_with_list_input",
+                {"key": "['hello']"},
+                0,
+                InputParseError,
+                (
+                    "Failed to parse the flow input. The value for flow input 'key' in line 0 of input data was "
+                    "interpreted as JSON string since its type is 'list'. However, the value "
+                    "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
+                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
+                    "properly formatted. For example, use double quotes instead of single quotes."
+                ),
+            ),
+        ],
+    )
+    def test_resolve_flow_inputs_type_json_error(self, flow_folder, inputs, index, error_type, error_message):
+        flow_yaml = get_yaml_file(flow_folder)
+        with open(flow_yaml, "r") as fin:
+            flow = Flow.deserialize(yaml.safe_load(fin))
+
+        with pytest.raises(error_type) as exe_info:
+            FlowValidator.resolve_flow_inputs_type(flow, inputs, idx=index)
+        assert error_message == exe_info.value.message

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_validator.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_validator.py
@@ -98,8 +98,7 @@ class TestFlowValidator:
                     "Failed to parse the flow input. The value for flow input 'key' was "
                     "interpreted as JSON string since its type is 'list'. However, the value "
                     "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
-                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
-                    "properly formatted. For example, use double quotes instead of single quotes."
+                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are properly formatted."
                 ),
             ),
             (
@@ -111,13 +110,14 @@ class TestFlowValidator:
                     "Failed to parse the flow input. The value for flow input 'key' in line 0 of input data was "
                     "interpreted as JSON string since its type is 'list'. However, the value "
                     "'['hello']' is invalid for JSON parsing. Error details: (JSONDecodeError) "
-                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are "
-                    "properly formatted. For example, use double quotes instead of single quotes."
+                    "Expecting value: line 1 column 2 (char 1). Please make sure your inputs are properly formatted."
                 ),
             ),
         ],
     )
-    def test_resolve_flow_inputs_type_json_error(self, flow_folder, inputs, index, error_type, error_message):
+    def test_resolve_flow_inputs_type_json_error_for_list_type(
+        self, flow_folder, inputs, index, error_type, error_message
+    ):
         flow_yaml = get_yaml_file(flow_folder)
         with open(flow_yaml, "r") as fin:
             flow = Flow.deserialize(yaml.safe_load(fin))

--- a/src/promptflow/tests/test_configs/flows/flow_with_list_input/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/flow_with_list_input/flow.dag.yaml
@@ -1,0 +1,15 @@
+inputs:
+  key:
+    type: list
+outputs:
+  output:
+    type: string
+    reference: ${print_val.output.value}
+nodes:
+- name: print_val
+  type: python
+  source:
+    type: code
+    path: print_val.py
+  inputs:
+    key: ${inputs.key}

--- a/src/promptflow/tests/test_configs/flows/flow_with_list_input/print_val.py
+++ b/src/promptflow/tests/test_configs/flows/flow_with_list_input/print_val.py
@@ -1,0 +1,10 @@
+from typing import List
+
+from promptflow import tool
+
+
+@tool
+def get_val(key):
+    # get from env var
+    print(key)
+    return {"value": f"{key}: {type(key)}"}


### PR DESCRIPTION
# Description

This is for bugfixing :

when user input List or Object, we use load user input as Json string and parse it as json first.  If the json string is not valid, then error would raised. We used to raise InputTypeError, but this definitely not illustrate the essence. So we try catch this specific exception for special handling.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
