### PR TITLE
remove pf version pinning and upgrade pf-tools to 0.1.0b8

### DIFF
--- a/src/promptflow-tools/promptflow/version.txt
+++ b/src/promptflow-tools/promptflow/version.txt
@@ -1,1 +1,1 @@
-VERSION = "0.1.0b7"
+VERSION = "0.1.0b8"

--- a/src/promptflow-tools/requirements.txt
+++ b/src/promptflow-tools/requirements.txt
@@ -1,3 +1,2 @@
 google-search-results==2.4.1
-# TODO: remove version pinning. This is a temporary workaround for a bug in the latest version of promptflow
-promptflow==0.1.0b6
+promptflow


### PR DESCRIPTION
remove pinned version of promptflow due to last hotfix and upgrade pf-tool version

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
