### PR TITLE
[Bugfix][Executor] Use actual start time to calculate execution time

### DIFF
--- a/src/promptflow/promptflow/_utils/utils.py
+++ b/src/promptflow/promptflow/_utils/utils.py
@@ -118,7 +118,7 @@ def count_and_log_progress(
 
 
 def log_progress(
-    start_time: datetime,
+    run_start_time: datetime,
     logger: logging.Logger,
     count: int,
     total_count: int,
@@ -126,7 +126,7 @@ def log_progress(
 ):
     log_interval = max(int(total_count / 10), 1)
     if count > 0 and (count % log_interval == 0 or count == total_count):
-        average_execution_time = round((datetime.now().timestamp() - start_time.timestamp()) / count, 2)
+        average_execution_time = round((datetime.now().timestamp() - run_start_time.timestamp()) / count, 2)
         estimated_execution_time = round(average_execution_time * (total_count - count), 2)
         logger.info(formatter.format(count=count, total_count=total_count))
         logger.info(


### PR DESCRIPTION
# Description

The `start_time` in `_timeout_process_wrapper` is the start time for a line, not for the whole batch run, so we should use actual start time to calculate execution time.
![image](https://github.com/microsoft/promptflow/assets/111329184/11e55325-6bc0-4aff-b568-905a969af87d)


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
