### PR TITLE
Fix comments when generate connection template

### DIFF
--- a/src/promptflow/promptflow/_utils/connection_utils.py
+++ b/src/promptflow/promptflow/_utils/connection_utils.py
@@ -114,11 +114,11 @@ def extract_comments_mapping(keys, doc):
             param_pattern = rf":param {key}: (.*)"
             key_description = " ".join(re.findall(param_pattern, doc))
             type_pattern = rf":type {key}: (.*)"
-            key_type = " ".join(re.findall(type_pattern, doc)).rstrip(".") + " type."
+            key_type = " ".join(re.findall(type_pattern, doc)).rstrip(".")
             if key_type and key_description:
-                comments_map[key] = " ".join([key_type, key_description])
+                comments_map[key] = " ".join([key_type + " type.", key_description])
             elif key_type:
-                comments_map[key] = key_type
+                comments_map[key] = key_type + " type."
             elif key_description:
                 comments_map[key] = key_description
         except re.error:

--- a/src/promptflow/promptflow/_utils/connection_utils.py
+++ b/src/promptflow/promptflow/_utils/connection_utils.py
@@ -114,9 +114,9 @@ def extract_comments_mapping(keys, doc):
             param_pattern = rf":param {key}: (.*)"
             key_description = " ".join(re.findall(param_pattern, doc))
             type_pattern = rf":type {key}: (.*)"
-            key_type = " ".join(re.findall(type_pattern, doc)).rstrip(".")
+            key_type = " ".join(re.findall(type_pattern, doc)).rstrip(".") + " type."
             if key_type and key_description:
-                comments_map[key] = ", ".join([key_type, key_description])
+                comments_map[key] = " ".join([key_type, key_description])
             elif key_type:
                 comments_map[key] = key_type
             elif key_description:

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -191,9 +191,9 @@ class TestToolsManager:
             package: test-custom-tools
             package_version: 0.0.2
             configs:
-              api_url: "This is a fake api url."  # String, The api url.
+              api_url: "This is a fake api url."  # String type. The api url.
             secrets:      # must-have
-              api_key: "to_replace_with_api_key"  # String, The api key.
+              api_key: "to_replace_with_api_key"  # String type. The api key.
             """
 
         content = templates["my_tool_package.tools.my_tool_with_custom_strong_type_connection.MyCustomConnection"]

--- a/src/promptflow/tests/executor/unittests/_utils/test_connection_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_connection_utils.py
@@ -62,12 +62,12 @@ class TestConnectionUtils:
             (
                 MyCustomConnectionWithInvalidComments,
                 [
-                    'api_base: "to_replace_with_api_base"  # String, The api base.\n',
-                    'api_key: "to_replace_with_api_key"  # String, The api key.\n',
+                    'api_base: "to_replace_with_api_base"  # String type. The api base.\n',
+                    'api_key: "to_replace_with_api_key"  # String type. The api key.\n',
                 ],
             ),
             (MyCustomConnectionMissingTypeComments, ['api_key: "to_replace_with_api_key"  # The api key.']),
-            (MyCustomConnectionMissingParamComments, ['api_key: "to_replace_with_api_key"  # String']),
+            (MyCustomConnectionMissingParamComments, ['api_key: "to_replace_with_api_key"  # String type.']),
         ],
     )
     def test_generate_custom_strong_type_connection_template_with_comments(self, cls, expected_str_in_template):


### PR DESCRIPTION
# Description

Fix the comments patten from "String, The api key." to "String type. The api key." when generate connection template.

Fixed yaml example:
```yaml
$schema: https://azuremlschemas.azureedge.net/promptflow/latest/CustomStrongTypeConnection.schema.json
name: "to_replace_with_connection_name"
type: custom
custom_type: MyCustomConnectionMissingTypeComments
module: executor.unittests._utils.test_connection_utils
package: test-package
package_version: 0.0.1
configs:
  api_base: "to_replace_with_api_base"  #  String type.
secrets:      # must-have
  api_key: "to_replace_with_api_key"  #  String type. The api key.
```

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
