### PR TITLE
[Feature] Improve error handling for loading tool error.

### DIFF
--- a/src/promptflow/promptflow/_core/_errors.py
+++ b/src/promptflow/promptflow/_core/_errors.py
@@ -24,12 +24,15 @@ class PackageToolNotFoundError(ValidationException):
     pass
 
 
-class LoadToolError(ValidationException):
+class MissingRequiredInputs(ValidationException):
     pass
 
 
-class MissingRequiredInputs(LoadToolError):
-    pass
+class ToolLoadError(UserErrorException):
+    """Exception raised when tool load failed."""
+
+    def __init__(self, *, module: str = None):
+        super().__init__(target=ErrorTarget.TOOL, module=module)
 
 
 class ToolExecutionError(UserErrorException):

--- a/src/promptflow/promptflow/_core/_errors.py
+++ b/src/promptflow/promptflow/_core/_errors.py
@@ -31,8 +31,8 @@ class MissingRequiredInputs(ValidationException):
 class ToolLoadError(UserErrorException):
     """Exception raised when tool load failed."""
 
-    def __init__(self, *, module: str = None):
-        super().__init__(target=ErrorTarget.TOOL, module=module)
+    def __init__(self, module: str = None, **kwargs):
+        super().__init__(target=ErrorTarget.TOOL, module=module, **kwargs)
 
 
 class ToolExecutionError(UserErrorException):

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -216,14 +216,12 @@ class BuiltinsManager:
         try:
             api = getattr(provider_class(**init_inputs_values), method_name)
         except Exception as ex:
+            error_type_and_message = f"({ex.__class__.__name__}) {ex}"
             raise ToolLoadError(
                 module=module_name,
-                message_format=(
-                    "Load package tool failed, tool: '{tool_name}', module: '{module_name}', exception: {exception}"
-                ),
+                message_format=("Failed to load package tool '{tool_name}': {error_type_and_message}"),
                 tool_name=tool_name,
-                module_name=module_name,
-                exception=str(ex),
+                error_type_and_message=error_type_and_message,
             ) from ex
         # Return the init_inputs to update node inputs in the afterward steps
         return api, init_inputs

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -216,7 +216,15 @@ class BuiltinsManager:
         try:
             api = getattr(provider_class(**init_inputs_values), method_name)
         except Exception as ex:
-            raise ToolLoadError(target=ErrorTarget.TOOL, module=module_name) from ex
+            raise ToolLoadError(
+                module=module_name,
+                message_format=(
+                    "Load package tool failed, tool: '{tool_name}', module: '{module_name}', exception: {exception}"
+                ),
+                tool_name=tool_name,
+                module_name=module_name,
+                exception=str(ex),
+            ) from ex
         # Return the init_inputs to update node inputs in the afterward steps
         return api, init_inputs
 

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -219,7 +219,7 @@ class BuiltinsManager:
             error_type_and_message = f"({ex.__class__.__name__}) {ex}"
             raise ToolLoadError(
                 module=module_name,
-                message_format=("Failed to load package tool '{tool_name}': {error_type_and_message}"),
+                message_format="Failed to load package tool '{tool_name}': {error_type_and_message}",
                 tool_name=tool_name,
                 error_type_and_message=error_type_and_message,
             ) from ex

--- a/src/promptflow/promptflow/_utils/exception_utils.py
+++ b/src/promptflow/promptflow/_utils/exception_utils.py
@@ -206,11 +206,10 @@ class ExceptionPresenter:
         See the below link for details:
         https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses
 
