### PR TITLE
[promptflow][fundamental] Rename environ name for pfazure test mode

### DIFF
--- a/.github/workflows/promptflow-sdk-cli-azure-e2e-test.yml
+++ b/.github/workflows/promptflow-sdk-cli-azure-e2e-test.yml
@@ -13,7 +13,7 @@ env:
   testWorkingDirectory: ${{ github.workspace }}/src/promptflow
   PYTHONPATH: ${{ github.workspace }}/src/promptflow
   IS_IN_CI_PIPELINE: "true"
-  PROMPT_FLOW_TEST_MODE: "live"
+  PROMPT_FLOW_TEST_MODE: "replay"
 
 jobs:
   sdk_cli_azure_e2e_test:

--- a/.github/workflows/promptflow-sdk-cli-azure-e2e-test.yml
+++ b/.github/workflows/promptflow-sdk-cli-azure-e2e-test.yml
@@ -13,8 +13,7 @@ env:
   testWorkingDirectory: ${{ github.workspace }}/src/promptflow
   PYTHONPATH: ${{ github.workspace }}/src/promptflow
   IS_IN_CI_PIPELINE: "true"
-  PROMPT_FLOW_TEST_RUN_LIVE: "false"
-  PROMPT_FLOW_SKIP_LIVE_RECORDING: "false"
+  PROMPT_FLOW_TEST_MODE: "live"
 
 jobs:
   sdk_cli_azure_e2e_test:

