### PR TITLE
Store package and package version for custom strong type connection, add test and support connection.key

### DIFF
--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -61,14 +61,20 @@ class CustomStrongTypeConnectionConfigs:
     PREFIX = "promptflow.connection."
     TYPE = "custom_type"
     MODULE = "module"
+    PACKAGE = "package"
+    PACKAGE_VERSION = "package_version"
     PROMPTFLOW_TYPE_KEY = PREFIX + TYPE
     PROMPTFLOW_MODULE_KEY = PREFIX + MODULE
+    PROMPTFLOW_PACKAGE_KEY = PREFIX + PACKAGE
+    PROMPTFLOW_PACKAGE_VERSION_KEY = PREFIX + PACKAGE_VERSION
 
     @staticmethod
     def is_custom_key(key):
         return key not in [
             CustomStrongTypeConnectionConfigs.PROMPTFLOW_TYPE_KEY,
             CustomStrongTypeConnectionConfigs.PROMPTFLOW_MODULE_KEY,
+            CustomStrongTypeConnectionConfigs.PROMPTFLOW_PACKAGE_KEY,
+            CustomStrongTypeConnectionConfigs.PROMPTFLOW_PACKAGE_VERSION_KEY,
         ]
 
 

--- a/src/promptflow/promptflow/_sdk/entities/_connection.py
+++ b/src/promptflow/promptflow/_sdk/entities/_connection.py
@@ -673,6 +673,13 @@ class CustomStrongTypeConnection(_Connection):
         self.package_version = kwargs.get(CustomStrongTypeConnectionConfigs.PACKAGE_VERSION, None)
 
     def __getattribute__(self, item):
+        # Note: The reason to overwrite __getattribute__ instead of __getattr__ is as follows:
+        # Custom strong type connection is written this way:
+        # class MyCustomConnection(CustomStrongTypeConnection):
+        #     api_key: Secret
+        #     api_base: str = "This is a default value"
+        # api_base has a default value, my_custom_connection_instance.api_base would not trigger __getattr__.
+        # The default value will be returned directly instead of the real value in configs.
         annotations = getattr(super().__getattribute__("__class__"), "__annotations__", {})
         if item in annotations:
             if annotations[item] == Secret:

--- a/src/promptflow/promptflow/_sdk/entities/_connection.py
+++ b/src/promptflow/promptflow/_sdk/entities/_connection.py
@@ -669,6 +669,19 @@ class CustomStrongTypeConnection(_Connection):
         super().__init__(configs=configs, secrets=secrets, **kwargs)
         self.module = kwargs.get("module", self.__class__.__module__)
         self.custom_type = custom_type or self.__class__.__name__
+        self.package = kwargs.get(CustomStrongTypeConnectionConfigs.PACKAGE, None)
+        self.package_version = kwargs.get(CustomStrongTypeConnectionConfigs.PACKAGE_VERSION, None)
+
+    def __getattribute__(self, item):
+        annotations = super().__getattribute__("__class__").__annotations__
+        if item in annotations:
+            if isinstance(item, Secret):
+                logger.warning("Please use connection.secrets[key] to access secrets.")
+                return self.secrets[item]
+            else:
+                logger.warning("Please use connection.configs[key] to access configs.")
+                return self.configs[item]
+        return super().__getattribute__(item)
 
     def _to_orm_object(self) -> ORMConnection:
         custom_connection = self._convert_to_custom()
@@ -678,6 +691,11 @@ class CustomStrongTypeConnection(_Connection):
         # update configs
         self.configs.update({CustomStrongTypeConnectionConfigs.PROMPTFLOW_TYPE_KEY: self.custom_type})
         self.configs.update({CustomStrongTypeConnectionConfigs.PROMPTFLOW_MODULE_KEY: self.module})
+        if self.package and self.package_version:
+            self.configs.update({CustomStrongTypeConnectionConfigs.PROMPTFLOW_PACKAGE_KEY: self.package})
+            self.configs.update(
+                {CustomStrongTypeConnectionConfigs.PROMPTFLOW_PACKAGE_VERSION_KEY: self.package_version}
+            )
 
         custom_connection = CustomConnection(configs=self.configs, secrets=self.secrets, **self.kwargs)
         return custom_connection

