### PR TITLE
[Test][CI] Remove AOAI connections in flow-as-func test to avoid transient connection invalid issue

### DIFF
--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_as_func.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_as_func.py
@@ -7,7 +7,8 @@ from types import GeneratorType
 import pytest
 
 from promptflow import load_flow
-from promptflow._sdk.entities import AzureOpenAIConnection, CustomConnection
+from promptflow._sdk._errors import ConnectionNotFoundError, InvalidFlowError
+from promptflow._sdk.entities import CustomConnection
 from promptflow.entities import FlowContext
 from promptflow.exceptions import UserErrorException
 
@@ -20,7 +21,7 @@ DATAS_DIR = "./tests/test_configs/datas"
 @pytest.mark.sdk_test
 @pytest.mark.e2etest
 class TestFlowAsFunc:
-    def test_flow_as_a_func(self, azure_open_ai_connection: AzureOpenAIConnection):
+    def test_flow_as_a_func(self):
         f = load_flow(f"{FLOWS_DIR}/print_env_var")
         result = f(key="unknown")
         assert result["output"] is None
@@ -93,11 +94,19 @@ class TestFlowAsFunc:
         result = f(key="key")
         assert result["output"] == "value"
 
-    def test_flow_as_a_func_with_variant(self, azure_open_ai_connection: AzureOpenAIConnection):
-        flow_path = Path(f"{FLOWS_DIR}/web_classification").absolute()
+    def test_flow_as_a_func_with_variant(self):
+        flow_path = Path(f"{FLOWS_DIR}/flow_with_dict_input_with_variant").absolute()
         f = load_flow(
             flow_path,
         )
-        f.context.variant = "${summarize_text_content.variant_0}"
+        f.context.variant = "${print_val.variant1}"
+        # variant1 will use a mock_custom_connection
+        with pytest.raises(ConnectionNotFoundError) as e:
+            f(key="a")
+        assert "Connection 'mock_custom_connection' is not found." in str(e.value)
 
-        f(url="https://www.youtube.com/watch?v=o5ZQyXaAv1g")
+        # non-exist variant
+        f.context.variant = "${print_val.variant_2}"
+        with pytest.raises(InvalidFlowError) as e:
+            f(key="a")
+        assert "Variant variant_2 not found for node print_val" in str(e.value)


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
This PR removed AOAI connections in flow-as-func test to avoid transient connection invalid issue.
In that issue, the connection exists but open ai complains the endpoint/key is invalid. 
![image](https://github.com/microsoft/promptflow/assets/7776147/d99e3205-bd54-49f7-8744-088152ddeb6f)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
