### PR TITLE
[PFServing] add chat flow metadata in swagger and streaming event callback

### DIFF
--- a/src/promptflow/promptflow/_sdk/_serving/swagger.py
+++ b/src/promptflow/promptflow/_sdk/_serving/swagger.py
@@ -68,6 +68,11 @@ def generate_swagger(flow: Flow, samples, outputs_to_remove: list) -> dict:
         input_schema["required"] = []
         request_body_required = True
         for name, input in flow.inputs.items():
+            if input.is_chat_input:
+                swagger["info"]["x-chat-input"] = name
+                swagger["info"]["x-flow-type"] = "chat"
+            if input.is_chat_history:
+                swagger["info"]["x-chat-history"] = name
             input_schema["properties"][name] = generate_input_field_schema(input)
             input_schema["required"].append(name)
 
@@ -79,6 +84,8 @@ def generate_swagger(flow: Flow, samples, outputs_to_remove: list) -> dict:
             # TODO remove this if sdk removed this evaluation_only field
             if output.evaluation_only:
                 continue
+            if output.is_chat_output:
+                swagger["info"]["x-chat-output"] = name
             if outputs_to_remove and name in outputs_to_remove:
                 continue
             output_schema["properties"][name] = generate_output_field_schema(output)

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -56,6 +56,65 @@ def test_swagger(flow_serving_client):
     }
 
 
+@pytest.mark.usefixtures("serving_client_llm_chat", "setup_local_connection")
+@pytest.mark.e2etest
+def test_chat_swagger(serving_client_llm_chat):
+    swagger_dict = json.loads(serving_client_llm_chat.get("/swagger.json").data.decode())
+    assert swagger_dict == {
+        "components": {"securitySchemes": {"bearerAuth": {"scheme": "bearer", "type": "http"}}},
+        "info": {
+            "title": "Promptflow[chat_flow_with_stream_output] API",
+            "version": "1.0.0",
+            "x-flow-name": "chat_flow_with_stream_output",
+            "x-chat-history": "chat_history",
+            "x-chat-input": "question",
+            "x-flow-type": "chat",
+            "x-chat-output": "answer",
+        },
+        "openapi": "3.0.0",
+        "paths": {
+            "/score": {
+                "post": {
+                    "requestBody": {
+                        "content": {
+                            "application/json": {
+                                "example": {},
+                                "schema": {
+                                    "properties": {
+                                        "chat_history": {
+                                            "type": "array",
+                                            "items": {"type": "object", "additionalProperties": {}}
+                                        },
+                                        "question": {"type": "string", "default": "What is ChatGPT?"}
+                                    },
+                                    "required": ["chat_history", "question"],
+                                    "type": "object",
+                                },
+                            }
+                        },
+                        "description": "promptflow input data",
+                        "required": True,
+                    },
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {"properties": {"answer": {"type": "string"}}, "type": "object"}
+                                }
+                            },
+                            "description": "successful operation",
+                        },
+                        "400": {"description": "Invalid input"},
+                        "default": {"description": "unexpected error"},
+                    },
+                    "summary": "run promptflow: chat_flow_with_stream_output with an given input",
+                }
+            }
+        },
+        "security": [{"bearerAuth": []}],
+    }
+
+
 @pytest.mark.usefixtures("flow_serving_client", "setup_local_connection")
 @pytest.mark.e2etest
 def test_user_agent(flow_serving_client):

--- a/src/promptflow/tests/test_configs/flows/chat_flow_with_stream_output/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/chat_flow_with_stream_output/flow.dag.yaml
@@ -1,6 +1,7 @@
 inputs:
   chat_history:
     type: list
+    is_chat_history: true
   question:
     type: string
     is_chat_input: true


### PR DESCRIPTION
# Description

changes includes:
- add chat flow metadata into the swagger for client consumption
- besides the streaming start/end callback, add a new streaming event callback which will be used for tracking/collecting streaming response data

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
