### PR TITLE
[Feature] Improve error handling for loading tool error.

### DIFF
--- a/src/promptflow/promptflow/_core/_errors.py
+++ b/src/promptflow/promptflow/_core/_errors.py
@@ -24,12 +24,15 @@ class PackageToolNotFoundError(ValidationException):
     pass
 
 
-class LoadToolError(ValidationException):
+class MissingRequiredInputs(ValidationException):
     pass
 
 
-class MissingRequiredInputs(LoadToolError):
-    pass
+class ToolLoadError(UserErrorException):
+    """Exception raised when tool load failed."""
+
+    def __init__(self, *, module: str = None):
+        super().__init__(target=ErrorTarget.TOOL, module=module)
 
 
 class ToolExecutionError(UserErrorException):

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -10,22 +10,19 @@ from pathlib import Path
 from typing import Callable, List, Optional
 
 from promptflow._core.connection_manager import ConnectionManager
-from promptflow._core.tools_manager import (
-    BuiltinsManager,
-    ToolLoader,
-    connection_type_to_api_mapping,
-)
+from promptflow._core.tools_manager import BuiltinsManager, ToolLoader, connection_type_to_api_mapping
 from promptflow._utils.tool_utils import get_inputs_for_prompt_template, get_prompt_param_name_from_func
 from promptflow.contracts.flow import InputAssignment, InputValueType, Node, ToolSourceType
 from promptflow.contracts.tool import ConnectionType, Tool, ToolType, ValueType
 from promptflow.contracts.types import PromptTemplate
-from promptflow.exceptions import ErrorTarget, UserErrorException
+from promptflow.exceptions import ErrorTarget, PromptflowException, UserErrorException
 from promptflow.executor._errors import (
     ConnectionNotFound,
     InvalidConnectionType,
     InvalidCustomLLMTool,
     InvalidSource,
     NodeInputValidationError,
+    ResolveToolError,
     ValueTypeUnresolved,
 )
 
@@ -97,26 +94,33 @@ class ToolResolver:
         return updated_node
 
     def resolve_tool_by_node(self, node: Node, convert_input_types=True) -> ResolvedTool:
-        if node.source is None:
-            raise UserErrorException(f"Node {node.name} does not have source defined.")
+        try:
+            if node.source is None:
+                raise UserErrorException(f"Node {node.name} does not have source defined.")
 
-        if node.type is ToolType.PYTHON:
-            if node.source.type == ToolSourceType.Package:
-                return self._resolve_package_node(node, convert_input_types=convert_input_types)
-            elif node.source.type == ToolSourceType.Code:
-                return self._resolve_script_node(node, convert_input_types=convert_input_types)
-            raise NotImplementedError(f"Tool source type {node.source.type} for python tool is not supported yet.")
-        elif node.type is ToolType.PROMPT:
-            return self._resolve_prompt_node(node)
-        elif node.type is ToolType.LLM:
-            return self._resolve_llm_node(node, convert_input_types=convert_input_types)
-        elif node.type is ToolType.CUSTOM_LLM:
-            if node.source.type == ToolSourceType.PackageWithPrompt:
-                resolved_tool = self._resolve_package_node(node, convert_input_types=convert_input_types)
-                return self._integrate_prompt_in_package_node(node, resolved_tool)
-            raise NotImplementedError(f"Tool source type {node.source.type} for custom_llm tool is not supported yet.")
-        else:
-            raise NotImplementedError(f"Tool type {node.type} is not supported yet.")
+            if node.type is ToolType.PYTHON:
+                if node.source.type == ToolSourceType.Package:
+                    return self._resolve_package_node(node, convert_input_types=convert_input_types)
+                elif node.source.type == ToolSourceType.Code:
+                    return self._resolve_script_node(node, convert_input_types=convert_input_types)
+                raise NotImplementedError(f"Tool source type {node.source.type} for python tool is not supported yet.")
+            elif node.type is ToolType.PROMPT:
+                return self._resolve_prompt_node(node)
+            elif node.type is ToolType.LLM:
+                return self._resolve_llm_node(node, convert_input_types=convert_input_types)
+            elif node.type is ToolType.CUSTOM_LLM:
+                if node.source.type == ToolSourceType.PackageWithPrompt:
+                    resolved_tool = self._resolve_package_node(node, convert_input_types=convert_input_types)
+                    return self._integrate_prompt_in_package_node(node, resolved_tool)
+                raise NotImplementedError(
+                    f"Tool source type {node.source.type} for custom_llm tool is not supported yet."
+                )
+            else:
+                raise NotImplementedError(f"Tool type {node.type} is not supported yet.")
+        except Exception as e:
+            if isinstance(e, PromptflowException) and e.target != ErrorTarget.UNKNOWN:
+                raise ResolveToolError(node_name=node.name, target=e.target, module=e.module) from e
+            raise ResolveToolError(node_name=node.name) from e
 
     def _load_source_content(self, node: Node) -> str:
         source = node.source

