### PR TITLE
Test Python 3.12 support

### DIFF
--- a/.github/workflows/promptflow-release-testing-matrix.yml
+++ b/.github/workflows/promptflow-release-testing-matrix.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         testType: [sdk-cli, executor]
-        pythonVersion: ['3.8', '3.9', '3.10', '3.11']
+        pythonVersion: ['3.8', '3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout

--- a/src/promptflow-tools/setup.py
+++ b/src/promptflow-tools/setup.py
@@ -37,6 +37,11 @@ setup(
     author="Microsoft Corporation",
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: Other/Proprietary License",
         "Operating System :: OS Independent",
     ],

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Improvements
 
 - [SDK/CLI] Include flow path & output path in `pf run visualize` page.
+- Added support for Python 3.12.
 
 ## 0.1.0b7.post1 (2023.09.28)
 

--- a/src/promptflow/setup.py
+++ b/src/promptflow/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
# Description

This PR adds the newly released Python 3.12 to the test matrix and updates the package classifiers to declare support. This package has python_requires >=3.8 so technically anyone using 3.12 can install it, but it needs testing :-)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.

Fixes #711 