### PR TITLE
Fix create_tools_release_tag release

### DIFF
--- a/.github/workflows/tools_release_tag.yml
+++ b/.github/workflows/tools_release_tag.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Get last tag version
         run: |
-          version=$(git tag | tail -1)
+          version=$(git tag -l '*-tools' | sort -V | tail -n 1)
           echo "last_tag_version=$version" >> $GITHUB_ENV
 
       - name: Generate release notes


### PR DESCRIPTION
# Description

Fix the command about getting the latest tag. This command will provide the most recent tag according to the creation date from all tags ending with "-tools". 

**Fixed command:**
```bash
git tag -l '*-tools' | sort -V | tail -n 1
```

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
