### PR TITLE
Rename the function name from "skip_if_no_key" to "skip_if_no_api_key"

### DIFF
--- a/src/promptflow-tools/tests/conftest.py
+++ b/src/promptflow-tools/tests/conftest.py
@@ -91,7 +91,7 @@ def open_source_llm_ws_service_connection() -> bool:
 
 
 @pytest.fixture(autouse=True)
-def skip_if_no_key(request, mocker):
+def skip_if_no_api_key(request, mocker):
     mocker.patch.dict(os.environ, {"PROMPTFLOW_CONNECTIONS": CONNECTION_FILE})
     if request.node.get_closest_marker('skip_if_no_key'):
         conn_name = request.node.get_closest_marker('skip_if_no_key').args[0]

--- a/src/promptflow-tools/tests/conftest.py
+++ b/src/promptflow-tools/tests/conftest.py
@@ -93,8 +93,8 @@ def open_source_llm_ws_service_connection() -> bool:
 @pytest.fixture(autouse=True)
 def skip_if_no_api_key(request, mocker):
     mocker.patch.dict(os.environ, {"PROMPTFLOW_CONNECTIONS": CONNECTION_FILE})
-    if request.node.get_closest_marker('skip_if_no_key'):
-        conn_name = request.node.get_closest_marker('skip_if_no_key').args[0]
+    if request.node.get_closest_marker('skip_if_no_api_key'):
+        conn_name = request.node.get_closest_marker('skip_if_no_api_key').args[0]
         connection = request.getfixturevalue(conn_name)
         # if dummy placeholder key, skip.
         if isinstance(connection, OpenAIConnection) or isinstance(connection, SerpConnection):

--- a/src/promptflow-tools/tests/pytest.ini
+++ b/src/promptflow-tools/tests/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 markers =
-    skip_if_no_key: skip the test if actual api key is not provided.
+    skip_if_no_api_key: skip the test if actual api key is not provided.

--- a/src/promptflow-tools/tests/test_embedding.py
+++ b/src/promptflow-tools/tests/test_embedding.py
@@ -13,7 +13,7 @@ class TestEmbedding:
             deployment_name="text-embedding-ada-002")
         assert len(result) == 1536
 
-    @pytest.mark.skip_if_no_key("open_ai_connection")
+    @pytest.mark.skip_if_no_api_key("open_ai_connection")
     def test_embedding_conn_oai(self, open_ai_connection):
         result = embedding(
             connection=open_ai_connection,

--- a/src/promptflow-tools/tests/test_handle_openai_error.py
+++ b/src/promptflow-tools/tests/test_handle_openai_error.py
@@ -260,7 +260,7 @@ class TestHandleOpenAIError:
         assert mock_method.call_count == 1
         assert exc_info.value.error_codes == error_codes.split("/")
 
-    @pytest.mark.skip_if_no_key("open_ai_connection")
+    @pytest.mark.skip_if_no_api_key("open_ai_connection")
     def test_model_not_accept_functions_as_param(
             self, open_ai_connection, example_prompt_template, functions):
         with pytest.raises(WrappedOpenAIError) as exc_info:

--- a/src/promptflow-tools/tests/test_open_source_llm.py
+++ b/src/promptflow-tools/tests/test_open_source_llm.py
@@ -97,14 +97,14 @@ user:
             deployment_name="gpt2-9")
         assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_chat(self, gpt2_provider):
         response = gpt2_provider.call(
             self.chat_prompt,
             API.CHAT)
         assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_chat_with_deploy(self, gpt2_provider):
         response = gpt2_provider.call(
             self.chat_prompt,
@@ -112,7 +112,7 @@ user:
             deployment_name="gpt2-9")
         assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_chat_with_max_length(self, gpt2_provider):
         response = gpt2_provider.call(
             self.chat_prompt,
@@ -121,7 +121,7 @@ user:
         # GPT-2 doesn't take this parameter
         assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_con_url_chat(self, gpt2_custom_connection):
         tmp = copy.deepcopy(gpt2_custom_connection)
         del tmp.configs['endpoint_url']
@@ -145,7 +145,7 @@ Required keys are: endpoint_url,model_family."""
 Required keys are: endpoint_api_key.""")
         assert exc_info.value.error_codes == "UserError/ToolValidationError/OpenSourceLLMKeyValidationError".split("/")
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_con_model_chat(self, gpt2_custom_connection):
         tmp = copy.deepcopy(gpt2_custom_connection)
         del tmp.configs['model_family']
@@ -209,7 +209,7 @@ user:
             + "gallery that contain 'Chat' in the name.")
         assert exc_info.value.error_codes == "UserError/OpenSourceLLMUserError".split("/")
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_llama_endpoint_miss(self, gpt2_custom_connection):
         tmp = copy.deepcopy(gpt2_custom_connection)
         tmp.configs['endpoint_url'] += 'completely/real/endpoint'
@@ -223,7 +223,7 @@ user:
             + "HTTPError: HTTP Error 424: Failed Dependency")
         assert exc_info.value.error_codes == "UserError/OpenSourceLLMOnlineEndpointError".split("/")
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_llama_deployment_miss(self, gpt2_provider):
         with pytest.raises(OpenSourceLLMOnlineEndpointError) as exc_info:
             gpt2_provider.call(self.completion_prompt,
@@ -234,14 +234,14 @@ user:
             + "HTTPError: HTTP Error 404: Not Found")
         assert exc_info.value.error_codes == "UserError/OpenSourceLLMOnlineEndpointError".split("/")
 