--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -229,6 +229,29 @@ class TestExceptionPresenter:
             },
         }
 
+    def test_error_codes_for_general_exception(self):
+        with pytest.raises(CustomizedException) as e:
+            raise_general_exception()
+
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["SystemError", "CustomizedException"]
+
+    def test_error_codes_romptflow_exception(self):
+        with pytest.raises(ToolExecutionError) as e:
+            raise_tool_execution_error()
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["UserError", "ToolExecutionError"]
+
+        with pytest.raises(PromptflowException) as e:
+            raise_promptflow_exception()
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["SystemError", "ZeroDivisionError"]
+
+        with pytest.raises(PromptflowException) as e:
+            raise_promptflow_exception_without_inner_exception()
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["SystemError"]
+
 
 @pytest.mark.unittest
 class TestErrorResponse:

--- a/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
@@ -1,0 +1,63 @@
+import pytest
+
+from promptflow._core.tool_meta_generator import PythonLoadError
+from promptflow.exceptions import ErrorTarget
+from promptflow.executor._errors import ResolveToolError
+
+
+def code_with_bug():
+    1 / 0
+
+
+def raise_resolve_tool_error(func, target=None, module=None):
+    try:
+        func()
+    except Exception as e:
+        if target:
+            raise ResolveToolError(node_name="MyTool", target=target, module=module) from e
+        raise ResolveToolError(node_name="MyTool") from e
+
+
+def raise_python_load_error():
+    try:
+        code_with_bug()
+    except Exception as e:
+        raise PythonLoadError(message="Test PythonLoadError.") from e
+
+
+def test_resolve_tool_error():
+    with pytest.raises(ResolveToolError) as e:
+        raise_resolve_tool_error(raise_python_load_error, ErrorTarget.TOOL, "__pf_main__")
+
+    exception = e.value
+    inner_exception = exception.inner_exception
+
+    assert isinstance(inner_exception, PythonLoadError)
+    assert exception.message == "Tool load failed in 'MyTool': (PythonLoadError) Test PythonLoadError."
+    assert exception.additional_info == inner_exception.additional_info
+    assert exception.error_codes == ["UserError", "ToolValidationError", "PythonParsingError", "PythonLoadError"]
+    assert exception.reference_code == "Tool/__pf_main__"
+
+
+def test_resolve_tool_error_with_none_inner():
+    with pytest.raises(ResolveToolError) as e:
+        raise ResolveToolError(node_name="MyTool")
+
+    exception = e.value
+    assert exception.inner_exception is None
+    assert exception.message == "Tool load failed in 'MyTool'."
+    assert exception.additional_info is None
+    assert exception.error_codes == ["SystemError"]
+    assert exception.reference_code == "Executor"
+
+
+def test_resolve_tool_error_with_no_PromptflowException_inner():
+    with pytest.raises(ResolveToolError) as e:
+        raise_resolve_tool_error(code_with_bug)
+
+    exception = e.value
+    assert isinstance(exception.inner_exception, ZeroDivisionError)
+    assert exception.message == "Tool load failed in 'MyTool': (ZeroDivisionError) division by zero"
+    assert exception.additional_info is None
+    assert exception.error_codes == ["SystemError", "ZeroDivisionError"]
+    assert exception.reference_code == "Executor"


### PR DESCRIPTION
# Description

Currently, for loading tool error, the error message does not contain the name of the node where the error occurred, which makes it difficult for users to locate the problematic nod. So we need to improve the error handling here.

Changes in this PR:
1. Define an error type: ToolLoadError, to encapsulate load errors thrown from a third-party tool package. Its most important function is to record the error target and module.
2. Define an error type: ResolveToolError, to append the name of the node in question to the error message, which can help user locate the error more quickly. ResolveToolError is a typeless error, so we need to rely on inner_error to redefine its additional_info and error_codes.
3. To achieve the second point, we improved the handling of error_codes in ExceptionPresenter.
4. Removes an unnecessary and ambiguous error type: LoadToolError(ValidationException).
5. Supplement test cases.


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
