### PR TITLE
fixed typos inside docs/reference

### DIFF
--- a/docs/reference/pf-command-reference.md
+++ b/docs/reference/pf-command-reference.md
@@ -41,13 +41,13 @@ pf flow init [--flow]
 Create a flow folder with code, prompts and YAML specification of the flow.
 
 ```bash
-pf flow init --flow <path-to-flow-direcotry>
+pf flow init --flow <path-to-flow-directory>
 ```
 
 Create an evaluation prompt flow
 
 ```bash
-pf flow init --flow <path-to-flow-direcotry> --type evaluation
+pf flow init --flow <path-to-flow-directory> --type evaluation
 ```
 
 Create a flow in existing folder
@@ -411,7 +411,7 @@ Manage prompt flow runs.
 | [pf run stream](#pf-run-stream) | Stream run logs to the console. |
 | [pf run list](#pf-run-list) | List runs. |
 | [pf run show](#pf-run-show) | Show details for a run. |
-| [pf run show-details](#pf-run-show-details) | Preview a run's intput(s) and output(s). |
+| [pf run show-details](#pf-run-show-details) | Preview a run's input(s) and output(s). |
 | [pf run show-metrics](#pf-run-show-metrics) | Print run metrics to the console. |
 | [pf run visualize](#pf-run-visualize) | Visualize a run. |
 | [pf run archive](#pf-run-archive) | Archive a run. |

--- a/docs/reference/tools-reference/open_source_llm_tool.md
+++ b/docs/reference/tools-reference/open_source_llm_tool.md
@@ -43,7 +43,7 @@ In order for Prompt flow to use your deployed model, you will need to setup a Co
         - This value can be found at the previously created Inferencing endpoint.
     3. **model_family**
         - Supported values: LLAMA, DOLLY, GPT2, or FALCON
-        - This value is dependent on the type of deployment you are targetting.
+        - This value is dependent on the type of deployment you are targeting.
 
 ## Running the Tool: Inputs
 


### PR DESCRIPTION
# Description

Multiple typos inside docs/reference/tools-reference/open_source_llm_tools.md and docs/reference/pf-command-reference.md have been fixed.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
