### PR TITLE
[infrastructure] Bypass GH operation for status update

### DIFF
--- a/.github/actions/step_publish_test_results/action.yml
+++ b/.github/actions/step_publish_test_results/action.yml
@@ -56,17 +56,17 @@ runs:
       indicators: true
       output: both
       thresholds: '${{ inputs.coverageThreshold }} 80'
-  - name: Sending PR status to checkenforcer
-    run: |-
-      gh api \
-        --method POST \
-        -H "Accept: application/vnd.github+json" \
-        -H "X-GitHub-Api-Version: 2022-11-28" \
-        /repos/${{ github.repository }}/statuses/${{ github.sha }} \
-        -f state='success' \
-        -f target_url='https://github.com/microsoft/promptflow/actions/runs/${{ github.run_id }}' \
-        -f description='The build succeeded!' \
-        -f context='${{ inputs.context }}'
-    shell: bash -el {0}
-    env:
-      GITHUB_TOKEN: ${{ inputs.token }}
+  # - name: Sending PR status to checkenforcer
+  #   run: |-
+  #     gh api \
+  #       --method POST \
+  #       -H "Accept: application/vnd.github+json" \
+  #       -H "X-GitHub-Api-Version: 2022-11-28" \
+  #       /repos/${{ github.repository }}/statuses/${{ github.sha }} \
+  #       -f state='success' \
+  #       -f target_url='https://github.com/microsoft/promptflow/actions/runs/${{ github.run_id }}' \
+  #       -f description='The build succeeded!' \
+  #       -f context='${{ inputs.context }}'
+  #   shell: bash -el {0}
+  #   env:
+  #     GITHUB_TOKEN: ${{ inputs.token }}


### PR DESCRIPTION
# Description

`pull_request` cannot use `secrets.GITHUB_TOKEN` to perform GH operations, commnet to bypass it.

This step targets to update status for check enforcer, however, we don't have a work one, so this step is not mandatory.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
