### PR TITLE
[PromptFlow][ProcessPool] Fix the logic of child process handling exception.

### DIFF
--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -349,17 +349,12 @@ def _exec_line(
         return line_result
     except Exception as e:
         logger.error(f"Line {index}, Process {os.getpid()} failed with exception: {e}")
-        if executor._run_tracker.flow_run_list:
-            logger.info(f"Line {index}, Process {os.getpid()} have been added to flow run list.")
-            run_info = executor._run_tracker.flow_run_list[0]
-        else:
-            flow_id = executor._flow_id
-            line_run_id = run_id if index is None else f"{run_id}_{index}"
-            # If line execution failed before start, there is no flow information in the run_tracker.
-            # So we call start_flow_run before handling exception to make sure the run_tracker has flow info.
-            executor._run_tracker.start_flow_run(flow_id, run_id, line_run_id, run_id)
-            logger.info(f"Line {index}, Process {os.getpid()} have not been added to flow run list.")
-            run_info = executor._run_tracker.end_run(f"{run_id}_{index}", ex=e)
+        flow_id = executor._flow_id
+        line_run_id = run_id if index is None else f"{run_id}_{index}"
+        # If line execution failed before start, there is no flow information in the run_tracker.
+        # So we call start_flow_run before handling exception to make sure the run_tracker has flow info.
+        executor._run_tracker.start_flow_run(flow_id, run_id, line_run_id, run_id)
+        run_info = executor._run_tracker.end_run(f"{run_id}_{index}", ex=e)
         output_queue.put(run_info)
         result = LineResult(
             output={},

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -353,6 +353,11 @@ def _exec_line(
             logger.info(f"Line {index}, Process {os.getpid()} have been added to flow run list.")
             run_info = executor._run_tracker.flow_run_list[0]
         else:
+            flow_id = executor._flow_id
+            line_run_id = run_id if index is None else f"{run_id}_{index}"
+            # If line execution failed before start, there is no flow information in the run_tracker.
+            # So we call start_flow_run before handling exception to make sure the run_tracker has flow info.
+            executor._run_tracker.start_flow_run(flow_id, run_id, line_run_id, run_id)
             logger.info(f"Line {index}, Process {os.getpid()} have not been added to flow run list.")
             run_info = executor._run_tracker.end_run(f"{run_id}_{index}", ex=e)
         output_queue.put(run_info)

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -362,7 +362,7 @@ def _exec_line(
             run_info=run_info,
             node_run_infos={},
         )
-    return result
+        return result
 
 
 def _process_wrapper(

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -442,7 +442,7 @@ class FlowExecutor:
             )
             logger.error(failed_msg)
 
-    def _exec_batch_with_threads(
+    def _exec_batch_with_process_pool(
         self, batch_inputs: List[dict], run_id, validate_inputs: bool = True, variant_id: str = ""
     ) -> List[LineResult]:
         nlines = len(batch_inputs)
@@ -765,7 +765,7 @@ class FlowExecutor:
         run_id = run_id or str(uuid.uuid4())
         with self._run_tracker.node_log_manager:
             OperationContext.get_instance().run_mode = RunMode.Batch.name
-            line_results = self._exec_batch_with_threads(inputs, run_id, validate_inputs=validate_inputs)
+            line_results = self._exec_batch_with_process_pool(inputs, run_id, validate_inputs=validate_inputs)
             self._add_line_results(line_results)  # For bulk run, currently we need to add line results to run_tracker
             self._handle_line_failures([r.run_info for r in line_results], raise_on_line_failure)
             aggr_results = self._exec_aggregation_with_bulk_results(inputs, line_results, run_id)

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -137,54 +137,6 @@ class TestLineExecutionProcessPool:
         assert isinstance(line_result, LineResult)
 
     @pytest.mark.parametrize(
-        "flow_folder, batch_input, error_message, error_class",
-        [
-            (
-                "simple_flow_with_python_tool",
-                [{"num11": "22"}],
-                (
-                    "The value for flow input 'num' is not provided in line 0 of input data. "
-                    "Please review your input data or remove this input in your flow if it's no longer needed."
-                ),
-                "InputNotFound",
-            )
-        ],
-    )
-    def test_exec_line_with_exception(self, flow_folder, batch_input, error_message, error_class, dev_connections):
-        executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections)
-        executor.exec_bulk(
-            batch_input,
-        )
-        output_queue = Queue()
-        run_id = str(uuid.uuid4())
-        line_result = _exec_line(
-            executor=executor,
-            output_queue=output_queue,
-            inputs=batch_input[0],
-            run_id=run_id,
-            index=0,
-            variant_id="",
-            validate_inputs=False,
-        )
-        if (
-            (sys.version_info.major == 3)
-            and (sys.version_info.minor >= 11)
-            and ((sys.platform == "linux") or (sys.platform == "darwin"))
-        ):
-            # Python >= 3.11 has a different error message on linux and macos
-            error_message_compare = error_message.replace("int", "ValueType.INT")
-            assert error_message_compare in str(
-                line_result.run_info.error
-            ), f"Expected message {error_message_compare} but got {str(line_result.run_info.error)}"
-        else:
-            assert error_message in str(
-                line_result.run_info.error
-            ), f"Expected message {error_message} but got {str(line_result.run_info.error)}"
-        assert error_class in str(
-            line_result.run_info.error
-        ), f"Expected message {error_class} but got {str(line_result.run_info.error)}"
-
-    @pytest.mark.parametrize(
         "flow_folder",
         [
             SAMPLE_FLOW,

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -14,11 +14,9 @@ from tempfile import mkdtemp
 from ...utils import (
     get_flow_sample_inputs,
     get_yaml_file,
-    FLOW_ROOT
 )
 
 import uuid
-import sys
 
 SAMPLE_FLOW = "web_classification_no_variants"
 


### PR DESCRIPTION
# Description

Fix exec_line failed when line execution not start in bulk run scenario.

**Problem**
When processing input images, system errors may occur because the image path cannot be found. At this time, the flow has not started running, and the catch logic of the sub-process will cause an error: `Run record with ID '{run_id}' was not tracked in promptflow execution. ` causing this line to fail due to timeout, but in reality, the reason is that the image path cannot be found.

**Solution**
Call start_flow_run before handling exception to make sure the run_tracker has flow info.


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
