### PR TITLE
[promptflow][BugFix] Keep original format in run output file

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - [SDK/CLI] Support `pfazure flow create`. Create a flow on Azure AI from local flow folder.
 
+### Bugs Fixed
+
+- [SDK/CLI] Keep original format in run output.jsonl.
 
 ## 0.1.0b8 (2023.10.26)
 

--- a/src/promptflow/promptflow/_utils/utils.py
+++ b/src/promptflow/promptflow/_utils/utils.py
@@ -62,7 +62,7 @@ def load_json(file_path: Union[str, Path]) -> dict:
 def dump_list_to_jsonl(file_path: Union[str, Path], list_data: List[Dict]):
     with open(file_path, "w", encoding=DEFAULT_ENCODING) as jsonl_file:
         for data in list_data:
-            json.dump(data, jsonl_file)
+            json.dump(data, jsonl_file, ensure_ascii=False)
             jsonl_file.write("\n")
 
 

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_run.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_run.py
@@ -184,5 +184,14 @@ node_variants:
         data = f"{FLOWS_DIR}/flow_with_non_english_input/data.jsonl"
         run = pf.run(flow=flow_path, data=data, column_mapping={"text": "${data.text}"})
         local_storage = LocalStorageOperations(run=run)
+        # assert non english in output.jsonl
+        output_jsonl_path = local_storage._outputs_path
+        with open(output_jsonl_path, "r", encoding="utf-8") as f:
+            outputs_text = f.readlines()
+            assert outputs_text == [
+                '{"line_number": 0, "output": "Hello 123 日本語"}\n',
+                '{"line_number": 1, "output": "World 123 日本語"}\n',
+            ]
+        # assert non english in memory
         outputs = local_storage.load_outputs()
         assert outputs == {"output": ["Hello 123 日本語", "World 123 日本語"]}


### PR DESCRIPTION
# Description

Specify `ensure_ascii`/`force_ascii` to False when dump json, so that the dumped result can keep original format, instead of something like `\u65e5\u672c\u8a9e`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
