### PR TITLE
[promptflow] Use as_posix() instead of pure str()

### DIFF
--- a/src/promptflow/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow/promptflow/_utils/multimedia_utils.py
@@ -152,9 +152,9 @@ def _save_image_to_file(
 ):
     ext = _get_extension_from_mime_type(image._mime_type)
     file_name = f"{file_name}.{ext}" if ext else file_name
-    image_path = str(relative_path / file_name) if relative_path else file_name
+    image_path = (relative_path / file_name).as_posix() if relative_path else file_name
     if use_absolute_path:
-        image_path = str(Path(folder_path / image_path).resolve())
+        image_path = Path(folder_path / image_path).resolve().as_posix()
     image_reference = {f"data:{image._mime_type};path": image_path}
     path = folder_path / relative_path if relative_path else folder_path
     os.makedirs(path, exist_ok=True)


### PR DESCRIPTION
# Description

Replace `str(Path)` with `Path.as_posix()`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
