### PR TITLE
Fix ut with error TypeError: refresh_connections_dir() missing 1 required positional argument: 'connection_template_yamls'

### DIFF
--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -173,7 +173,9 @@ class TestUtils:
 
         # Create and start threads
         for _ in range(concurrent_count):
-            thread = threading.Thread(target=refresh_connections_dir, args={None, None})
+            thread = threading.Thread(
+                target=lambda: refresh_connections_dir(connection_spec_files=[], connection_template_yamls=[])
+            )
             thread.start()
             threads.append(thread)
 


### PR DESCRIPTION
# Description

Error in sdk_cli_test CI: TypeError: refresh_connections_dir() missing 1 required positional argument: 'connection_template_yamls'

Failed reason: 
The error you're seeing is due to incorrect argument passing in your threading.Thread line. You're trying to pass arguments to refresh_connections_dir as a dictionary, but this function expects two positional arguments.

The correct way to provide arguments to the target function in threading.Thread is to use a tuple. In your case, since refresh_connections_dir requires two arguments, you should provide a tuple of two elements.

Solution:
![image](https://github.com/microsoft/promptflow/assets/46446115/ac2cf6fe-2c11-4f6c-9d49-b6d12cce230f)
