### PR TITLE
Add lock to prevent concurrency issue when refreshing connections dir and enable custom strong type connection tests

### DIFF
--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -37,6 +37,7 @@ FILE_PREFIX = "file:"
 KEYRING_SYSTEM = "promptflow"
 KEYRING_ENCRYPTION_KEY_NAME = "encryption_key"
 KEYRING_ENCRYPTION_LOCK_PATH = (HOME_PROMPT_FLOW_DIR / "encryption_key.lock").resolve()
+REFRESH_CONNECTIONS_DIR_LOCK_PATH = (HOME_PROMPT_FLOW_DIR / "refresh_connections_dir.lock").resolve()
 # Note: Use this only for show. Reading input should regard all '*' string as scrubbed, no matter the length.
 SCRUBBED_VALUE = "******"
 SCRUBBED_VALUE_NO_CHANGE = "<no-change>"

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -45,6 +45,7 @@ from promptflow._sdk._constants import (
     NODE_VARIANTS,
     NODES,
     PROMPT_FLOW_DIR_NAME,
+    REFRESH_CONNECTIONS_DIR_LOCK_PATH,
     USE_VARIANTS,
     VARIANTS,
     CommonYamlFields,
@@ -788,21 +789,27 @@ def _generate_connections_dir():
     return connections_dir
 
 
+_refresh_connection_dir_lock = FileLock(REFRESH_CONNECTIONS_DIR_LOCK_PATH)
+
+
 # This function is used by extension to generate the connection files every time collect tools.
 def refresh_connections_dir(connection_spec_files, connection_template_yamls):
     connections_dir = _generate_connections_dir()
-    if os.path.isdir(connections_dir):
-        shutil.rmtree(connections_dir)
-    os.makedirs(connections_dir)
 
-    if connection_spec_files and connection_template_yamls:
-        for connection_name, content in connection_spec_files.items():
-            file_name = connection_name + ".spec.json"
-            with open(connections_dir / file_name, "w") as f:
-                json.dump(content, f, indent=2)
+    # Use lock to prevent concurrent access
+    with _refresh_connection_dir_lock:
+        if os.path.isdir(connections_dir):
+            shutil.rmtree(connections_dir)
+        os.makedirs(connections_dir)
 
-        for connection_name, content in connection_template_yamls.items():
-            yaml_data = yaml.safe_load(content)
-            file_name = connection_name + ".template.yaml"
-            with open(connections_dir / file_name, "w") as f:
-                yaml.dump(yaml_data, f, sort_keys=False)
+        if connection_spec_files and connection_template_yamls:
+            for connection_name, content in connection_spec_files.items():
+                file_name = connection_name + ".spec.json"
+                with open(connections_dir / file_name, "w") as f:
+                    json.dump(content, f, indent=2)
+
+            for connection_name, content in connection_template_yamls.items():
+                yaml_data = yaml.safe_load(content)
+                file_name = connection_name + ".template.yaml"
+                with open(connections_dir / file_name, "w") as f:
+                    yaml.dump(yaml_data, f, sort_keys=False)

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 from _constants import CONNECTION_FILE, ENV_FILE
 from _pytest.monkeypatch import MonkeyPatch
+from filelock import FileLock
 from pytest_mock import MockerFixture
 
 from promptflow._constants import PROMPTFLOW_CONNECTIONS
@@ -109,13 +110,20 @@ def prepare_symbolic_flow() -> str:
 
 @pytest.fixture(scope="session")
 def install_custom_tool_pkg():
-    # Leave the pkg installed since multiple tests rely on it and the tests may run concurrently
-    try:
-        import my_tool_package  # noqa: F401
+    # The tests could be running in parallel. Use a lock to prevent race conditions.
+    lock = FileLock("custom_tool_pkg_installation.lock")
+    with lock:
+        try:
+            import my_tool_package  # noqa: F401
 
-    except ImportError:
-        import subprocess
-        import sys
+        except ImportError:
+            import subprocess
+            import sys
 
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "test-custom-tools==0.0.1"])
-    yield
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "test-custom-tools==0.0.1"])
+            # Need to reload pkg_resources to collect the newly installed tools
+            import importlib
+
+            import pkg_resources
+
+            importlib.reload(pkg_resources)

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -121,9 +121,3 @@ def install_custom_tool_pkg():
             import sys
 
             subprocess.check_call([sys.executable, "-m", "pip", "install", "test-custom-tools==0.0.1"])
-            # Need to reload pkg_resources to collect the newly installed tools
-            import importlib
-
-            import pkg_resources
-
-            importlib.reload(pkg_resources)

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -137,13 +137,6 @@ class TestToolsManager:
         assert str(ex.value) == error_message
 
     def test_collect_package_tools_and_connections(self, install_custom_tool_pkg):
-        # Need to reload pkg_resources to get the latest installed packages
-        import importlib
-
-        import pkg_resources
-
-        importlib.reload(pkg_resources)
-
         keys = ["my_tool_package.tools.my_tool_2.MyTool.my_tool"]
         tools, specs, templates = collect_package_tools_and_connections(keys)
         assert len(tools) == 1

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -137,6 +137,13 @@ class TestToolsManager:
         assert str(ex.value) == error_message
 
     def test_collect_package_tools_and_connections(self, install_custom_tool_pkg):
+        # Need to reload pkg_resources to get the latest installed tools
+        import importlib
+
+        import pkg_resources
+
+        importlib.reload(pkg_resources)
+
         keys = ["my_tool_package.tools.my_tool_2.MyTool.my_tool"]
         tools, specs, templates = collect_package_tools_and_connections(keys)
         assert len(tools) == 1

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -136,7 +136,6 @@ class TestToolsManager:
             gen_tool_by_source("fake_name", tool_source, tool_type, working_dir),
         assert str(ex.value) == error_message
 