-        For general exceptions, the hierarchy should be:
-        ["SystemError", {exception type name}]
+        This method returns the error codes in a list. It will be converted into a nested json format by
+        error_code_recursed.
         """
-        error_codes = [infer_error_code_from_class(SystemErrorException), self._ex.__class__.__name__]
-        return error_codes
+        return [infer_error_code_from_class(SystemErrorException), self._ex.__class__.__name__]
 
     @property
     def error_code_recursed(self):
@@ -254,7 +253,7 @@ class ExceptionPresenter:
         This dict specification corresponds to the specification of the Microsoft API Guidelines:
         https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses
 
-        Note that this dict representation the "error" field in the response body of the API.
+        Note that this dict represents the "error" field in the response body of the API.
         The whole error response is then populated in another place outside of this class.
         """
         if isinstance(self._ex, JsonSerializedPromptflowException):

--- a/src/promptflow/promptflow/_utils/exception_utils.py
+++ b/src/promptflow/promptflow/_utils/exception_utils.py
@@ -202,10 +202,14 @@ class ExceptionPresenter:
     def error_codes(self):
         """The hierarchy of the error codes.
 
+        We follow the "Microsoft REST API Guidelines" to define error codes in a hierarchy style.
+        See the below link for details:
+        https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses
+
         For general exceptions, the hierarchy should be:
         ["SystemError", {exception type name}]
         """
-        error_codes: list[str] = [infer_error_code_from_class(SystemErrorException), self._ex.__class__.__name__]
+        error_codes = [infer_error_code_from_class(SystemErrorException), self._ex.__class__.__name__]
         return error_codes
 
     @property
@@ -258,11 +262,8 @@ class ExceptionPresenter:
 
         # Otherwise, return general dict representation of the exception.
         result = {"message": str(self._ex), "messageFormat": "", "messageParameters": {}}
-        if self.error_code_recursed:
-            result.update(self.error_code_recursed)
-        else:
-            result["code"] = infer_error_code_from_class(SystemErrorException)
-            result["innerError"] = None
+        result.update(self.error_code_recursed)
+
         if include_debug_info:
             result["debugInfo"] = self.debug_info
 
@@ -273,6 +274,10 @@ class PromptflowExceptionPresenter(ExceptionPresenter):
     @property
     def error_codes(self):
         """The hierarchy of the error codes.
+
+        We follow the "Microsoft REST API Guidelines" to define error codes in a hierarchy style.
+        See the below link for details:
+        https://github.com/microsoft/api-guidelines/blob/vNext/Guidelines.md#7102-error-condition-responses
 
         For subclass of PromptflowException, use the ex.error_codes directly.
 
@@ -285,7 +290,7 @@ class PromptflowExceptionPresenter(ExceptionPresenter):
 
         # For PromptflowException (not a subclass), the ex.error_code is None.
         # Handle this case specifically.
-        error_codes: list[str] = [infer_error_code_from_class(SystemErrorException)]
+        error_codes = [infer_error_code_from_class(SystemErrorException)]
         if self._ex.inner_exception:
             error_codes.append(infer_error_code_from_class(self._ex.inner_exception.__class__))
         return error_codes
@@ -298,11 +303,7 @@ class PromptflowExceptionPresenter(ExceptionPresenter):
             "referenceCode": self._ex.reference_code,
         }
 
-        if self.error_code_recursed:
-            result.update(self.error_code_recursed)
-        else:
-            result["code"] = infer_error_code_from_class(SystemErrorException)
-            result["innerError"] = None
+        result.update(self.error_code_recursed)
         if self._ex.additional_info:
             result["additionalInfo"] = [{"type": k, "info": v} for k, v in self._ex.additional_info.items()]
         if include_debug_info:

--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -192,9 +192,9 @@ class LineExecutionTimeoutError(UserErrorException):
 class ResolveToolError(PromptflowException):
     """Exception raised when tool load failed.
 