--- a/src/promptflow/promptflow/_sdk/entities/_connection.py
+++ b/src/promptflow/promptflow/_sdk/entities/_connection.py
@@ -673,7 +673,10 @@ class CustomStrongTypeConnection(_Connection):
         self.package_version = kwargs.get(CustomStrongTypeConnectionConfigs.PACKAGE_VERSION, None)
 
     def __getattribute__(self, item):
-        annotations = super().__getattribute__("__class__").__annotations__
+        if "__annotations__" in super().__getattribute__("__class__").__dict__:
+            annotations = super().__getattribute__("__class__").__annotations__
+        else:
+            annotations = {}
         if item in annotations:
             if isinstance(item, Secret):
                 logger.warning("Please use connection.secrets[key] to access secrets.")

--- a/src/promptflow/promptflow/_sdk/schemas/_connection.py
+++ b/src/promptflow/promptflow/_sdk/schemas/_connection.py
@@ -122,6 +122,8 @@ class CustomStrongTypeConnectionSchema(CustomConnectionSchema):
     name = fields.Str(attribute="name")
     module = fields.Str(required=True)
     custom_type = fields.Str(required=True)
+    package = fields.Str(required=True)
+    package_version = fields.Str(required=True)
 
     # TODO: validate configs and secrets
     @validates("configs")

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -107,13 +107,19 @@ def prepare_symbolic_flow() -> str:
     return target_folder
 
 
-@pytest.fixture
-def is_custom_tool_pkg_installed() -> bool:
+@pytest.fixture()
+def install_custom_tool_pkg():
+    is_installed = False
     try:
         import my_tool_package  # noqa: F401
 
-        pkg_installed = True
-    except ImportError:
-        pkg_installed = False
+        is_installed = True
 
-    return pkg_installed
+    except ImportError:
+        import subprocess
+        import sys
+
+        subprocess.check_call([sys.executable, "-m", "pip", "install", "test-custom-tools==0.0.1"])
+    yield
+    if not is_installed:
+        subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", "test-custom-tools"])

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -109,11 +109,9 @@ def prepare_symbolic_flow() -> str:
 
 @pytest.fixture(scope="session")
 def install_custom_tool_pkg():
-    is_installed = False
+    # Leave the pkg installed since multiple tests rely on it and the tests may run concurrently
     try:
         import my_tool_package  # noqa: F401
-
-        is_installed = True
 
     except ImportError:
         import subprocess
@@ -121,5 +119,3 @@ def install_custom_tool_pkg():
 
         subprocess.check_call([sys.executable, "-m", "pip", "install", "test-custom-tools==0.0.1"])
     yield
-    if not is_installed:
-        subprocess.check_call([sys.executable, "-m", "pip", "uninstall", "-y", "test-custom-tools"])

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -107,7 +107,7 @@ def prepare_symbolic_flow() -> str:
     return target_folder
 
 
-@pytest.fixture()
+@pytest.fixture(scope="session")
 def install_custom_tool_pkg():
     is_installed = False
     try:

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -136,8 +136,7 @@ class TestToolsManager:
             gen_tool_by_source("fake_name", tool_source, tool_type, working_dir),
         assert str(ex.value) == error_message
 
-    @pytest.mark.usefixtures("install_custom_tool_pkg")
-    def test_collect_package_tools_and_connections(self):
+    def test_collect_package_tools_and_connections(self, install_custom_tool_pkg):
         # Need to reload pkg_resources to get the latest installed packages
         import importlib
 

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -136,35 +136,42 @@ class TestToolsManager:
             gen_tool_by_source("fake_name", tool_source, tool_type, working_dir),
         assert str(ex.value) == error_message
 
-    @pytest.mark.skip("test package not installed")
+    @pytest.mark.usefixtures("install_custom_tool_pkg")
     def test_collect_package_tools_and_connections(self):
