### PR TITLE
Fix reading special character issue for tool resolver

### DIFF
--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -146,15 +146,16 @@ class ToolResolver:
 
     def _load_source_content(self, node: Node) -> str:
         source = node.source
-        if source is None or source.path is None or not Path(self._working_dir / source.path).exists():
+        # If is_file returns True, the path points to a existing file, so we don't need to check if exists.
+        if source is None or source.path is None or not Path(self._working_dir / source.path).is_file():
             raise InvalidSource(
                 target=ErrorTarget.EXECUTOR,
                 message_format="Node source path '{source_path}' is invalid on node '{node_name}'.",
                 source_path=source.path if source is not None else None,
                 node_name=node.name,
             )
-        with open(self._working_dir / source.path) as fin:
-            return fin.read()
+        file = Path(self._working_dir / source.path)
+        return file.read_text(encoding="utf-8")
 
     def _validate_duplicated_inputs(self, prompt_tpl_inputs: list, tool_params: list, msg: str):
         duplicated_inputs = set(prompt_tpl_inputs) & set(tool_params)

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -147,14 +147,14 @@ class ToolResolver:
     def _load_source_content(self, node: Node) -> str:
         source = node.source
         # If is_file returns True, the path points to a existing file, so we don't need to check if exists.
-        if source is None or source.path is None or not Path(self._working_dir / source.path).is_file():
+        if source is None or source.path is None or not (self._working_dir / source.path).is_file():
             raise InvalidSource(
                 target=ErrorTarget.EXECUTOR,
                 message_format="Node source path '{source_path}' is invalid on node '{node_name}'.",
                 source_path=source.path if source is not None else None,
                 node_name=node.name,
             )
-        file = Path(self._working_dir / source.path)
+        file = self._working_dir / source.path
         return file.read_text(encoding="utf-8")
 
     def _validate_duplicated_inputs(self, prompt_tpl_inputs: list, tool_params: list, msg: str):

--- a/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
@@ -75,6 +75,7 @@ class TestToolMetaUtils:
             ("prompt_tools", "summarize_text_content_prompt.jinja2", "llm"),
             ("script_with_import", "dummy_utils/main.py", "python"),
             ("script_with___file__", "script_with___file__.py", "python"),
+            ("script_with_special_character", "script_with_special_character.py", "python"),
         ],
     )
     def test_generate_tool_meta_dict_by_file(self, flow_dir, tool_path, tool_type):

--- a/src/promptflow/tests/test_configs/flows/script_with___file__/script_with___file__.py
+++ b/src/promptflow/tests/test_configs/flows/script_with___file__/script_with___file__.py
@@ -2,9 +2,6 @@ from pathlib import Path
 
 from promptflow import tool
 
-# Add special character to test if file read is working.
-print("https://www.bing.com/")
-
 print(f"The script is {__file__}")
 assert Path(__file__).is_absolute(), f"__file__ should be absolute path, got {__file__}"
 

--- a/src/promptflow/tests/test_configs/flows/script_with_special_character/script_with_special_character.meta.json
+++ b/src/promptflow/tests/test_configs/flows/script_with_special_character/script_with_special_character.meta.json
@@ -1,0 +1,13 @@
+{
+  "name": "script_with_special_character",
+  "type": "python",
+  "inputs": {
+    "input1": {
+      "type": [
+        "string"
+      ]
+    }
+  },
+  "source": "script_with_special_character.py",
+  "function": "print_special_character"
+}

--- a/src/promptflow/tests/test_configs/flows/script_with_special_character/script_with_special_character.py
+++ b/src/promptflow/tests/test_configs/flows/script_with_special_character/script_with_special_character.py
@@ -1,9 +1,6 @@
-from pathlib import Path
-
 from promptflow import tool
-
 
 @tool
 def print_special_character(input1: str) -> str:
     # Add special character to test if file read is working.
-    return "https://www.bing.com/"
+    return "https://www.bing.com//"

--- a/src/promptflow/tests/test_configs/flows/script_with_special_character/script_with_special_character.py
+++ b/src/promptflow/tests/test_configs/flows/script_with_special_character/script_with_special_character.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+from promptflow import tool
+
+
+@tool
+def print_special_character(input1: str) -> str:
+    # Add special character to test if file read is working.
+    return "https://www.bing.com/"


### PR DESCRIPTION
# Description

For LLM/Prompt/CUSTOM_LLM tool, we need to read file to resolve the tool.
If there is special character, will introduce unexpected error.
So, we set encoding as "uts-8".

This is continuing PR for https://github.com/microsoft/promptflow/pull/759

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
