### PR TITLE
Make error message format more robust.

### DIFF
--- a/src/promptflow/promptflow/exceptions.py
+++ b/src/promptflow/promptflow/exceptions.py
@@ -79,9 +79,9 @@ class PromptflowException(Exception):
         parameters = {}
         for argument in required_arguments:
             if argument not in self._kwargs:
-                # Set one default value for the missing argument to avoid KeyError.
+                # Set a default value for the missing argument to avoid KeyError.
                 # For long term solution, use CI to guarantee the message_format and message_parameters are in sync.
-                parameters[argument] = "N/A"
+                parameters[argument] = f"<{argument}>"
             else:
                 parameters[argument] = self._kwargs[argument]
         return parameters

--- a/src/promptflow/promptflow/exceptions.py
+++ b/src/promptflow/promptflow/exceptions.py
@@ -75,8 +75,16 @@ class PromptflowException(Exception):
         if not self._kwargs:
             return {}
 
-        arguments = self.get_arguments_from_message_format(self.message_format)
-        return {k: v for k, v in self._kwargs.items() if k in arguments}
+        required_arguments = self.get_arguments_from_message_format(self.message_format)
+        parameters = {}
+        for argument in required_arguments:
+            if argument not in self._kwargs:
+                # Set one default value for the missing argument to avoid KeyError.
+                # For long term solution, use CI to guarantee the message_format and message_parameters are in sync.
+                parameters[argument] = "N/A"
+            else:
+                parameters[argument] = self._kwargs[argument]
+        return parameters
 
     @cached_property
     def serializable_message_parameters(self):

--- a/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
@@ -1,0 +1,14 @@
+import pytest
+
+from promptflow.exceptions import PromptflowException
+
+
+@pytest.mark.unittest
+class TestExceptions:
+    def test_exception_message(self):
+        ex = PromptflowException(
+            message_format="Test exception message with parameters: {param}, {param1}.",
+            param="test_param",
+        )
+
+        assert ex.message == "Test exception message with parameters: test_param, N/A."

--- a/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_exceptions.py
@@ -11,4 +11,4 @@ class TestExceptions:
             param="test_param",
         )
 
-        assert ex.message == "Test exception message with parameters: test_param, N/A."
+        assert ex.message == "Test exception message with parameters: test_param, <param1>."


### PR DESCRIPTION
# Description

If we set parameter does not align with `message_format`, show <Param> to customer. For now, we will throw KeyError, which is one bad experience for customer.

For example:
```
ex = PromptflowException(
        message_format="Test exception message with parameters: {param}, {param1}.",
        param="test_param",
)
```
Will raise KeyError for ex.message, since we don't have `param1`.

After this PR, ex.message = "Test exception message with parameters: test_param, <param>."
# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
