### PR TITLE
Resolve input type for exec_aggreation.

### DIFF
--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -560,8 +560,14 @@ class FlowExecutor:
             self._flow.inputs, aggregated_flow_inputs, aggregation_inputs
         )
 
+        # Resolve the type of aggregated_flow_inputs
+        # TODO: For now, we resolve type for batch run's aggregation input in _exec_aggregation_with_bulk_results.
+        # If we decide to merge the resolve logic into one place, remember to take care of index for batch run.
+        resolved_aggregated_flow_inputs = FlowValidator.resolve_aggregated_flow_inputs_type(
+            self._flow, aggregated_flow_inputs
+        )
         with self._run_tracker.node_log_manager:
-            return self._exec_aggregation(aggregated_flow_inputs, aggregation_inputs, run_id)
+            return self._exec_aggregation(resolved_aggregated_flow_inputs, aggregation_inputs, run_id)
 
     @staticmethod
     def _apply_default_value_for_aggregation_input(

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -560,7 +560,7 @@ class FlowExecutor:
             self._flow.inputs, aggregated_flow_inputs, aggregation_inputs
         )
 
-        # Resolve the type of aggregated_flow_inputs
+        # Resolve aggregated_flow_inputs from list of strings to list of objects, whose type is specified in yaml file.
         # TODO: For now, we resolve type for batch run's aggregation input in _exec_aggregation_with_bulk_results.
         # If we decide to merge the resolve logic into one place, remember to take care of index for batch run.
         resolved_aggregated_flow_inputs = FlowValidator.resolve_aggregated_flow_inputs_type(

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -153,7 +153,7 @@ class FlowValidator:
         return FlowValidator._ensure_nodes_order(flow)
 
     @staticmethod
-    def _convert_input_by_type(input_key: str, input_value: Any, expected_type: ValueType, idx=None):
+    def _parse_input_value(input_key: str, input_value: Any, expected_type: ValueType, idx=None):
         try:
             return expected_type.parse(input_value)
         except JSONDecodeError as e:
@@ -193,7 +193,7 @@ class FlowValidator:
             if input_key in inputs:
                 input_value_list = inputs[input_key]
                 updated_inputs[input_key] = [
-                    FlowValidator._convert_input_by_type(input_key, each_line_item, input_def.type, idx)
+                    FlowValidator._parse_input_value(input_key, each_line_item, input_def.type, idx)
                     for idx, each_line_item in enumerate(input_value_list)
                 ]
         return updated_inputs
@@ -217,7 +217,7 @@ class FlowValidator:
         updated_inputs = {k: v for k, v in inputs.items()}
         for k, v in flow.inputs.items():
             if k in inputs:
-                updated_inputs[k] = FlowValidator._convert_input_by_type(k, inputs[k], v.type, idx)
+                updated_inputs[k] = FlowValidator._parse_input_value(k, inputs[k], v.type, idx)
         return updated_inputs
 
     @staticmethod

--- a/src/promptflow/promptflow/executor/flow_validator.py
+++ b/src/promptflow/promptflow/executor/flow_validator.py
@@ -4,10 +4,11 @@
 
 import copy
 from json import JSONDecodeError
-from typing import Any, Mapping, Optional
+from typing import Any, List, Mapping, Optional
 
 from promptflow._utils.logger_utils import logger
 from promptflow.contracts.flow import Flow, InputValueType, Node
+from promptflow.contracts.tool import ValueType
 from promptflow.executor._errors import (
     DuplicateNodeName,
     EmptyOutputReference,
@@ -152,6 +153,52 @@ class FlowValidator:
         return FlowValidator._ensure_nodes_order(flow)
 
     @staticmethod
+    def _convert_input_by_type(input_key: str, input_value: Any, expected_type: ValueType, idx=None):
+        try:
+            return expected_type.parse(input_value)
+        except JSONDecodeError as e:
+            line_info = "" if idx is None else f" in line {idx} of input data"
+            flow_input_info = f"'{input_key}'{line_info}"
+            error_type_and_message = f"({e.__class__.__name__}) {e}"
+
+            msg_format = (
+                "Failed to parse the flow input. The value for flow input {flow_input_info} "
+                "was interpreted as JSON string since its type is '{value_type}'. However, the value "
+                "'{input_value}' is invalid for JSON parsing. Error details: {error_type_and_message}. "
+                "Please make sure your inputs are properly formatted."
+            )
+            raise InputParseError(
+                message_format=msg_format,
+                flow_input_info=flow_input_info,
+                input_value=input_value,
+                value_type=expected_type,
+                error_type_and_message=error_type_and_message,
+            ) from e
+        except Exception as e:
+            line_info = "" if idx is None else f" in line {idx} of input data"
+            flow_input_info = f"'{input_key}'{line_info}"
+            msg_format = (
+                "The input for flow is incorrect. The value for flow input {flow_input_info} "
+                "does not match the expected type '{expected_type}'. Please change flow input type "
+                "or adjust the input value in your input data."
+            )
+            raise InputTypeError(
+                message_format=msg_format, flow_input_info=flow_input_info, expected_type=expected_type
+            ) from e
+
+    @staticmethod
+    def resolve_aggregated_flow_inputs_type(flow: Flow, inputs: Mapping[str, List[Any]]) -> Mapping[str, Any]:
+        updated_inputs = {}
+        for input_key, input_def in flow.inputs.items():
+            if input_key in inputs:
+                input_value_list = inputs[input_key]
+                updated_inputs[input_key] = [
+                    FlowValidator._convert_input_by_type(input_key, each_line_item, input_def.type, idx)
+                    for idx, each_line_item in enumerate(input_value_list)
+                ]
+        return updated_inputs
+
+    @staticmethod
     def resolve_flow_inputs_type(flow: Flow, inputs: Mapping[str, Any], idx: Optional[int] = None) -> Mapping[str, Any]:
         """Resolve inputs by type if existing. Ignore missing inputs.
 
@@ -169,38 +216,8 @@ class FlowValidator:
         """
         updated_inputs = {k: v for k, v in inputs.items()}
         for k, v in flow.inputs.items():
-            try:
-                if k in inputs:
-                    updated_inputs[k] = v.type.parse(inputs[k])
-            except JSONDecodeError as e:
-                line_info = "" if idx is None else f" in line {idx} of input data"
-                flow_input_info = f"'{k}'{line_info}"
-                error_type_and_message = f"({e.__class__.__name__}) {e}"
-
-                msg_format = (
-                    "Failed to parse the flow input. The value for flow input {flow_input_info} "
-                    "was interpreted as JSON string since its type is '{value_type}'. However, the value "
-                    "'{input_value}' is invalid for JSON parsing. Error details: {error_type_and_message}. "
-                    "Please make sure your inputs are properly formatted."
-                )
-                raise InputParseError(
-                    message_format=msg_format,
-                    flow_input_info=flow_input_info,
-                    input_value=inputs[k],
-                    value_type=v.type,
-                    error_type_and_message=error_type_and_message,
-                ) from e
-            except Exception as e:
-                line_info = "" if idx is None else f" in line {idx} of input data"
-                flow_input_info = f"'{k}'{line_info}"
-                msg_format = (
-                    "The input for flow is incorrect. The value for flow input {flow_input_info} "
-                    "does not match the expected type '{expected_type}'. Please change flow input type "
-                    "or adjust the input value in your input data."
-                )
-                raise InputTypeError(
-                    message_format=msg_format, flow_input_info=flow_input_info, expected_type=v.type
-                ) from e
+            if k in inputs:
+                updated_inputs[k] = FlowValidator._convert_input_by_type(k, inputs[k], v.type, idx)
         return updated_inputs
 
     @staticmethod


### PR DESCRIPTION
# Description
Resolve type for exec_aggreation's flow inputs.
**Before:**
Aggregation node's flow input is a list of strings.
(Didn't honor the definition in yaml file)
For example: the below flow input will be string "123", but not int 123 when default value is used.
![image](https://github.com/microsoft/promptflow/assets/17527303/b4359f3c-b1d1-496c-a6b0-f24655a8cc81)

**After:**
Aggregation node's flow input is a list of objects, whose type is specified in yaml file.


Extract `_convert_input_by_type` to convert each item, then we could reuse the error message.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
