### PR TITLE
Fix testing matrix to remove python 3 12

### DIFF
--- a/.github/workflows/promptflow-release-testing-matrix.yml
+++ b/.github/workflows/promptflow-release-testing-matrix.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         testType: [sdk-cli, executor]
-        pythonVersion: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        pythonVersion: ['3.8', '3.9', '3.10', '3.11', '3.12.0-rc.3']
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout

--- a/.github/workflows/promptflow-release-testing-matrix.yml
+++ b/.github/workflows/promptflow-release-testing-matrix.yml
@@ -39,8 +39,8 @@ jobs:
       run: 
         env | sort >> $GITHUB_OUTPUT
       shell: bash -el {0}
-    - name: Conda Setup - ${{ matrix.os }} - Python Version ${{ matrix.pythonVersion }}
-      uses: "./.github/actions/step_create_conda_environment"
+    - name: Python Env Setup - ${{ matrix.os }} - Python Version ${{ matrix.pythonVersion }}
+      uses: "./.github/actions/step_create_python_environment"
       with:
         pythonVersion: ${{ matrix.pythonVersion }}
     - name: Build wheel

--- a/.github/workflows/promptflow-release-testing-matrix.yml
+++ b/.github/workflows/promptflow-release-testing-matrix.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         testType: [sdk-cli, executor]
-        pythonVersion: ['3.8', '3.9', '3.10', '3.11', '3.12.0-rc.3']
+        pythonVersion: ['3.8', '3.9', '3.10', '3.11']
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
@@ -66,7 +66,6 @@ jobs:
       run: |
         gci env:* | sort-object name
         az account show
-        conda activate release-env
         python "../../scripts/building/run_coverage_tests.py" `
           -p promptflow `
           -t ${{ github.workspace }}/src/promptflow/tests/sdk_cli_azure_test ${{ github.workspace }}/src/promptflow/tests/sdk_cli_test `
@@ -81,7 +80,6 @@ jobs:
       run: |
         gci env:* | sort-object name
         az account show
-        conda activate release-env
         pip install langchain
         python scripts/building/run_coverage_tests.py `
           -p ${{ github.workspace }}/src/promptflow/promptflow `


### PR DESCRIPTION
# Description

3.12 is too pre-release, some tools like pytest-mock doesn't support pre-release version of python.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