--- a/docs/dev/replay-e2e-test-for-pfazure.md
+++ b/docs/dev/replay-e2e-test-for-pfazure.md
@@ -1,0 +1,25 @@
+# Replay end-to-end test for pfazure
+
+This document introduces replay test for those tests located in [end-to-end tests for pfazure](../../src/promptflow/tests/sdk_cli_azure_test/e2etests/).
+
+## Why we need replay test
+
+End-to-end tests for pfazure targets to test the behavior that Prompt Flow SDK/CLI interacts with service, this process can be time consuming, error prone, and require credentials (which is unavailable to pull request from forked repository); all of these go against our intention for a smooth develop experience.
+
+Therefore, we introduce replay test, which leverage [VCR.py](https://pypi.org/project/vcrpy/) to record all required network traffic to local files and replay during tests. In this way, we avoid the need of credentials, speed up and stabilize the test process.
+
+## 3 test modes
+
+- `live`: tests run against real backend, which is the way traditional end-to-end test do.
+- `record`: tests run against real backend, and network traffic will be sanitized (filter sensitive and unnecessary requests/responses) and recorded to local files (recordings).
+- `replay`: there is no real network traffic between SDK/CLI and backend, tests run against local recordings.
+
+## How to record a test
+
+We are planning to build a workflow to automatically update recordings on behalf of you, but it's still work in progress. Before that, you need to manually record it(them) locally.
+
+To record a test, all you need is specifying environment variable `PROMPT_FLOW_TEST_MODE` to `'record'`; if you have a `.env` file, we recommend to specify it there. Then, just run the test that you want to record. Once the test completed, there should be one new YAML file located in `src/promptflow/tests/test_configs/recordings/`, containing the network traffic of the test - Congratulations! You have just recorded a test!
+
+## How to run test(s) in replay mode
+
+Specify environment variable `PROMPT_FLOW_TEST_MODE` to `'replay'` and run the test(s).

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -24,12 +24,7 @@ from promptflow._utils.utils import environment_variable_overwrite
 from promptflow.azure import PFClient
 
 from ._azure_utils import get_cred
-from .recording_utilities import (
-    PFAzureIntegrationTestRecording,
-    get_pf_client_for_playback,
-    is_live,
-    is_live_and_not_recording,
-)
+from .recording_utilities import PFAzureIntegrationTestRecording, get_pf_client_for_playback, is_live, is_replay
 
 FLOWS_DIR = "./tests/test_configs/flows"
 DATAS_DIR = "./tests/test_configs/datas"
@@ -39,7 +34,7 @@ load_dotenv()
 
 @pytest.fixture
 def tenant_id() -> str:
-    if not is_live():
+    if is_replay():
         return ""
     credential = get_cred()
     access_token = credential.get_token("https://management.azure.com/.default")
@@ -66,7 +61,7 @@ def ml_client(
 
 @pytest.fixture
 def remote_client() -> PFClient:
-    if not is_live():
+    if is_replay():
         yield get_pf_client_for_playback()
     else:
         # enable telemetry for CI
@@ -88,7 +83,7 @@ def remote_workspace_resource_id() -> str:
 
 @pytest.fixture
 def remote_client_int() -> PFClient:
-    if not is_live():
+    if is_replay():
         yield get_pf_client_for_playback()
     else:
         # enable telemetry for non-playback CI
@@ -212,7 +207,7 @@ def vcr_recording(request: pytest.FixtureRequest, tenant_id: str) -> PFAzureInte
         test_func_name=request.node.name,
         tenant_id=tenant_id,
     )
-    if not is_live_and_not_recording():
+    if not is_live():
         recording.enter_vcr()
         request.addfinalizer(recording.exit_vcr)
     yield recording
@@ -232,7 +227,7 @@ def randstr(vcr_recording: PFAzureIntegrationTestRecording) -> Callable[[str], s
 # we expect this fixture only work when running live test without recording
 # when recording, we don't want to record any application insights secrets
 # when replaying, we also don't need this
-@pytest.fixture(autouse=not is_live_and_not_recording())
+@pytest.fixture(autouse=not is_live())
 def mock_appinsights_log_handler(mocker: MockerFixture) -> None:
     dummy_logger = logging.getLogger("dummy")
     mocker.patch("promptflow._telemetry.telemetry.get_telemetry_logger", return_value=dummy_logger)

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -24,7 +24,7 @@ from promptflow._utils.utils import environment_variable_overwrite
 from promptflow.azure import PFClient
 
 from ._azure_utils import get_cred
-from .recording_utilities import PFAzureIntegrationTestRecording, get_pf_client_for_playback, is_live, is_replay
+from .recording_utilities import PFAzureIntegrationTestRecording, get_pf_client_for_replay, is_live, is_replay
 
 FLOWS_DIR = "./tests/test_configs/flows"
 DATAS_DIR = "./tests/test_configs/datas"
@@ -62,7 +62,7 @@ def ml_client(
 @pytest.fixture
 def remote_client() -> PFClient:
     if is_replay():
-        yield get_pf_client_for_playback()
+        yield get_pf_client_for_replay()
     else:
         # enable telemetry for CI
         with environment_variable_overwrite(TELEMETRY_ENABLED, "true"):
@@ -84,7 +84,7 @@ def remote_workspace_resource_id() -> str:
 @pytest.fixture
 def remote_client_int() -> PFClient:
     if is_replay():
-        yield get_pf_client_for_playback()
+        yield get_pf_client_for_replay()
     else:
         # enable telemetry for non-playback CI
         with environment_variable_overwrite(TELEMETRY_ENABLED, "true"):

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/__init__.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/__init__.py
@@ -3,11 +3,12 @@
 # ---------------------------------------------------------
 
 from .bases import PFAzureIntegrationTestRecording
-from .utils import get_pf_client_for_playback, is_live, is_live_and_not_recording
+from .utils import get_pf_client_for_playback, is_live, is_record, is_replay
 
 __all__ = [
     "PFAzureIntegrationTestRecording",
     "get_pf_client_for_playback",
     "is_live",
-    "is_live_and_not_recording",
+    "is_record",
+    "is_replay",
 ]

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/__init__.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/__init__.py
@@ -3,11 +3,11 @@
 # ---------------------------------------------------------
 
 from .bases import PFAzureIntegrationTestRecording
-from .utils import get_pf_client_for_playback, is_live, is_record, is_replay
+from .utils import get_pf_client_for_replay, is_live, is_record, is_replay
 
 __all__ = [
     "PFAzureIntegrationTestRecording",
-    "get_pf_client_for_playback",
+    "get_pf_client_for_replay",
     "is_live",
     "is_record",
     "is_replay",

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/bases.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/bases.py
@@ -20,7 +20,7 @@ from .processors import (
     StorageProcessor,
     TenantProcessor,
 )
-from .utils import is_live, is_live_and_not_recording, sanitize_upload_hash
+from .utils import is_live, is_record, is_replay, sanitize_upload_hash
 from .variable_recorder import VariableRecorder
 
 
@@ -29,7 +29,6 @@ class PFAzureIntegrationTestRecording:
         self.test_class = test_class
         self.test_func_name = test_func_name
         self.tenant_id = tenant_id
-        self.is_live = is_live()
         self.recording_file = self._get_recording_file()
         self.recording_processors = self._get_recording_processors()
         self.replay_processors = self._get_replay_processors()
@@ -70,7 +69,7 @@ class PFAzureIntegrationTestRecording:
             # recording filename pattern: {test_file_name}_{test_class_name}_{test_func_name}.yaml
             recording_filename = f"{test_file_name}_{test_class_name}_{self.test_func_name}.yaml"
             recording_file = (recording_dir / recording_filename).resolve()
-        if self.is_live and not is_live_and_not_recording() and recording_file.is_file():
+        if is_record() and recording_file.is_file():
             recording_file.unlink()
         return recording_file
 
@@ -89,15 +88,15 @@ class PFAzureIntegrationTestRecording:
         self.cassette = self._cm.__enter__()
 
     def exit_vcr(self):
-        if self.is_live and not is_live_and_not_recording():
+        if is_record():
             self._postprocess_recording()
         self._cm.__exit__()
 
     def _process_request_recording(self, request: Request) -> Request:
-        if is_live_and_not_recording():
+        if is_live():
             return request
 
-        if self.is_live:
+        if is_record():
             for processor in self.recording_processors:
                 request = processor.process_request(request)
         else:
@@ -106,11 +105,11 @@ class PFAzureIntegrationTestRecording:
         return request
 
     def _process_response_recording(self, response: Dict) -> Dict:
-        if is_live_and_not_recording():
+        if is_live():
             return response
 
         response["body"]["string"] = response["body"]["string"].decode("utf-8")
-        if self.is_live:
+        if is_record():
             # lower and filter some headers
             headers = {}
             for k in response["headers"]:
@@ -139,7 +138,7 @@ class PFAzureIntegrationTestRecording:
         return []
 
     def get_or_record_variable(self, variable: str, default: str) -> str:
-        if is_live():
+        if not is_replay():
             return self.variable_recorder.get_or_record_variable(variable, default)
         else:
             # return variable when playback, which is expected to be sanitized

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/bases.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/bases.py
@@ -79,7 +79,7 @@ class PFAzureIntegrationTestRecording:
             before_record_request=self._process_request_recording,
             before_record_response=self._process_response_recording,
             decode_compressed_response=True,
-            record_mode="none" if not self.is_live else "all",
+            record_mode="none" if not is_replay() else "all",
             filter_headers=FILTER_HEADERS,
         )
 

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/bases.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/bases.py
@@ -79,7 +79,7 @@ class PFAzureIntegrationTestRecording:
             before_record_request=self._process_request_recording,
             before_record_response=self._process_response_recording,
             decode_compressed_response=True,
-            record_mode="none" if not is_replay() else "all",
+            record_mode="none" if is_replay() else "all",
             filter_headers=FILTER_HEADERS,
         )
 

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/constants.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/constants.py
@@ -2,8 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-TEST_RUN_LIVE = "PROMPT_FLOW_TEST_RUN_LIVE"
-SKIP_LIVE_RECORDING = "PROMPT_FLOW_SKIP_LIVE_RECORDING"
+ENVIRON_TEST_MODE = "PROMPT_FLOW_TEST_MODE"
+
+
+class TestMode:
+    LIVE = "live"
+    RECORD = "record"
+    REPLAY = "replay"
+
 
 FILTER_HEADERS = [
     "aml-user-token",

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/utils.py
@@ -14,15 +14,23 @@ from vcr.request import Request
 
 from promptflow.azure import PFClient
 
-from .constants import SKIP_LIVE_RECORDING, TEST_RUN_LIVE, SanitizedValues
+from .constants import ENVIRON_TEST_MODE, SanitizedValues, TestMode
+
+
+def get_test_mode_from_environ() -> str:
+    return os.getenv(ENVIRON_TEST_MODE, TestMode.LIVE)
 
 
 def is_live() -> bool:
-    return os.getenv(TEST_RUN_LIVE, "true") == "true"
+    return get_test_mode_from_environ() == TestMode.LIVE
 
 
-def is_live_and_not_recording() -> bool:
-    return is_live() and os.getenv(SKIP_LIVE_RECORDING, "true") == "true"
+def is_record() -> bool:
+    return get_test_mode_from_environ() == TestMode.RECORD
+
+
+def is_replay() -> bool:
+    return get_test_mode_from_environ() == TestMode.REPLAY
 
 
 class FakeTokenCredential:

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/utils.py
@@ -67,7 +67,7 @@ def mock_workspace_get(*args, **kwargs) -> Workspace:
     )
 
 
-def get_pf_client_for_playback() -> PFClient:
+def get_pf_client_for_replay() -> PFClient:
     ml_client = MLClient(
         credential=FakeTokenCredential(),
         subscription_id=SanitizedValues.SUBSCRIPTION_ID,


### PR DESCRIPTION
# Description

This PR applies a rename to the test mode of pfazure tests. The three new modes are:

- **live**: real network traffic against live backend
- **record**: real network traffic against live backend, and recorded to YAML files
- **replay**: no real network traffic, interact with YAML files

This PR also includes a simple dev doc on this.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
