### PR TITLE
[promptflow][BugFix] Make image path absolute path

### DIFF
--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -193,8 +193,9 @@ class LocalStorageOperations(AbstractRunStorage):
         self._flow_tools_json_path = (
             self._snapshot_folder_path / PROMPT_FLOW_DIR_NAME / LocalStorageFilenames.FLOW_TOOLS_JSON
         )
+        self._inputs_path = self.path / LocalStorageFilenames.INPUTS  # keep this for other usages
         # below inputs and outputs are dumped by SDK
-        self._sdk_inputs_path = self.path / LocalStorageFilenames.INPUTS
+        self._sdk_inputs_path = self._inputs_path
         self._sdk_output_path = self.path / LocalStorageFilenames.OUTPUTS
         # metrics
         self._metrics_path = self.path / LocalStorageFilenames.METRICS

--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -451,7 +451,7 @@ class LocalStorageOperations(AbstractRunStorage):
                 outputs = pd.read_json(f, orient="records", lines=True)
                 # if all line runs are failed, no need to fill
                 if len(outputs) > 0:
-                    outputs = self._outputs_padding(outputs, len(list(inputs.values())[0]))
+                    outputs = self._outputs_padding(outputs, len(inputs))
                     outputs.fillna(value="(Failed)", inplace=True)  # replace nan with explicit prompt
                     outputs = outputs.set_index(LINE_NUMBER)
         return inputs, outputs
@@ -462,10 +462,13 @@ class LocalStorageOperations(AbstractRunStorage):
             if line_run_record_file.suffix.lower() != ".jsonl":
                 continue
             with open(line_run_record_file, mode="r", encoding=DEFAULT_ENCODING) as f:
-                line_run_info: dict = json.load(f)["run_info"]
+                data = json.load(f)
+                line_number: int = data[LINE_NUMBER]
+                line_run_info: dict = data["run_info"]
                 current_inputs = line_run_info.get("inputs")
                 current_outputs = line_run_info.get("output")
                 inputs.append(copy.deepcopy(current_inputs))
                 if current_outputs is not None:
+                    current_outputs[LINE_NUMBER] = line_number
                     outputs.append(copy.deepcopy(current_outputs))
         return pd.DataFrame(inputs), pd.DataFrame(outputs)

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -223,7 +223,6 @@ class RunOperations(TelemetryMixin):
 
         name = Run._validate_and_return_run_name(name)
         run = self.get(name=name)
-        run._check_run_status_is_completed()
         local_storage = LocalStorageOperations(run=run)
         inputs, outputs = local_storage.load_inputs_and_outputs()
         inputs = inputs.to_dict("list")

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -225,8 +225,9 @@ class RunOperations(TelemetryMixin):
         run = self.get(name=name)
         run._check_run_status_is_completed()
         local_storage = LocalStorageOperations(run=run)
-        inputs = local_storage.load_inputs()
-        outputs = local_storage.load_outputs()
+        inputs, outputs = local_storage.load_inputs_and_outputs()
+        inputs = inputs.to_dict("list")
+        outputs = outputs.to_dict("list")
         data = {}
         columns = []
         for k in inputs:

--- a/src/promptflow/promptflow/_sdk/operations/_run_submitter.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_submitter.py
@@ -353,7 +353,7 @@ class RunSubmitter:
             # won't raise the exception since it's already included in run object.
         finally:
             # persist snapshot and result
-            # snapshot: flow directory and (mapped) inputs
+            # snapshot: flow directory
             local_storage.dump_snapshot(flow)
             # persist inputs, outputs and metrics
             local_storage.persist_result(bulk_result)

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -800,3 +800,18 @@ class TestFlowRun:
         result = pf.run(flow=image_flow_path, data=data_path, column_mapping={"image": "${data.image}"})
         run = local_client.runs.get(name=result.name)
         assert run.status == "Completed"
+
+    def test_get_details_for_image_in_flow(self, pf: PFClient) -> None:
+        image_flow_path = f"{FLOWS_DIR}/python_tool_with_simple_image"
+        data_path = f"{image_flow_path}/image_inputs/inputs.jsonl"
+        run = pf.run(
+            flow=image_flow_path,
+            data=data_path,
+            column_mapping={"image": "${data.image}"},
+        )
+        details = pf.get_details(run.name)
+        for i in range(len(details)):
+            input_image_path = details["inputs.image"][i]["data:image/png;path"]
+            assert Path(input_image_path).is_absolute()
+            output_image_path = details["outputs.output"][i]["data:image/png;path"]
+            assert Path(output_image_path).is_absolute()


### PR DESCRIPTION
# Description

This PR updates the way SDK/CLI dump inputs and outputs. After the run completed, SDK will collect and dump IO from debug info (flow artifacts folder), so that later SDK/CLI can directly read from that file; before that, SDK/CLI will get IO directly from debug info.

This change make image path absolute path in SDK/CLI, as the path is kept abs in debug info.

![image](https://github.com/microsoft/promptflow/assets/38847871/a3192196-f122-4bcc-bee3-3a31c17b70ba)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
