### PR TITLE
Support gen tool meta for package tool with custom strong type connection

### DIFF
--- a/scripts/tool/utils/tool_utils.py
+++ b/scripts/tool/utils/tool_utils.py
@@ -30,7 +30,7 @@ def resolve_annotation(anno) -> Union[str, list]:
 def param_to_definition(param, value_type) -> (InputDefinition, bool):
     default_value = param.default
     enum = None
-    custom_typ = None
+    custom_type = None
     # Get value type and enum from default if no annotation
     if default_value is not inspect.Parameter.empty and value_type == inspect.Parameter.empty:
         value_type = default_value.__class__ if isinstance(default_value, Enum) else type(default_value)
@@ -42,7 +42,7 @@ def param_to_definition(param, value_type) -> (InputDefinition, bool):
     if ConnectionType.is_connection_value(value_type):
         if ConnectionType.is_custom_strong_type(value_type):
             typ = ["CustomConnection"]
-            custom_typ = [value_type.__name__]
+            custom_type = [value_type.__name__]
         else:
             typ = [value_type.__name__]
         is_connection = True
@@ -52,20 +52,20 @@ def param_to_definition(param, value_type) -> (InputDefinition, bool):
         else:
             custom_connection_added = False
             typ = []
-            custom_typ = []
+            custom_type = []
             for t in value_type:
                 if ConnectionType.is_custom_strong_type(t):
                     if not custom_connection_added:
                         custom_connection_added = True
                         typ.append("CustomConnection")
-                    custom_typ.append(t.__name__)
+                    custom_type.append(t.__name__)
                 else:
                     typ.append(t.__name__)
             is_connection = True
     else:
         typ = [ValueType.from_type(value_type)]
     return InputDefinition(type=typ, default=value_to_str(default_value),
-                           description=None, enum=enum, custom_type=custom_typ), is_connection
+                           description=None, enum=enum, custom_type=custom_type), is_connection
 
 
 def function_to_interface(f: Callable, tool_type, initialize_inputs=None) -> tuple:

--- a/scripts/tool/utils/tool_utils.py
+++ b/scripts/tool/utils/tool_utils.py
@@ -30,6 +30,7 @@ def resolve_annotation(anno) -> Union[str, list]:
 def param_to_definition(param, value_type) -> (InputDefinition, bool):
     default_value = param.default
     enum = None
+    custom_typ = None
     # Get value type and enum from default if no annotation
     if default_value is not inspect.Parameter.empty and value_type == inspect.Parameter.empty:
         value_type = default_value.__class__ if isinstance(default_value, Enum) else type(default_value)
@@ -39,17 +40,32 @@ def param_to_definition(param, value_type) -> (InputDefinition, bool):
         value_type = str
     is_connection = False
     if ConnectionType.is_connection_value(value_type):
-        typ = [value_type.__name__]
+        if ConnectionType.is_custom_strong_type(value_type):
+            typ = ["CustomConnection"]
+            custom_typ = [value_type.__name__]
+        else:
+            typ = [value_type.__name__]
         is_connection = True
     elif isinstance(value_type, list):
         if not all(ConnectionType.is_connection_value(t) for t in value_type):
             typ = [ValueType.OBJECT]
         else:
-            typ = [t.__name__ for t in value_type]
+            custom_connection_added = False
+            typ = []
+            custom_typ = []
+            for t in value_type:
+                if ConnectionType.is_custom_strong_type(t):
+                    if not custom_connection_added:
+                        custom_connection_added = True
+                        typ.append("CustomConnection")
+                    custom_typ.append(t.__name__)
+                else:
+                    typ.append(t.__name__)
             is_connection = True
     else:
         typ = [ValueType.from_type(value_type)]
-    return InputDefinition(type=typ, default=value_to_str(default_value), description=None, enum=enum), is_connection
+    return InputDefinition(type=typ, default=value_to_str(default_value),
+                           description=None, enum=enum, custom_type=custom_typ), is_connection
 
 
 def function_to_interface(f: Callable, tool_type, initialize_inputs=None) -> tuple:

