### PR TITLE
Remove types.GenericAlias check since types.GenericAlias is not supported in python3.8

### DIFF
--- a/src/promptflow/promptflow/contracts/tool.py
+++ b/src/promptflow/promptflow/contracts/tool.py
@@ -4,7 +4,6 @@
 
 import json
 import logging
-import types
 from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, TypeVar
@@ -200,9 +199,6 @@ class ConnectionType:
         from promptflow._sdk.entities import CustomStrongTypeConnection
 
         val = type(val) if not isinstance(val, type) else val
-        # Check for instances of GenericAlias (for parameterized generic types like list[str])
-        if isinstance(val, types.GenericAlias):
-            return False
 
         try:
             return issubclass(val, CustomStrongTypeConnection)


### PR DESCRIPTION
types.GenericAlias is only supported for python>=3.9 
https://docs.python.org/3/library/types.html#types.GenericAlias

![image](https://github.com/microsoft/promptflow/assets/46446115/5b728c8b-2f11-4d2b-bb21-78d89addc346)

