### PR TITLE
Fix typo in tools example quickstart

### DIFF
--- a/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_custom_strong_type_connection.py
+++ b/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_custom_strong_type_connection.py
@@ -7,7 +7,7 @@ class MyCustomConnection(CustomStrongTypeConnection):
     """My custom strong type connection.
 
     :param api_key: The api key get from "https://xxx.com".
-    :type api_key: String
+    :type api_key: Secret
     :param api_base: The api base.
     :type api_base: String
     """


### PR DESCRIPTION
# Description

Fix typo in tools example quickstart. The api-key in custom strong type connection tool should be secret type.