--- a/src/promptflow/promptflow/contracts/tool.py
+++ b/src/promptflow/promptflow/contracts/tool.py
@@ -216,6 +216,7 @@ class InputDefinition:
     default: str = None
     description: str = None
     enum: List[str] = None
+    custom_type: List[str] = None
 
     def serialize(self) -> dict:
         """Serialize input definition to dict.
@@ -234,6 +235,8 @@ class InputDefinition:
             data["description"] = self.description
         if self.enum:
             data["enum"] = self.enum
+        if self.custom_type:
+            data["custom_type"] = self.custom_type
         return data
 
     @staticmethod


### PR DESCRIPTION
# Description

Support generate tool meta yaml for custom package tool with custom strong type connection.

Tool yaml is used to generate flow.tools.json for package tools. And both portal and local uses the meta in flow.tools.json to display the node interface. For portal, the node input type should be CustomConnection. While for local extension, the node input type should display as custom strong type connection. So we add a another field "custom_type" for local extension to display (if no custom_type found, read "type" field), and portal would still read the "type" field.

Test cases:
1. Tool uses custom strong type connection:
    tool:
    ```python
    from promptflow import ToolProvider, tool
    from my_tool_package.connections import MyFirstConnection
    
    
    class MyTool(ToolProvider):
        """
        Doc reference :
        """
    
        def __init__(self, connection: MyFirstConnection):
            super().__init__()
            self.connection = connection
    
        @tool
        def my_tool2(self, input_text: str) -> str:
            # Replace with your tool code.
            # Usually connection contains configs to connect to an API.
            # Not all tools need a connection. You can remove it if you don't need it.
            return input_text + self.connection.api_base

    ```
    yaml:
    ```
    my_tool_package.tools.my_tool_2.MyTool.my_tool:
      class_name: MyTool
      function: my_tool
      inputs:
        connection:
          custom_type:
          - MyFirstConnection
          type:
          - CustomConnection
        input_text:
          type:
          - string
      module: my_tool_package.tools.my_tool_2
      name: MyTool.my_tool
      type: python

    ```
2. Tool has custom strong type connection union as input:
    tool:
    ```python
    from promptflow import tool
    from my_tool_package.connections import MyFirstConnection, MySecondConnection
    from typing import Union
    
    
    @tool
    def my_tool(connection: Union[MyFirstConnection, MySecondConnection], input_text: str) -> str:
        # Replace with your tool code.
        # Usually connection contains configs to connect to an API.
        # Not all tools need a connection. You can remove it if you don't need it.
        return f"connection_value is MyFirstConnection: {str(isinstance(connection, MyFirstConnection))}"

    ```
    yaml:
    ```
    my_tool_package.tools.my_tool_1.my_tool:
      function: my_tool
      inputs:
        connection:
          custom_type:
          - MyFirstConnection
          - MySecondConnection
          type:
          - CustomConnection
        input_text:
          type:
          - string
      module: my_tool_package.tools.my_tool_1
      name: my_tool
      type: python

    ```
3. Tool uses orignal builtin CustomConnection:
    tool:
    ```python
    from promptflow import tool
    from promptflow.connections import CustomConnection
    
    
    @tool
    def my_tool3(connection: CustomConnection, input_text: str) -> str:
        # Replace with your tool code.
        # Usually connection contains configs to connect to an API.
        # Not all tools need a connection. You can remove it if you don't need it.
        return f"{input_text} {connection.api_base}"

    ```
    yaml:
    ```
    my_tool_package.tools.my_tool_3.my_tool3:
      function: my_tool3
      inputs:
        connection:
          type:
          - CustomConnection
        input_text:
          type:
          - string
      module: my_tool_package.tools.my_tool_3
      name: my_tool3
      type: python

    ```