### PR TITLE
[Bugfix][Executor] Change workinng dir when exec_bulk

### DIFF
--- a/src/promptflow/promptflow/executor/batch_engine.py
+++ b/src/promptflow/promptflow/executor/batch_engine.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Union
 
+from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.load_data import load_data
 from promptflow._utils.multimedia_utils import resolve_multimedia_data_recursively
 from promptflow._utils.utils import dump_list_to_jsonl
@@ -50,7 +51,8 @@ class BatchEngine:
         mapped_inputs = self.flow_executor.validate_and_apply_inputs_mapping(input_dicts, inputs_mapping)
         # run flow in batch mode
         output_dir = self._resolve_dir(output_dir)
-        batch_result = self.flow_executor.exec_bulk(mapped_inputs, run_id, output_dir=output_dir)
+        with _change_working_dir(self.flow_executor._working_dir):
+            batch_result = self.flow_executor.exec_bulk(mapped_inputs, run_id, output_dir=output_dir)
         # persist outputs to output dir
         self._persist_outputs(batch_result.outputs, output_dir)
         return batch_result

--- a/src/promptflow/tests/executor/e2etests/test_executor_with_image.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_with_image.py
@@ -176,6 +176,11 @@ class TestExecutorWithImage:
                 {"data": "inputs.jsonl"},
                 {"image_list": "${data.image_list}", "image_dict": "${data.image_dict}"},
             ),
+            (
+                COMPOSITE_IMAGE_FLOW,
+                {"data": "incomplete_inputs.jsonl"},
+                {"image_dict": "${data.image_dict}"},
+            ),
         ],
     )
     def test_executor_batch_engine_with_image(self, flow_folder, input_dirs, inputs_mapping):

--- a/src/promptflow/tests/test_configs/flows/python_tool_with_composite_image/incomplete_inputs.jsonl
+++ b/src/promptflow/tests/test_configs/flows/python_tool_with_composite_image/incomplete_inputs.jsonl
@@ -1,0 +1,2 @@
+{"image_dict":{"image_1": {"data:image/jpg;path": "logo.jpg"},"image_2": {"data:image/png;path": "logo_2.png"}}}
+{"image_dict":{"image_1": {"data:image/jpg;path": "logo_2.png"},"image_2": {"data:image/png;path": "logo.jpg"}}}


### PR DESCRIPTION
# Description

When submitting bulk run, if the default value of the image path is used, `FileNotFound` will be raised because the directory is not change to the flow working directory.  So we should change workinng dir when `exec_bulk`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
