### PR TITLE
[Bugfix][Contracts] Fix the bug that Image cannot be initialized with keyword args

### DIFF
--- a/src/promptflow/promptflow/contracts/multimedia.py
+++ b/src/promptflow/promptflow/contracts/multimedia.py
@@ -16,6 +16,8 @@ class PFBytes(bytes):
         return super().__new__(cls, value)
 
     def __init__(self, value: bytes, mime_type: str):
+        # Here the first argument should also be "value", the same as __new__.
+        # Otherwise we will get error when initialize the object.
         super().__init__()
         # Use this hash to identify this bytes.
         self._hash = hashlib.sha1(value).hexdigest()[:8]

--- a/src/promptflow/promptflow/contracts/multimedia.py
+++ b/src/promptflow/promptflow/contracts/multimedia.py
@@ -15,10 +15,10 @@ class PFBytes(bytes):
         # See https://docs.python.org/3/reference/datamodel.html#object.__new__
         return super().__new__(cls, value)
 
-    def __init__(self, data: bytes, mime_type: str):
+    def __init__(self, value: bytes, mime_type: str):
         super().__init__()
         # Use this hash to identify this bytes.
-        self._hash = hashlib.sha1(data).hexdigest()[:8]
+        self._hash = hashlib.sha1(value).hexdigest()[:8]
         self._mime_type = mime_type.lower()
 
     def to_base64(self, with_type: bool = False, dict_type: bool = False):
@@ -36,8 +36,8 @@ class Image(PFBytes):
     ~promptflow.contracts.multimedia.PFBytes.
     """
 
-    def __init__(self, data: bytes, mime_type: str = "image/*"):
-        return super().__init__(data, mime_type)
+    def __init__(self, value: bytes, mime_type: str = "image/*"):
+        return super().__init__(value, mime_type)
 
     def __str__(self):
         return f"Image({self._hash})"

--- a/src/promptflow/tests/executor/unittests/contracts/test_multimedia.py
+++ b/src/promptflow/tests/executor/unittests/contracts/test_multimedia.py
@@ -1,0 +1,27 @@
+import pytest
+import yaml
+from pathlib import Path
+
+from promptflow.contracts.multimedia import PFBytes, Image
+
+PACKAGE_TOOL_BASE = Path(__file__).parent.parent.parent / "package_tools"
+
+
+@pytest.mark.e2etest
+class TestMultimediaContract:
+    def test_constructors(self):
+        content = b"test"
+        mime_type = "image/*"
+        bs = [
+            PFBytes(content, mime_type),
+            Image(content, mime_type),
+            PFBytes(content, mime_type=mime_type),
+            Image(content, mime_type=mime_type),
+            PFBytes(value=content, mime_type=mime_type),
+            Image(value=content, mime_type=mime_type),
+        ]
+        for b in bs:
+            assert b._mime_type == "image/*"
+            assert b._hash == "a94a8fe5"
+            assert b.to_base64() == "dGVzdA=="
+            assert bytes(b) == content

--- a/src/promptflow/tests/executor/unittests/contracts/test_multimedia.py
+++ b/src/promptflow/tests/executor/unittests/contracts/test_multimedia.py
@@ -1,10 +1,6 @@
 import pytest
-import yaml
-from pathlib import Path
 
 from promptflow.contracts.multimedia import PFBytes, Image
-
-PACKAGE_TOOL_BASE = Path(__file__).parent.parent.parent / "package_tools"
 
 
 @pytest.mark.e2etest


### PR DESCRIPTION
# Description
Fix the bug that pfbytes cannot be initialized with keyword args
Before this PR, we cannot use `Image(value=f.read())` to initialize an image object.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