+        # Need to reload pkg_resources to get the latest installed packages
+        import importlib
+
+        import pkg_resources
+
+        importlib.reload(pkg_resources)
+
         keys = ["my_tool_package.tools.my_tool_2.MyTool.my_tool"]
         tools, specs, templates = collect_package_tools_and_connections(keys)
         assert len(tools) == 1
         assert specs == {
-            "my_tool_package.connections.MySecondConnection": {
+            "my_tool_package.connections.MyFirstConnection": {
                 "connectionCategory": "CustomKeys",
                 "flowValueType": "CustomConnection",
-                "connectionType": "MySecondConnection",
-                "ConnectionTypeDisplayName": "MySecondConnection",
+                "connectionType": "MyFirstConnection",
+                "ConnectionTypeDisplayName": "MyFirstConnection",
                 "configSpecs": [
                     {"name": "api_key", "displayName": "Api Key", "configValueType": "Secret", "isOptional": False},
                     {"name": "api_base", "displayName": "Api Base", "configValueType": "str", "isOptional": True},
                 ],
                 "module": "my_tool_package.connections",
-                "package": "my-tools-package-with-cstc",
-                "package_version": "0.0.6",
+                "package": "test-custom-tools",
+                "package_version": "0.0.1",
             }
         }
         expected_template = {
             "name": "<connection-name>",
             "type": "custom",
-            "custom_type": "MySecondConnection",
+            "custom_type": "MyFirstConnection",
             "module": "my_tool_package.connections",
-            "package": "my-tools-package-with-cstc",
-            "package_version": "0.0.6",
+            "package": "test-custom-tools",
+            "package_version": "0.0.1",
             "configs": {"api_base": "<api-base>"},
             "secrets": {"api_key": "<api-key>"},
         }
-        loaded_yaml = yaml.safe_load(templates["my_tool_package.connections.MySecondConnection"])
+        loaded_yaml = yaml.safe_load(templates["my_tool_package.connections.MyFirstConnection"])
         assert loaded_yaml == expected_template

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_cli_with_azure.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_cli_with_azure.py
@@ -56,6 +56,24 @@ class TestCliWithAzure:
         run = pf.runs.get(run=name)
         assert isinstance(run, Run)
 
+    @pytest.mark.skip("Custom tool pkg and promptprompt pkg with CustomStrongTypeConnection not installed on runtime.")
+    def test_basic_flow_run_with_custom_strong_type_connection(self, pf, runtime) -> None:
+        name = str(uuid.uuid4())
+        run_pf_command(
+            "run",
+            "create",
+            "--flow",
+            f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow",
+            "--data",
+            f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow/data.jsonl",
+            "--name",
+            name,
+            pf=pf,
+            runtime=runtime,
+        )
+        run = pf.runs.get(run=name)
+        assert isinstance(run, Run)
+
     def test_run_with_remote_data(self, pf, runtime, remote_web_classification_data, temp_output_dir: str):
         # run with arm id
         name = str(uuid.uuid4())

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1025,7 +1025,9 @@ class TestCli:
             ),
         ],
     )
-    def test_connection_create_update(self, file_name, expected, update_item, capfd, local_client):
+    def test_connection_create_update(
+        self, install_custom_tool_pkg, file_name, expected, update_item, capfd, local_client
+    ):
         name = f"Connection_{str(uuid.uuid4())[:4]}"
         run_pf_command("connection", "create", "--file", f"{CONNECTIONS_DIR}/{file_name}", "--name", f"{name}")
         out, err = capfd.readouterr()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1007,20 +1007,22 @@ class TestCli:
                 },
                 ("configs.key1", "new_value"),
             ),
-            # (
-            #     "custom_strong_type_connection.yaml",
-            #     {
-            #         "module": "promptflow.connections",
-            #         "type": "custom",
-            #         "configs": {
-            #             "api_base": "This is my first connection.",
-            #             "promptflow.connection.custom_type": "MyFirstConnection",
-            #             "promptflow.connection.module": "my_tool_package.connections",
-            #         },
-            #         "secrets": {"api_key": SCRUBBED_VALUE},
-            #     },
-            #     ("configs.api_base", "new_value"),
-            # ),
+            (
+                "custom_strong_type_connection.yaml",
+                {
+                    "module": "promptflow.connections",
+                    "type": "custom",
+                    "configs": {
+                        "api_base": "This is my first connection.",
+                        "promptflow.connection.custom_type": "MyFirstConnection",
+                        "promptflow.connection.module": "my_tool_package.connections",
+                        "promptflow.connection.package": "test-custom-tools",
+                        "promptflow.connection.package_version": "0.0.1",
+                    },
+                    "secrets": {"api_key": SCRUBBED_VALUE},
+                },
+                ("configs.api_base", "new_value"),
+            ),
         ],
     )
     def test_connection_create_update(self, file_name, expected, update_item, capfd, local_client):

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -45,7 +45,7 @@ def run_pf_command(*args, cwd=None):
         os.chdir(origin_cwd)
 
 