-    @pytest.mark.skip("TODO: need to fix random pacakge not found error")
     def test_collect_package_tools_and_connections(self, install_custom_tool_pkg):
         # Need to reload pkg_resources to get the latest installed packages
         import importlib

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1021,22 +1021,22 @@ class TestCli:
                 },
                 ("configs.key1", "new_value"),
             ),
-            # (
-            #     "custom_strong_type_connection.yaml",
-            #     {
-            #         "module": "promptflow.connections",
-            #         "type": "custom",
-            #         "configs": {
-            #             "api_base": "This is my first connection.",
-            #             "promptflow.connection.custom_type": "MyFirstConnection",
-            #             "promptflow.connection.module": "my_tool_package.connections",
-            #             "promptflow.connection.package": "test-custom-tools",
-            #             "promptflow.connection.package_version": "0.0.1",
-            #         },
-            #         "secrets": {"api_key": SCRUBBED_VALUE},
-            #     },
-            #     ("configs.api_base", "new_value"),
-            # ),
+            (
+                "custom_strong_type_connection.yaml",
+                {
+                    "module": "promptflow.connections",
+                    "type": "custom",
+                    "configs": {
+                        "api_base": "This is my first connection.",
+                        "promptflow.connection.custom_type": "MyFirstConnection",
+                        "promptflow.connection.module": "my_tool_package.connections",
+                        "promptflow.connection.package": "test-custom-tools",
+                        "promptflow.connection.package_version": "0.0.1",
+                    },
+                    "secrets": {"api_key": SCRUBBED_VALUE},
+                },
+                ("configs.api_base", "new_value"),
+            ),
         ],
     )
     def test_connection_create_update(

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
@@ -136,7 +136,6 @@ class TestCustomStrongTypeConnection:
         assert converted_conn.api_base == "test2"
         assert converted_conn.configs["api_base"] == "test2"
 
-    @pytest.mark.skip("TODO: need to fix random pacakge not found error")
     @pytest.mark.parametrize(
         "file_name, expected_updated_item, expected_secret_item",
         [

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -248,6 +248,13 @@ class TestFlowRun:
         assert "Connection with name new_connection not found" in str(e.value)
 
     def test_custom_strong_type_connection_basic_flow(self, install_custom_tool_pkg, local_client, pf):
+        # Need to reload pkg_resources to get the latest installed tools
+        import importlib
+
+        import pkg_resources
+
+        importlib.reload(pkg_resources)
+
         result = pf.run(
             flow=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow",
             data=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow/data.jsonl",

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -247,7 +247,6 @@ class TestFlowRun:
             )
         assert "Connection with name new_connection not found" in str(e.value)
 
-    @pytest.mark.skip("TODO: need to fix random pacakge not found error")
     def test_custom_strong_type_connection_basic_flow(self, install_custom_tool_pkg, local_client, pf):
         result = pf.run(
             flow=f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow",

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -34,6 +34,13 @@ class TestFlowTest:
         assert all([key in FLOW_RESULT_KEYS for key in result])
 
     def test_pf_test_flow_with_custom_strong_type_connection(self, install_custom_tool_pkg):
+        # Need to reload pkg_resources to get the latest installed tools
+        import importlib
+
+        import pkg_resources
+
+        importlib.reload(pkg_resources)
+
         inputs = {"text": "Hello World!"}
         flow_path = Path(f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow").absolute()
 

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -33,7 +33,6 @@ class TestFlowTest:
         result = _client.test(flow=f"{FLOWS_DIR}/web_classification")
         assert all([key in FLOW_RESULT_KEYS for key in result])
 
-    @pytest.mark.skip("TODO: need to fix random pacakge not found error")
     def test_pf_test_flow_with_custom_strong_type_connection(self, install_custom_tool_pkg):
         inputs = {"text": "Hello World!"}
         flow_path = Path(f"{FLOWS_DIR}/custom_strong_type_connection_basic_flow").absolute()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -42,7 +42,7 @@ class TestFlowTest:
         assert result == {"out": "connection_value is MyFirstConnection: True"}
 
         # Test that connection
-        result = _client.test(flow=flow_path, inputs=inputs, node="My_Second_Tool_usi3")
+        result = _client.test(flow=flow_path, inputs={"input_text": "Hello World!"}, node="My_Second_Tool_usi3")
         assert result == "Hello World!This is my first custom connection."
 
     def test_pf_test_with_streaming_output(self):

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -7,6 +7,7 @@ import os
 import shutil
 import sys
 import tempfile
+import threading
 from pathlib import Path
 from unittest.mock import patch
 
@@ -27,6 +28,7 @@ from promptflow._sdk._utils import (
     decrypt_secret_value,
     encrypt_secret_value,
     generate_flow_tools_json,
+    refresh_connections_dir,
     resolve_connections_environment_variable_reference,
     snake_to_camel,
 )
@@ -130,6 +132,19 @@ class TestUtils:
         with patch.object(sys, "executable", python_path):
             result = _generate_connections_dir()
             assert result == expected_result
+
+    @pytest.mark.parametrize("concurrent_count", [1, 2, 4, 8])
+    def test_concurrent_execution_of_refresh_connections_dir(self, concurrent_count):
+        threads = []
+
+        # Create and start threads
+        for _ in range(concurrent_count):
+            thread = threading.Thread(target=refresh_connections_dir, args={None, None})
+            thread.start()
+            threads.append(thread)
+
+        for thread in threads:
+            thread.join()
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
# Description

This pull request does the following two things:
1. Bugfix. Add lock to prevent concurrency issue when refreshing connections dir.
2. Enable custom strong type connection tests that need custom tool package.

