### PR TITLE
Avoid converting literal node input type by tool definition when load tool

### DIFF
--- a/src/promptflow/promptflow/contracts/tool.py
+++ b/src/promptflow/promptflow/contracts/tool.py
@@ -136,6 +136,23 @@ class ValueType(str, Enum):
         # TODO: parse other types
         return v
 
+    # This method is used to get the expect python class for input.
+    # When the actual input and expectation is not matched, we log a warning.
+    def _get_python_type(self):
+        if self == ValueType.INT:
+            return int
+        if self == ValueType.DOUBLE:
+            return float
+        if self == ValueType.BOOL:
+            return bool
+        if self == ValueType.STRING:
+            return str
+        if self == ValueType.LIST:
+            return list
+        if self == ValueType.OBJECT:
+            return dict
+        return None
+
 
 class ConnectionType:
     """This class provides methods to interact with connection types."""

--- a/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
@@ -207,11 +207,9 @@ class TestToolResolver:
             inputs={"int_input": InputAssignment(value="invalid", value_type=InputValueType.LITERAL)},
         )
         connections = {}
-        with pytest.raises(NodeInputValidationError) as e:
-            tool_resolver = ToolResolver(working_dir=None, connections=connections)
-            tool_resolver._convert_node_literal_input_types(node, tool)
-        message = "value 'invalid' is not type int"
-        assert message in str(e.value), "Expected: {}, Actual: {}".format(message, str(e.value))
+        tool_resolver = ToolResolver(working_dir=None, connections=connections)
+        updated_node = tool_resolver._convert_node_literal_input_types(node, tool)
+        assert updated_node.inputs["int_input"].value == "invalid", "Don't convert literal value by defination."
 
         # Case 4: Unresolved value, like newly added type not in old version ValueType enum
         tool = Tool(name="mock", type="python", inputs={"int_input": InputDefinition(type=["A_good_type"])})

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -95,7 +95,7 @@ class TestCli:
             run_id,
         )
         out, _ = capfd.readouterr()
-        assert "Completed" in out
+        assert "Completedtest" in out
 
         # Check the CLI works correctly when the parameter is surrounded by quotation, as below shown:
         # --param "key=value" key="value"

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_run.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_run.py
@@ -36,7 +36,7 @@ class TestRun:
                 flow_dag = yaml.safe_load(f)
             node_name_2_node = {node["name"]: node for node in flow_dag[NODES]}
             node = node_name_2_node["summarize_text_content"]
-            assert node["inputs"]["temperature"] == "0.2"
+            assert node["inputs"]["temperature"] == 0.2
 
     def test_overwrite_connections(self):
         with variant_overwrite_context(

--- a/src/promptflow/tests/test_configs/flows/chat_flow/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/chat_flow/flow.dag.yaml
@@ -11,20 +11,20 @@ outputs:
     reference: ${show_answer.output}
     is_chat_output: true
 nodes:
-- inputs:
-    deployment_name: gpt-35-turbo
-    max_tokens: "256"
-    temperature: "0.7"
-    chat_history: ${inputs.chat_history}
-    question: ${inputs.question}
-  name: chat_node
+- name: chat_node
   type: llm
   source:
     type: code
     path: chat.jinja2
-  api: chat
+  inputs:
+    deployment_name: gpt-35-turbo
+    max_tokens: 256
+    temperature: 0.7
+    chat_history: ${inputs.chat_history}
+    question: ${inputs.question}
   provider: AzureOpenAI
   connection: azure_open_ai_connection
+  api: chat
 - name: show_answer
   type: python
   source:
@@ -32,4 +32,3 @@ nodes:
     path: show_answer.py
   inputs:
     chat_answer: ${chat_node.output}
-node_variants: {}

--- a/src/promptflow/tests/test_configs/flows/web_classification/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/web_classification/flow.dag.yaml
@@ -19,7 +19,6 @@ nodes:
   inputs:
     fetch_url: ${inputs.url}
 - name: summarize_text_content
-  type: llm
   use_variants: true
 - name: prepare_examples
   type: python
@@ -34,17 +33,12 @@ nodes:
     path: classify_with_llm.jinja2
   inputs:
     deployment_name: gpt-35-turbo
-    suffix: ''
-    max_tokens: '128'
-    temperature: '0.1'
-    top_p: '1.0'
-    logprobs: ''
-    echo: 'False'
-    stop: ''
-    presence_penalty: '0'
-    frequency_penalty: '0'
-    best_of: '1'
-    logit_bias: ''
+    max_tokens: 128
+    temperature: 0.1
+    top_p: 1
+    echo: "False"
+    presence_penalty: 0
+    frequency_penalty: 0
     url: ${inputs.url}
     examples: ${prepare_examples.output}
     text_content: ${summarize_text_content.output}
@@ -71,17 +65,12 @@ node_variants:
             path: summarize_text_content.jinja2
           inputs:
             deployment_name: gpt-35-turbo
-            suffix: ''
-            max_tokens: '128'
+            max_tokens: 128
             temperature: 0.2
-            top_p: '1.0'
-            logprobs: ''
-            echo: 'False'
-            stop: ''
-            presence_penalty: '0'
-            frequency_penalty: '0'
-            best_of: '1'
-            logit_bias: ''
+            top_p: 1
+            echo: "False"
+            presence_penalty: 0
+            frequency_penalty: 0
             text: ${fetch_text_content_from_url.output}
           provider: AzureOpenAI
           connection: azure_open_ai_connection
@@ -95,17 +84,12 @@ node_variants:
             path: summarize_text_content__variant_1.jinja2
           inputs:
             deployment_name: gpt-35-turbo
-            suffix: ''
-            max_tokens: '256'
+            max_tokens: 256
             temperature: 0.3
-            top_p: '1.0'
-            logprobs: ''
-            echo: 'False'
-            stop: ''
-            presence_penalty: '0'
-            frequency_penalty: '0'
-            best_of: '1'
-            logit_bias: ''
+            top_p: 1
+            echo: "False"
+            presence_penalty: 0
+            frequency_penalty: 0
             text: ${fetch_text_content_from_url.output}
           connection: azure_open_ai_connection
           api: chat

--- a/src/promptflow/tests/test_configs/flows/web_classification/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/web_classification/flow.dag.yaml
@@ -73,7 +73,7 @@ node_variants:
             deployment_name: gpt-35-turbo
             suffix: ''
             max_tokens: '128'
-            temperature: '0.2'
+            temperature: 0.2
             top_p: '1.0'
             logprobs: ''
             echo: 'False'
@@ -97,7 +97,7 @@ node_variants:
             deployment_name: gpt-35-turbo
             suffix: ''
             max_tokens: '256'
-            temperature: '0.3'
+            temperature: 0.3
             top_p: '1.0'
             logprobs: ''
             echo: 'False'


### PR DESCRIPTION
# Description

Avoid converting literal node input type by tool definition.
UX/extension should assign literal node input by correct format in yaml.
Executor could skip conversion.
That will be better for customer's debugging, since all tools' could receive original content in yaml.

Warning log:
![image](https://github.com/microsoft/promptflow/assets/17527303/d447b08a-a4cd-41cf-b27b-a007fd3ab160)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