-@pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection")
+@pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection", "install_custom_tool_pkg")
 @pytest.mark.cli_test
 @pytest.mark.e2etest
 class TestCli:

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
@@ -124,14 +124,15 @@ class TestCustomStrongTypeConnection:
             _client.connections.create_or_update(result)
         assert "secrets ['api_key'] value invalid, please fill them" in str(e.value)
 
-    @pytest.mark.usefixtures("install_custom_tool_pkg")
     @pytest.mark.parametrize(
         "file_name, expected_updated_item, expected_secret_item",
         [
             ("custom_strong_type_connection.yaml", ("api_base", "new_value"), ("api_key", "<to-be-replaced>")),
         ],
     )
-    def test_upsert_connection_from_file(self, file_name, expected_updated_item, expected_secret_item):
+    def test_upsert_connection_from_file(
+        self, install_custom_tool_pkg, file_name, expected_updated_item, expected_secret_item
+    ):
         from promptflow._cli._pf._connection import _upsert_connection_from_file
 
         name = f"Connection_{str(uuid.uuid4())[:4]}"

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
@@ -124,7 +124,7 @@ class TestCustomStrongTypeConnection:
             _client.connections.create_or_update(result)
         assert "secrets ['api_key'] value invalid, please fill them" in str(e.value)
 
-    @pytest.mark.skip("test package not installed")
+    @pytest.mark.usefixtures("install_custom_tool_pkg")
     @pytest.mark.parametrize(
         "file_name, expected_updated_item, expected_secret_item",
         [

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -50,7 +50,7 @@ def create_run_against_run(client, run: Run) -> Run:
     )
 
 
-@pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection")
+@pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection", "install_custom_tool_pkg")
 @pytest.mark.sdk_test
 @pytest.mark.e2etest
 class TestFlowRun:

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -247,8 +247,7 @@ class TestFlowRun:
             )
         assert "Connection with name new_connection not found" in str(e.value)
 
-    @pytest.mark.usefixtures("install_custom_tool_pkg")
-    def test_custom_strong_type_connection_basic_flow(self, local_client, pf):
+    def test_custom_strong_type_connection_basic_flow(self, install_custom_tool_pkg, local_client, pf):
         result = pf.run(
             flow=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow",
             data=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow/data.jsonl",

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -247,17 +247,15 @@ class TestFlowRun:
             )
         assert "Connection with name new_connection not found" in str(e.value)
 
-    def test_custom_strong_type_connection_basic_flow(self, local_client, pf, is_custom_tool_pkg_installed):
-        if is_custom_tool_pkg_installed:
-            result = pf.run(
-                flow=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow",
-                data=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow/data.jsonl",
-                connections={"My_First_Tool_00f8": {"connection": "custom_strong_type_connection"}},
-            )
-            run = local_client.runs.get(name=result.name)
-            assert run.status == "Completed"
-        else:
-            pytest.skip("Custom tool package 'my_tools_package_with_cstc' not installed.")
+    @pytest.mark.usefixtures("install_custom_tool_pkg")
+    def test_custom_strong_type_connection_basic_flow(self, local_client, pf):
+        result = pf.run(
+            flow=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow",
+            data=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow/data.jsonl",
+            connections={"My_First_Tool_00f8": {"connection": "custom_strong_type_connection"}},
+        )
+        run = local_client.runs.get(name=result.name)
+        assert run.status == "Completed"
 
     def test_run_with_connection_overwrite_non_exist(self, local_client, local_aoai_connection, pf):
         # overwrite non_exist connection

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -33,15 +33,18 @@ class TestFlowTest:
         result = _client.test(flow=f"{FLOWS_DIR}/web_classification")
         assert all([key in FLOW_RESULT_KEYS for key in result])
 