-    @pytest.mark.skip_if_no_key("open_source_llm_ws_service_connection")
+    @pytest.mark.skip_if_no_api_key("open_source_llm_ws_service_connection")
     def test_open_source_llm_chat_endpoint_name(self, chat_endpoints_provider):
         for endpoint_name in chat_endpoints_provider:
             os_llm = OpenSourceLLM(endpoint_name=endpoint_name)
             response = os_llm.call(self.chat_prompt, API.CHAT)
             assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("open_source_llm_ws_service_connection")
+    @pytest.mark.skip_if_no_api_key("open_source_llm_ws_service_connection")
     def test_open_source_llm_chat_endpoint_name_with_deployment(self, chat_endpoints_provider):
         for endpoint_name in chat_endpoints_provider:
             os_llm = OpenSourceLLM(endpoint_name=endpoint_name)
@@ -249,14 +249,14 @@ user:
                 response = os_llm.call(self.chat_prompt, API.CHAT, deployment_name=deployment_name)
                 assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("open_source_llm_ws_service_connection")
+    @pytest.mark.skip_if_no_api_key("open_source_llm_ws_service_connection")
     def test_open_source_llm_completion_endpoint_name(self, completion_endpoints_provider):
         for endpoint_name in completion_endpoints_provider:
             os_llm = OpenSourceLLM(endpoint_name=endpoint_name)
             response = os_llm.call(self.completion_prompt, API.COMPLETION)
             assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("open_source_llm_ws_service_connection")
+    @pytest.mark.skip_if_no_api_key("open_source_llm_ws_service_connection")
     def test_open_source_llm_completion_endpoint_name_with_deployment(self, completion_endpoints_provider):
         for endpoint_name in completion_endpoints_provider:
             os_llm = OpenSourceLLM(endpoint_name=endpoint_name)
@@ -264,12 +264,12 @@ user:
                 response = os_llm.call(self.completion_prompt, API.COMPLETION, deployment_name=deployment_name)
                 assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("llama_chat_custom_connection")
+    @pytest.mark.skip_if_no_api_key("llama_chat_custom_connection")
     def test_open_source_llm_llama_chat(self, llama_chat_provider):
         response = llama_chat_provider.call(self.chat_prompt, API.CHAT)
         assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("llama_chat_custom_connection")
+    @pytest.mark.skip_if_no_api_key("llama_chat_custom_connection")
     def test_open_source_llm_llama_chat_history(self, llama_chat_provider):
         chat_history_prompt = """user:
 * Given the following conversation history and the users next question, answer the next question.

--- a/src/promptflow-tools/tests/test_open_source_llm.py
+++ b/src/promptflow-tools/tests/test_open_source_llm.py
@@ -82,14 +82,14 @@ You are a AI which helps Customers answer questions.
 user:
 """ + completion_prompt
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_completion(self, gpt2_provider):
         response = gpt2_provider.call(
             self.completion_prompt,
             API.COMPLETION)
         assert len(response) > 25
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_completion_with_deploy(self, gpt2_provider):
         response = gpt2_provider.call(
             self.completion_prompt,
@@ -132,7 +132,7 @@ user:
 Required keys are: endpoint_url,model_family."""
         assert exc_info.value.error_codes == "UserError/ToolValidationError/OpenSourceLLMKeyValidationError".split("/")
 
-    @pytest.mark.skip_if_no_key("gpt2_custom_connection")
+    @pytest.mark.skip_if_no_api_key("gpt2_custom_connection")
     def test_open_source_llm_con_key_chat(self, gpt2_custom_connection):
         tmp = copy.deepcopy(gpt2_custom_connection)
         del tmp.secrets['endpoint_api_key']

--- a/src/promptflow-tools/tests/test_openai.py
+++ b/src/promptflow-tools/tests/test_openai.py
@@ -10,7 +10,7 @@ def openai_provider(open_ai_connection) -> OpenAI:
 
 
 @pytest.mark.usefixtures("use_secrets_config_file")
-@pytest.mark.skip_if_no_key("open_ai_connection")
+@pytest.mark.skip_if_no_api_key("open_ai_connection")
 class TestOpenAI:
     def test_openai_completion(self, openai_provider):
         prompt_template = "please complete this sentence: world war II "

--- a/src/promptflow-tools/tests/test_serpapi.py
+++ b/src/promptflow-tools/tests/test_serpapi.py
@@ -7,7 +7,7 @@ import tests.utils as utils
 
 
 @pytest.mark.usefixtures("use_secrets_config_file")
-@pytest.mark.skip_if_no_key("serp_connection")
+@pytest.mark.skip_if_no_api_key("serp_connection")
 class TestSerpAPI:
     def test_engine(self, serp_connection):
         query = "cute cats"


### PR DESCRIPTION
# Description

The function "skip_if_no_key" is used to skip the test if actual api key is not provided. To avoid misunderstanding, rename the function name from "skip_if_no_key" to "skip_if_no_api_key".

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
