### PR TITLE
Update Run Info Inputs once input resolved in bulk run

### DIFF
--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -863,6 +863,8 @@ class FlowExecutor:
         try:
             if validate_inputs:
                 inputs = FlowValidator.ensure_flow_inputs_type(flow=self._flow, inputs=inputs, idx=line_number)
+                # Make sure the run_info with converted inputs results rather than original inputs
+                run_info.inputs = inputs
             output, nodes_outputs = self._traverse_nodes(inputs, context)
             output = self._stringify_generator_output(output) if not allow_generator_output else output
             run_tracker.allow_generator_types = allow_generator_output

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -372,3 +372,20 @@ class TestExecutor:
         # Assert for exec
         exec_result = executor.exec({})
         assert exec_result["output"] == default_input_value
+
+    @pytest.mark.parametrize(
+        "flow_folder, batch_input, expected_type, validate_inputs",
+        [
+            ("simple_aggregation", [{"text": 4}], str, True),
+            ("simple_aggregation", [{"text": 4.5}], str, True),
+            ("simple_aggregation", [{"text": "3.0"}], str, True),
+            ("simple_aggregation", [{"text": 4}], int, False),
+        ],
+    )
+    def test_bulk_run_line_result(self, flow_folder, batch_input, expected_type, validate_inputs, dev_connections):
+        executor = FlowExecutor.create(get_yaml_file(flow_folder), dev_connections)
+        bulk_result = executor.exec_bulk(
+            batch_input,
+            validate_inputs=validate_inputs,
+        )
+        assert type(bulk_result.line_results[0].run_info.inputs["text"]) is expected_type


### PR DESCRIPTION
# Description

In bulk run, if validate_input enabled, the input would be converted based on flow input type. We need to update run info as well to make sure the UI would correctly populate right-typed value

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
