### PR TITLE
[SDK]Fix dict subscribing in py38

### DIFF
--- a/src/promptflow/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow/promptflow/_utils/multimedia_utils.py
@@ -2,13 +2,13 @@ import base64
 import imghdr
 import os
 import re
-import requests
 import uuid
-
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, Callable, Dict
 from urllib.parse import urlparse
+
+import requests
 
 from promptflow.contracts._errors import InvalidImageInput
 from promptflow.contracts.flow import FlowInputDefinition
@@ -146,12 +146,10 @@ def create_image(value: any, base_dir: Path = None):
 def save_image_to_file(image: Image, file_name: str, folder_path: Path, relative_path: Path = None):
     ext = get_extension_from_mime_type(image._mime_type)
     file_name = f"{file_name}.{ext}" if ext else file_name
-    image_reference = {
-        f"data:{image._mime_type};path": str(relative_path / file_name) if relative_path else file_name
-    }
+    image_reference = {f"data:{image._mime_type};path": str(relative_path / file_name) if relative_path else file_name}
     path = folder_path / relative_path if relative_path else folder_path
     os.makedirs(path, exist_ok=True)
-    with open(os.path.join(path, file_name), 'wb') as file:
+    with open(os.path.join(path, file_name), "wb") as file:
         file.write(image)
     return image_reference
 
@@ -163,6 +161,7 @@ def get_file_reference_encoder(folder_path: Path, relative_path: Path = None) ->
             file_name = str(uuid.uuid4())
             return save_image_to_file(obj, file_name, folder_path, relative_path)
         raise TypeError(f"Not supported to dump type '{type(obj).__name__}'.")
+
     return pfbytes_file_reference_encoder
 
 
@@ -185,7 +184,7 @@ def convert_multimedia_data_to_base64(value: Any):
 
 
 # TODO: Move this function to a more general place and integrate serialization to this function.
-def recursive_process(value: Any, process_funcs: dict[type, Callable] = None) -> dict:
+def recursive_process(value: Any, process_funcs: Dict[type, Callable] = None) -> dict:
     if process_funcs:
         for cls, f in process_funcs.items():
             if isinstance(value, cls):
@@ -197,7 +196,7 @@ def recursive_process(value: Any, process_funcs: dict[type, Callable] = None) ->
     return value
 
 
-def load_multimedia_data(inputs: dict[str, FlowInputDefinition], line_inputs: dict, base_dir: Path):
+def load_multimedia_data(inputs: Dict[str, FlowInputDefinition], line_inputs: dict, base_dir: Path):
     updated_inputs = dict(line_inputs or {})
     for key, value in inputs.items():
         if value.type == ValueType.IMAGE:


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

`dict` subscribing is not supported in py38. This PR fixed it with `typing.Dict`
![image](https://github.com/microsoft/promptflow/assets/7776147/687e786c-052d-4c3c-a662-f75b89f39f2c)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
