### PR TITLE
[promptflow][CLI] Show absolute path for image in show-details

### DIFF
--- a/src/promptflow/promptflow/_cli/_pf/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf/_run.py
@@ -22,6 +22,7 @@ from promptflow._cli._params import (
 )
 from promptflow._cli._utils import (
     activate_action,
+    convert_image_path_to_absolute_path,
     exception_handler,
     list_of_dict_to_dict,
     list_of_dict_to_nested_dict,
@@ -507,6 +508,7 @@ def show_run(name: str) -> None:
 def show_run_details(name: str, max_results: int, all_results: bool) -> None:
     pf_client = PFClient()
     details = pf_client.runs.get_details(name=name, max_results=max_results, all_results=all_results)
+    details = convert_image_path_to_absolute_path(df=details, client=pf_client, name=name)
     pretty_print_dataframe_as_table(details)
 
 

--- a/src/promptflow/promptflow/_cli/_pf/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf/_run.py
@@ -33,6 +33,7 @@ from promptflow._sdk._load_functions import load_run
 from promptflow._sdk._pf_client import PFClient
 from promptflow._sdk._run_functions import _create_run
 from promptflow._sdk.entities import Run
+from promptflow._sdk.operations._local_storage_operations import LocalStorageOperations
 
 
 def add_run_parser(subparsers):
@@ -508,7 +509,11 @@ def show_run(name: str) -> None:
 def show_run_details(name: str, max_results: int, all_results: bool) -> None:
     pf_client = PFClient()
     details = pf_client.runs.get_details(name=name, max_results=max_results, all_results=all_results)
-    details = convert_image_path_to_absolute_path(df=details, client=pf_client, name=name)
+    # get output.json path for potential usage for image
+    run = pf_client.runs.get(name=name)
+    local_storage = LocalStorageOperations(run)
+    output_json_path = local_storage._outputs_path.parent
+    details = convert_image_path_to_absolute_path(df=details, prefix=output_json_path)
     pretty_print_dataframe_as_table(details)
 
 

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -19,6 +19,7 @@ from promptflow._cli._params import AppendToDictAction
 from promptflow._cli._utils import (
     _build_sorted_column_widths_tuple_list,
     _calculate_column_widths,
+    convert_image_path_to_absolute_path,
     list_of_dict_to_nested_dict,
 )
 from promptflow._sdk._constants import HOME_PROMPT_FLOW_DIR
@@ -288,3 +289,33 @@ class TestCLIUtils:
         terminal_width = 120
         res = _calculate_column_widths(df, terminal_width)
         assert res == [4, 23, 13, 15, 15, 15]
+
+    def test_convert_image_path_to_absolute_path(self, tmpdir) -> None:
+        data = [
+            {
+                "inputs.ni": "not important",
+                "outputs.ni": "not important",
+                "outputs.image": {"data:image/png;path": "1.png"},
+            },
+            {
+                "inputs.ni": "not important",
+                "outputs.ni": "not important",
+                "outputs.image": {"data:image/png;path": "2.png"},
+            },
+        ]
+        df = pd.DataFrame(data)
+        prefix = Path(tmpdir)
+        df = convert_image_path_to_absolute_path(df, prefix=prefix)
+        converted_data = df.to_dict("records")
+        assert converted_data == [
+            {
+                "inputs.ni": "not important",
+                "outputs.ni": "not important",
+                "outputs.image": {"data:image/png;path": (prefix / "1.png").resolve().as_posix()},
+            },
+            {
+                "inputs.ni": "not important",
+                "outputs.ni": "not important",
+                "outputs.image": {"data:image/png;path": (prefix / "2.png").resolve().as_posix()},
+            },
+        ]


### PR DESCRIPTION
# Description

Show absolute path for images in `pf run show-details`.

Before

![image](https://github.com/microsoft/promptflow/assets/38847871/c776c5e4-9242-4b99-b766-aa41e612852a)

After

![image](https://github.com/microsoft/promptflow/assets/38847871/11ee7926-4504-4e0c-a470-3dfa0dac4753)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