-    def test_pf_test_flow_with_custom_strong_type_connection(self, is_custom_tool_pkg_installed):
-        if is_custom_tool_pkg_installed:
-            inputs = {"text": "Hello World!"}
-            flow_path = Path(f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow").absolute()
+    @pytest.mark.usefixtures("install_custom_tool_pkg")
+    def test_pf_test_flow_with_custom_strong_type_connection(self):
+        inputs = {"text": "Hello World!"}
+        flow_path = Path(f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow").absolute()
 
-            result = _client.test(flow=flow_path, inputs=inputs)
-            assert result == {"out": "connection_value is MyFirstConnection: True"}
-        else:
-            pytest.skip("Custom tool package 'my_tools_package_with_cstc' not installed.")
+        # Test that connection would be custom strong type in flow
+        result = _client.test(flow=flow_path, inputs=inputs)
+        assert result == {"out": "connection_value is MyFirstConnection: True"}
+
+        # Test that connection
+        result = _client.test(flow=flow_path, inputs=inputs, node="My_Second_Tool_usi3")
+        assert result == "Hello World!This is my first custom connection."
 
     def test_pf_test_with_streaming_output(self):
         flow_path = Path(f"{FLOWS_DIR}/chat_flow_with_stream_output")

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -19,7 +19,7 @@ FLOW_RESULT_KEYS = ["category", "evidence"]
 _client = PFClient()
 
 
-@pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection")
+@pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection", "install_custom_tool_pkg")
 @pytest.mark.sdk_test
 @pytest.mark.e2etest
 class TestFlowTest:

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -33,8 +33,7 @@ class TestFlowTest:
         result = _client.test(flow=f"{FLOWS_DIR}/web_classification")
         assert all([key in FLOW_RESULT_KEYS for key in result])
 
-    @pytest.mark.usefixtures("install_custom_tool_pkg")
-    def test_pf_test_flow_with_custom_strong_type_connection(self):
+    def test_pf_test_flow_with_custom_strong_type_connection(self, install_custom_tool_pkg):
         inputs = {"text": "Hello World!"}
         flow_path = Path(f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow").absolute()
 

--- a/src/promptflow/tests/test_configs/connections/custom_strong_type_connection.yaml
+++ b/src/promptflow/tests/test_configs/connections/custom_strong_type_connection.yaml
@@ -2,6 +2,8 @@ name: my_custom_strong_type_connection
 type: custom
 custom_type: MyFirstConnection
 module: my_tool_package.connections
+package: test-custom-tools
+package_version: 0.0.1
 configs:
   api_base: "This is my first connection."
 secrets:  # must-have

--- a/src/promptflow/tests/test_configs/connections/update_custom_strong_type_connection.yaml
+++ b/src/promptflow/tests/test_configs/connections/update_custom_strong_type_connection.yaml
@@ -2,6 +2,8 @@ name: my_custom_strong_type_connection
 type: custom
 custom_type: MyFirstConnection
 module: my_tool_package.connections
+package: test-custom-tools
+package_version: 0.0.1
 configs:
   api_base: "new_value"
 secrets:  # must-have

--- a/src/promptflow/tests/test_configs/flows/custom_strong_type_connection_basic_flow/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/custom_strong_type_connection_basic_flow/flow.dag.yaml
@@ -1,16 +1,29 @@
+id: template_standard_flow
+name: Template Standard Flow
+environment:
+  python_requirements_txt: requirements.txt
 inputs:
   text:
     type: string
+    default: Hello!
 outputs:
   out:
     type: string
     reference: ${My_First_Tool_00f8.output}
 nodes:
+- name: My_Second_Tool_usi3
+  type: python
+  source:
+    type: package
+    tool: my_tool_package.tools.my_tool_2.MyTool.my_tool
+  inputs:
+    connection: custom_strong_type_connection
+    input_text: ${inputs.text}
 - name: My_First_Tool_00f8
   type: python
   source:
     type: package
     tool: my_tool_package.tools.my_tool_1.my_tool
   inputs:
-    connection: my_custom_strong_type_connection
-    input_text: ${inputs.text}
+    connection: custom_strong_type_connection
+    input_text: ${My_Second_Tool_usi3.output}

--- a/src/promptflow/tests/test_configs/flows/custom_strong_type_connection_basic_flow/requirements.txt
+++ b/src/promptflow/tests/test_configs/flows/custom_strong_type_connection_basic_flow/requirements.txt
@@ -1,0 +1,1 @@
+test-custom-tools==0.0.1


### PR DESCRIPTION
# Description

This PR does the following things:
1. Enable test for custom strong type connection, including connection CRUD, basic flow test&run.
2. Store package and package version of the connection module in order for the local vs code extension to show package info for each created connection.
3. Support user script to use their custom connection configs like **connection.key**
4. Provide refresh_connections_dir in order for the vs code extension to generate and refresh the connections directory, so that ui can show the supported types in current env