-    It is used to append the name of the node in question to the error message to improve the user experience.
-    ResolveToolError has no classification of its own.
-    So we need to rely on inner_error to redefine its additional_info and error_codes.
+    It is used to append the name of the failed node to the error message to improve the user experience.
+    It simply wraps the error thrown by the Resolve Tool phase.
+    It has the same additional_info and error_codes as inner error.
     """
 
     def __init__(self, *, node_name: str, target: ErrorTarget = ErrorTarget.EXECUTOR, module: str = None):

--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -2,7 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-from promptflow.exceptions import ErrorTarget, SystemErrorException, UserErrorException, ValidationException
+from promptflow._utils.exception_utils import ExceptionPresenter, RootErrorCode
+from promptflow.exceptions import (
+    ErrorTarget,
+    PromptflowException,
+    SystemErrorException,
+    UserErrorException,
+    ValidationException,
+)
 
 
 class InvalidCustomLLMTool(ValidationException):
@@ -180,3 +187,42 @@ class LineExecutionTimeoutError(UserErrorException):
         super().__init__(
             message=f"Line {line_number} execution timeout for exceeding {timeout} seconds", target=ErrorTarget.EXECUTOR
         )
+
+
+class ResolveToolError(PromptflowException):
+    """Exception raised when tool load failed."""
+
+    def __init__(self, *, node_name: str, target: ErrorTarget = ErrorTarget.EXECUTOR, module: str = None):
+        self._node_name = node_name
+        super().__init__(target=target, module=module)
+
+    @property
+    def message_format(self):
+        if self.inner_exception:
+            return "Tool load failed in '{node_name}': {error_type_and_message}"
+        else:
+            return "Tool load failed in '{node_name}'."
+
+    @property
+    def message_parameters(self):
+        error_type_and_message = None
+        if self.inner_exception:
+            error_type_and_message = f"({self.inner_exception.__class__.__name__}) {self.inner_exception}"
+
+        return {
+            "node_name": self._node_name,
+            "error_type_and_message": error_type_and_message,
+        }
+
+    @property
+    def additional_info(self):
+        """Get additional info from innererror when the innererror is PromptflowException"""
+        if isinstance(self.inner_exception, PromptflowException):
+            return self.inner_exception.additional_info
+        return None
+
+    @property
+    def error_codes(self):
+        if self.inner_exception:
+            return ExceptionPresenter.create(self.inner_exception).error_codes
+        return [RootErrorCode.SYSTEM_ERROR]

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -16,13 +16,14 @@ from promptflow._utils.tool_utils import get_inputs_for_prompt_template, get_pro
 from promptflow.contracts.flow import InputAssignment, InputValueType, Node, ToolSourceType
 from promptflow.contracts.tool import ConnectionType, Tool, ToolType, ValueType
 from promptflow.contracts.types import PromptTemplate
-from promptflow.exceptions import ErrorTarget, UserErrorException
+from promptflow.exceptions import ErrorTarget, PromptflowException, UserErrorException
 from promptflow.executor._errors import (
     ConnectionNotFound,
     InvalidConnectionType,
     InvalidCustomLLMTool,
     InvalidSource,
     NodeInputValidationError,
+    ResolveToolError,
     ValueTypeUnresolved,
 )
 
@@ -98,26 +99,33 @@ class ToolResolver:
         return updated_node
 
     def resolve_tool_by_node(self, node: Node, convert_input_types=True) -> ResolvedTool:
-        if node.source is None:
-            raise UserErrorException(f"Node {node.name} does not have source defined.")
+        try:
+            if node.source is None:
+                raise UserErrorException(f"Node {node.name} does not have source defined.")
 
-        if node.type is ToolType.PYTHON:
-            if node.source.type == ToolSourceType.Package:
-                return self._resolve_package_node(node, convert_input_types=convert_input_types)
-            elif node.source.type == ToolSourceType.Code:
-                return self._resolve_script_node(node, convert_input_types=convert_input_types)
-            raise NotImplementedError(f"Tool source type {node.source.type} for python tool is not supported yet.")
-        elif node.type is ToolType.PROMPT:
-            return self._resolve_prompt_node(node)
-        elif node.type is ToolType.LLM:
-            return self._resolve_llm_node(node, convert_input_types=convert_input_types)
-        elif node.type is ToolType.CUSTOM_LLM:
-            if node.source.type == ToolSourceType.PackageWithPrompt:
-                resolved_tool = self._resolve_package_node(node, convert_input_types=convert_input_types)
-                return self._integrate_prompt_in_package_node(node, resolved_tool)
-            raise NotImplementedError(f"Tool source type {node.source.type} for custom_llm tool is not supported yet.")
-        else:
-            raise NotImplementedError(f"Tool type {node.type} is not supported yet.")
+            if node.type is ToolType.PYTHON:
+                if node.source.type == ToolSourceType.Package:
+                    return self._resolve_package_node(node, convert_input_types=convert_input_types)
+                elif node.source.type == ToolSourceType.Code:
+                    return self._resolve_script_node(node, convert_input_types=convert_input_types)
+                raise NotImplementedError(f"Tool source type {node.source.type} for python tool is not supported yet.")
+            elif node.type is ToolType.PROMPT:
+                return self._resolve_prompt_node(node)
+            elif node.type is ToolType.LLM:
+                return self._resolve_llm_node(node, convert_input_types=convert_input_types)
+            elif node.type is ToolType.CUSTOM_LLM:
+                if node.source.type == ToolSourceType.PackageWithPrompt:
+                    resolved_tool = self._resolve_package_node(node, convert_input_types=convert_input_types)
+                    return self._integrate_prompt_in_package_node(node, resolved_tool)
+                raise NotImplementedError(
+                    f"Tool source type {node.source.type} for custom_llm tool is not supported yet."
+                )
+            else:
+                raise NotImplementedError(f"Tool type {node.type} is not supported yet.")
+        except Exception as e:
+            if isinstance(e, PromptflowException) and e.target != ErrorTarget.UNKNOWN:
+                raise ResolveToolError(node_name=node.name, target=e.target, module=e.module) from e
+            raise ResolveToolError(node_name=node.name) from e
 
     def _load_source_content(self, node: Node) -> str:
         source = node.source

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -9,7 +9,7 @@ from promptflow.contracts.run_info import RunInfo as NodeRunInfo
 from promptflow.contracts.run_info import Status
 from promptflow.exceptions import UserErrorException
 from promptflow.executor import FlowExecutor
-from promptflow.executor._errors import ConnectionNotFound, InputTypeError
+from promptflow.executor._errors import ConnectionNotFound, InputTypeError, ResolveToolError
 from promptflow.executor.flow_executor import BulkResult, LineResult
 from promptflow.storage import AbstractRunStorage
 
@@ -265,13 +265,14 @@ class TestExecutor:
         assert type(e.value).__name__ == "WrappedOpenAIError"
         assert "The API deployment for this resource does not exist." in str(e.value)
 
-        with pytest.raises(ConnectionNotFound) as e:
+        with pytest.raises(ResolveToolError) as e:
             executor = FlowExecutor.create(
                 get_yaml_file(SAMPLE_FLOW),
                 dev_connections,
                 node_override={"classify_with_llm.connection": "dummy_connection"},
                 raise_ex=True,
             )
+        isinstance(e.value.inner_exception, ConnectionNotFound)
         assert "Connection 'dummy_connection' not found" in str(e.value)
 
     @pytest.mark.parametrize(

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -272,7 +272,7 @@ class TestExecutor:
                 node_override={"classify_with_llm.connection": "dummy_connection"},
                 raise_ex=True,
             )
-        isinstance(e.value.inner_exception, ConnectionNotFound)
+        assert isinstance(e.value.inner_exception, ConnectionNotFound)
         assert "Connection 'dummy_connection' not found" in str(e.value)
 
     @pytest.mark.parametrize(

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -24,6 +24,7 @@ from promptflow.executor._errors import (
     NodeInputValidationError,
     NodeReferenceNotFound,
     OutputReferenceNotFound,
+    ResolveToolError,
     SingleNodeValidationError,
 )
 from promptflow.executor.flow_executor import BulkResult
@@ -35,12 +36,13 @@ from ..utils import FLOW_ROOT, WRONG_FLOW_ROOT, get_yaml_file
 @pytest.mark.e2etest
 class TestValidation:
     @pytest.mark.parametrize(
-        "flow_folder, yml_file, error_class, error_msg",
+        "flow_folder, yml_file, error_class, inner_class, error_msg",
         [
             (
                 "nodes_names_duplicated",
                 "flow.dag.yaml",
                 DuplicateNodeName,
+                None,
                 (
                     "Invalid node definitions found in the flow graph. Node with name 'stringify_num' appears more "
                     "than once in the node definitions in your flow, which is not allowed. To "
@@ -51,16 +53,19 @@ class TestValidation:
             (
                 "source_file_missing",
                 "flow.dag.jinja.yaml",
+                ResolveToolError,
                 InvalidSource,
                 (
-                    "Node source path 'summarize_text_content__variant_1.jinja2' is invalid on "
-                    "node 'summarize_text_content'."
+                    "Tool load failed in 'summarize_text_content': (InvalidSource) "
+                    "Node source path 'summarize_text_content__variant_1.jinja2' is invalid on node "
+                    "'summarize_text_content'."
                 ),
             ),
             (
                 "node_reference_not_found",
                 "flow.dag.yaml",
                 NodeReferenceNotFound,
+                None,
                 (
                     "Invalid node definitions found in the flow graph. Node 'divide_num_2' references a non-existent "
                     "node 'divide_num_3' in your flow. Please review your flow to ensure that the "
@@ -71,6 +76,7 @@ class TestValidation:
                 "node_circular_dependency",
                 "flow.dag.yaml",
                 NodeCircularDependency,
+                None,
                 (
                     "Invalid node definitions found in the flow graph. Node circular dependency has been detected "
                     "among the nodes in your flow. Kindly review the reference relationships for "
@@ -82,6 +88,7 @@ class TestValidation:
                 "flow_input_reference_invalid",
                 "flow.dag.yaml",
                 InputReferenceNotFound,
+                None,
                 (
                     "Invalid node definitions found in the flow graph. Node 'divide_num' references flow input 'num_1' "
                     "which is not defined in your flow. To resolve this issue, please review your "
@@ -93,6 +100,7 @@ class TestValidation:
                 "flow_output_reference_invalid",
                 "flow.dag.yaml",
                 EmptyOutputReference,
+                None,
                 (
                     "The output 'content' for flow is incorrect. The reference is not specified for the output "
                     "'content' in the flow. To rectify this, ensure that you accurately specify "
@@ -103,6 +111,7 @@ class TestValidation:
                 "outputs_reference_not_valid",
                 "flow.dag.yaml",
                 OutputReferenceNotFound,
+                None,
                 (
                     "The output 'content' for flow is incorrect. The output 'content' references non-existent "
                     "node 'another_stringify_num' in your flow. To resolve this issue, please "
@@ -114,6 +123,7 @@ class TestValidation:
                 "outputs_with_invalid_flow_inputs_ref",
                 "flow.dag.yaml",
                 OutputReferenceNotFound,
+                None,
                 (
                     "The output 'num' for flow is incorrect. The output 'num' references non-existent flow "
                     "input 'num11' in your flow. Please carefully review your flow and correct "
@@ -123,21 +133,25 @@ class TestValidation:
         ],
     )
     def test_executor_create_failure_type_and_message(
-        self, flow_folder, yml_file, error_class, error_msg, dev_connections
+        self, flow_folder, yml_file, error_class, inner_class, error_msg, dev_connections
     ):
         with pytest.raises(error_class) as exc_info:
             FlowExecutor.create(get_yaml_file(flow_folder, WRONG_FLOW_ROOT, yml_file), dev_connections)
+        if isinstance(exc_info.value, ResolveToolError):
+            assert isinstance(exc_info.value.inner_exception, inner_class)
         assert error_msg == exc_info.value.message
 
     @pytest.mark.parametrize(
-        "flow_folder, yml_file, error_class",
+        "flow_folder, yml_file, error_class, inner_class",
         [
-            ("source_file_missing", "flow.dag.python.yaml", PythonParsingError),
+            ("source_file_missing", "flow.dag.python.yaml", ResolveToolError, PythonParsingError),
         ],
     )
-    def test_executor_create_failure_type(self, flow_folder, yml_file, error_class, dev_connections):
-        with pytest.raises(error_class):
+    def test_executor_create_failure_type(self, flow_folder, yml_file, error_class, inner_class, dev_connections):
+        with pytest.raises(error_class) as e:
             FlowExecutor.create(get_yaml_file(flow_folder, WRONG_FLOW_ROOT, yml_file), dev_connections)
+        if isinstance(e.value, ResolveToolError):
+            assert isinstance(e.value.inner_exception, inner_class)
 
     @pytest.mark.parametrize(
         "ordered_flow_folder,  unordered_flow_folder",
@@ -153,18 +167,20 @@ class TestValidation:
             assert node1.name == node2.name
 
     @pytest.mark.parametrize(
-        "flow_folder, error_class",
+        "flow_folder, error_class, inner_class",
         [
-            ("invalid_connection", ConnectionNotFound),
-            ("tool_type_missing", NotImplementedError),
-            ("wrong_module", FailedToImportModule),
-            ("wrong_api", APINotFound),
-            ("wrong_provider", APINotFound),
+            ("invalid_connection", ResolveToolError, ConnectionNotFound),
+            ("tool_type_missing", ResolveToolError, NotImplementedError),
+            ("wrong_module", FailedToImportModule, None),
+            ("wrong_api", ResolveToolError, APINotFound),
+            ("wrong_provider", ResolveToolError, APINotFound),
         ],
     )
-    def test_invalid_flow_dag(self, flow_folder, error_class, dev_connections):
-        with pytest.raises(error_class):
+    def test_invalid_flow_dag(self, flow_folder, error_class, inner_class, dev_connections):
+        with pytest.raises(error_class) as e:
             FlowExecutor.create(get_yaml_file(flow_folder, WRONG_FLOW_ROOT), dev_connections)
+        if isinstance(e.value, ResolveToolError):
+            assert isinstance(e.value.inner_exception, inner_class)
 
     @pytest.mark.parametrize(
         "flow_folder, line_input, error_class",
@@ -342,8 +358,9 @@ class TestValidation:
         ],
     )
     def test_flow_run_with_duplicated_inputs(self, flow_folder, msg, dev_connections):
-        with pytest.raises(NodeInputValidationError, match=msg):
+        with pytest.raises(ResolveToolError, match=msg) as e:
             FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections)
+        assert isinstance(e.value.inner_exception, NodeInputValidationError)
 
     @pytest.mark.parametrize(
         "flow_folder, batch_input, raise_on_line_failure, error_class",

--- a/src/promptflow/tests/executor/e2etests/test_package_tool.py
+++ b/src/promptflow/tests/executor/e2etests/test_package_tool.py
@@ -132,8 +132,7 @@ class TestPackageTool:
             (
                 "tool_with_init_error",
                 "Tool load failed in 'tool_with_init_error': "
-                "(ToolLoadError) Load package tool failed, tool: 'Tool with init error', "
-                "module: 'tool_with_init_error', exception: Tool load error.",
+                "(ToolLoadError) Failed to load package tool 'Tool with init error': (Exception) Tool load error.",
             )
         ],
     )

--- a/src/promptflow/tests/executor/package_tools/tool_with_init_error.py
+++ b/src/promptflow/tests/executor/package_tools/tool_with_init_error.py
@@ -1,0 +1,10 @@
+from promptflow import ToolProvider, tool
+
+
+class TestLoadErrorTool(ToolProvider):
+    def __init__(self):
+        raise Exception("Tool load error.")
+
+    @tool
+    def tool(self, name: str):
+        return name

--- a/src/promptflow/tests/executor/package_tools/tool_with_init_error/flow.dag.yaml
+++ b/src/promptflow/tests/executor/package_tools/tool_with_init_error/flow.dag.yaml
@@ -1,0 +1,10 @@
+inputs: {}
+outputs: {}
+nodes:
+- name: tool_with_init_error
+  type: python
+  source:
+    type: package
+    tool: tool_with_init_error
+  inputs:
+    name: test_name

--- a/src/promptflow/tests/executor/package_tools/tool_with_init_error/package_tool_definition.json
+++ b/src/promptflow/tests/executor/package_tools/tool_with_init_error/package_tool_definition.json
@@ -1,0 +1,12 @@
+{
+    "tool_with_init_error": {
+        "class_name": "TestLoadErrorTool",
+        "function": "tool",
+        "inputs": {
+            "name": {"type": ["string"]}
+        },
+        "module": "tool_with_init_error",
+        "name": "Tool with init error",
+        "type": "python"
+    }
+}

--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -229,6 +229,29 @@ class TestExceptionPresenter:
             },
         }
 
+    def test_error_codes_for_general_exception(self):
+        with pytest.raises(CustomizedException) as e:
+            raise_general_exception()
+
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["SystemError", "CustomizedException"]
+
+    def test_error_codes_romptflow_exception(self):
+        with pytest.raises(ToolExecutionError) as e:
+            raise_tool_execution_error()
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["UserError", "ToolExecutionError"]
+
+        with pytest.raises(PromptflowException) as e:
+            raise_promptflow_exception()
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["SystemError", "ZeroDivisionError"]
+
+        with pytest.raises(PromptflowException) as e:
+            raise_promptflow_exception_without_inner_exception()
+        presenter = ExceptionPresenter.create(e.value)
+        assert presenter.error_codes == ["SystemError"]
+
 
 @pytest.mark.unittest
 class TestErrorResponse:

--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -229,28 +229,21 @@ class TestExceptionPresenter:
             },
         }
 
-    def test_error_codes_for_general_exception(self):
-        with pytest.raises(CustomizedException) as e:
-            raise_general_exception()
+    @pytest.mark.parametrize(
+        "raise_exception_func, error_class, expected_error_codes",
+        [
+            (raise_general_exception, CustomizedException, ["SystemError", "CustomizedException"]),
+            (raise_tool_execution_error, ToolExecutionError, ["UserError", "ToolExecutionError"]),
+            (raise_promptflow_exception, PromptflowException, ["SystemError", "ZeroDivisionError"]),
+            (raise_promptflow_exception_without_inner_exception, PromptflowException, ["SystemError"]),
+        ],
+    )
+    def test_error_codes(self, raise_exception_func, error_class, expected_error_codes):
+        with pytest.raises(error_class) as e:
+            raise_exception_func()
 
         presenter = ExceptionPresenter.create(e.value)
-        assert presenter.error_codes == ["SystemError", "CustomizedException"]
-
-    def test_error_codes_romptflow_exception(self):
-        with pytest.raises(ToolExecutionError) as e:
-            raise_tool_execution_error()
-        presenter = ExceptionPresenter.create(e.value)
-        assert presenter.error_codes == ["UserError", "ToolExecutionError"]
-
-        with pytest.raises(PromptflowException) as e:
-            raise_promptflow_exception()
-        presenter = ExceptionPresenter.create(e.value)
-        assert presenter.error_codes == ["SystemError", "ZeroDivisionError"]
-
-        with pytest.raises(PromptflowException) as e:
-            raise_promptflow_exception_without_inner_exception()
-        presenter = ExceptionPresenter.create(e.value)
-        assert presenter.error_codes == ["SystemError"]
+        assert presenter.error_codes == expected_error_codes
 
 
 @pytest.mark.unittest

--- a/src/promptflow/tests/executor/unittests/executor/test_errors.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_errors.py
@@ -47,7 +47,7 @@ def test_resolve_tool_error_with_none_inner():
     assert exception.inner_exception is None
     assert exception.message == "Tool load failed in 'MyTool'."
     assert exception.additional_info is None
-    assert exception.error_codes == ["SystemError"]
+    assert exception.error_codes == ["SystemError", "ResolveToolError"]
     assert exception.reference_code == "Executor"
 
 

--- a/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
@@ -1,0 +1,63 @@
+import pytest
+
+from promptflow._core.tool_meta_generator import PythonLoadError
+from promptflow.exceptions import ErrorTarget
+from promptflow.executor._errors import ResolveToolError
+
+
+def code_with_bug():
+    1 / 0
+
+
+def raise_resolve_tool_error(func, target=None, module=None):
+    try:
+        func()
+    except Exception as e:
+        if target:
+            raise ResolveToolError(node_name="MyTool", target=target, module=module) from e
+        raise ResolveToolError(node_name="MyTool") from e
+
+
+def raise_python_load_error():
+    try:
+        code_with_bug()
+    except Exception as e:
+        raise PythonLoadError(message="Test PythonLoadError.") from e
+
+
+def test_resolve_tool_error():
+    with pytest.raises(ResolveToolError) as e:
+        raise_resolve_tool_error(raise_python_load_error, ErrorTarget.TOOL, "__pf_main__")
+
+    exception = e.value
+    inner_exception = exception.inner_exception
+
+    assert isinstance(inner_exception, PythonLoadError)
+    assert exception.message == "Tool load failed in 'MyTool': (PythonLoadError) Test PythonLoadError."
+    assert exception.additional_info == inner_exception.additional_info
+    assert exception.error_codes == ["UserError", "ToolValidationError", "PythonParsingError", "PythonLoadError"]
+    assert exception.reference_code == "Tool/__pf_main__"
+
+
+def test_resolve_tool_error_with_none_inner():
+    with pytest.raises(ResolveToolError) as e:
+        raise ResolveToolError(node_name="MyTool")
+
+    exception = e.value
+    assert exception.inner_exception is None
+    assert exception.message == "Tool load failed in 'MyTool'."
+    assert exception.additional_info is None
+    assert exception.error_codes == ["SystemError"]
+    assert exception.reference_code == "Executor"
+
+
+def test_resolve_tool_error_with_no_PromptflowException_inner():
+    with pytest.raises(ResolveToolError) as e:
+        raise_resolve_tool_error(code_with_bug)
+
+    exception = e.value
+    assert isinstance(exception.inner_exception, ZeroDivisionError)
+    assert exception.message == "Tool load failed in 'MyTool': (ZeroDivisionError) division by zero"
+    assert exception.additional_info is None
+    assert exception.error_codes == ["SystemError", "ZeroDivisionError"]
+    assert exception.reference_code == "Executor"


### PR DESCRIPTION
# Description

Currently, for loading tool error, the error message does not contain the name of the node where the error occurred, which makes it difficult for users to locate the problematic nod. So we need to improve the error handling here.

Changes in this PR:

1. Define an error type: ToolLoadError, to encapsulate load errors thrown from a third-party tool package. Its most important function is to record the error target and module.
2. Define an error type: ResolveToolError, to append the name of the failed node to the error message, which can help user locate the error more quickly. ResolveToolError is a typeless error, so we need to rely on inner_error to redefine its additional_info and error_codes.
3. To achieve the second point, we improved the handling of error_codes in ExceptionPresenter.
4. Removes an unnecessary and ambiguous error type: LoadToolError(ValidationException).
5. Supplement test cases.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes]**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
