### PR TITLE
Add `enable_kwargs` tag in tools.json for customer python tool

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features Added
 
+- [Executor] Add `enable_kwargs` tag in tools.json for customer python tool.
 - [SDK/CLI] Support `pfazure flow create`. Create a flow on Azure AI from local flow folder.
 
 

--- a/src/promptflow/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow/promptflow/_core/tool_meta_generator.py
@@ -136,7 +136,9 @@ def _parse_tool_from_function(f, initialize_inputs=None, gen_custom_type_conn=Fa
     if hasattr(f, "__original_function"):
         f = f.__original_function
     try:
-        inputs, _, _ = function_to_interface(f, initialize_inputs, gen_custom_type_conn=gen_custom_type_conn)
+        inputs, _, _, enable_kwargs = function_to_interface(
+            f, initialize_inputs, gen_custom_type_conn=gen_custom_type_conn
+        )
     except Exception as e:
         error_type_and_message = f"({e.__class__.__name__}) {e}"
         raise BadFunctionInterface(
@@ -156,6 +158,7 @@ def _parse_tool_from_function(f, initialize_inputs=None, gen_custom_type_conn=Fa
         class_name=class_name,
         function=f.__name__,
         module=f.__module__,
+        enable_kwargs=enable_kwargs,
     )
 
 

--- a/src/promptflow/promptflow/_sdk/operations/_tool_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_tool_operations.py
@@ -70,7 +70,7 @@ class ToolOperations:
         if hasattr(f, "__original_function"):
             f = getattr(f, "__original_function")
         try:
-            inputs, _, _ = function_to_interface(f, initialize_inputs=initialize_inputs)
+            inputs, _, _, _ = function_to_interface(f, initialize_inputs=initialize_inputs)
         except Exception as e:
             raise UserErrorException(f"Failed to parse interface for tool {f.__name__}, reason: {e}") from e
         class_name = None

--- a/src/promptflow/promptflow/_utils/tool_utils.py
+++ b/src/promptflow/promptflow/_utils/tool_utils.py
@@ -117,6 +117,7 @@ def function_to_interface(f: Callable, initialize_inputs=None, gen_custom_type_c
         if any(k for k in initialize_inputs if k in sign.parameters):
             raise Exception(f'Duplicate inputs found from {f.__name__!r} and "__init__()"!')
         all_inputs = {**initialize_inputs}
+    enable_kwargs = any([param.kind == inspect.Parameter.VAR_KEYWORD for _, param in sign.parameters.items()])
     all_inputs.update(
         {
             k: v
@@ -132,7 +133,7 @@ def function_to_interface(f: Callable, initialize_inputs=None, gen_custom_type_c
             connection_types.append(input_def.type)
     outputs = {}
     # Note: We don't have output definition now
-    return input_defs, outputs, connection_types
+    return input_defs, outputs, connection_types, enable_kwargs
 
 
 def function_to_tool_definition(f: Callable, type=None, initialize_inputs=None) -> Tool:
@@ -146,7 +147,7 @@ def function_to_tool_definition(f: Callable, type=None, initialize_inputs=None) 
     """
     if hasattr(f, "__original_function"):
         f = f.__original_function
-    inputs, outputs, _ = function_to_interface(f, initialize_inputs)
+    inputs, outputs, _, _ = function_to_interface(f, initialize_inputs)
     # Hack to get class name
     class_name = None
     if "." in f.__qualname__:

--- a/src/promptflow/promptflow/contracts/tool.py
+++ b/src/promptflow/promptflow/contracts/tool.py
@@ -361,6 +361,8 @@ class Tool:
     :type is_builtin: Optional[bool]
     :param stage: The stage of the tool
     :type stage: Optional[str]
+    :param enable_kwargs: Whether to enable kwargs, only available for customer python tool
+    :type enable_kwargs: Optional[bool]
     """
 
     name: str
@@ -376,6 +378,7 @@ class Tool:
     connection_type: Optional[List[str]] = None
     is_builtin: Optional[bool] = None
     stage: Optional[str] = None
+    enable_kwargs: Optional[bool] = False
 
     def serialize(self) -> dict:
         """Serialize tool to dict and skip None fields.
@@ -415,6 +418,7 @@ class Tool:
             connection_type=data.get("connection_type"),
             is_builtin=data.get("is_builtin"),
             stage=data.get("stage"),
+            enable_kwargs=data.get("enable_kwargs", False),
         )
 
     def _require_connection(self) -> bool:

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -92,7 +92,7 @@ class ToolResolver:
             if v.value_type != InputValueType.LITERAL:
                 continue
             tool_input = tool.inputs.get(k)
-            if tool_input is None:
+            if tool_input is None:  # For kwargs input, tool_input is None.
                 continue
             value_type = tool_input.type[0]
             updated_inputs[k] = InputAssignment(value=v.value, value_type=InputValueType.LITERAL)

--- a/src/promptflow/tests/executor/unittests/_utils/test_tool_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_tool_utils.py
@@ -55,11 +55,12 @@ class TestToolUtils:
         def func(conn: [AzureOpenAIConnection, CustomConnection], input: [str, int]):
             pass
 
-        input_defs, _, connection_types = function_to_interface(func)
+        input_defs, _, connection_types, enable_kwargs = function_to_interface(func)
         assert len(input_defs) == 2
         assert input_defs["conn"].type == ["AzureOpenAIConnection", "CustomConnection"]
         assert input_defs["input"].type == [ValueType.OBJECT]
         assert connection_types == [["AzureOpenAIConnection", "CustomConnection"]]
+        assert enable_kwargs is False
 
     def test_function_to_interface_with_invalid_initialize_inputs(self):
         def func(input_str: str):
@@ -68,6 +69,13 @@ class TestToolUtils:
         with pytest.raises(Exception) as exec_info:
             function_to_interface(func, {"input_str": "test"})
         assert "Duplicate inputs found from" in exec_info.value.args[0]
+
+    def test_function_to_interface_with_kwargs(self):
+        def func(input_str: str, **kwargs):
+            pass
+
+        _, _, _, enable_kwargs = function_to_interface(func)
+        assert enable_kwargs is True
 
     def test_param_to_definition(self):
         from promptflow._sdk.entities import CustomStrongTypeConnection


### PR DESCRIPTION
# Description
https://github.com/microsoft/promptflow/issues/714 asked support for kwargs.

Add `enable_kwargs` tag in tools.json for customer python tool.
Then clients could add corresponding support for kwargs by yaml authoring.
We don't need to modify execution logic to support kwargs.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
