### PR TITLE
[promptflow][Test] Skip known enum issue in test when Python 3.11

### DIFF
--- a/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
@@ -153,6 +153,10 @@ class TestToolResolver:
         assert isinstance(exec_info.value.inner_exception, NodeInputValidationError)
         assert "These inputs are duplicated" in exec_info.value.message
 
+    @pytest.mark.skipif(
+        condition=(sys.version_info.major == 3 and sys.version_info.minor == 11),
+        reason="BUG 2709800: known issue on enum in Python 3.11",
+    )
     def test_ensure_node_inputs_type(self):
         # Case 1: conn_name not in connections, should raise conn_name not found error
         tool = Tool(name="mock", type="python", inputs={"conn": InputDefinition(type=["CustomConnection"])})

--- a/src/promptflow/tests/executor/unittests/processpool/test_healthy_ensured_process.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_healthy_ensured_process.py
@@ -27,7 +27,7 @@ def end_process(healthy_ensured_process):
 class TestHealthyEnsuredProcess:
 
     def test_healthy_ensured_process(self):
-        context = get_multiprocessing_context("fork")
+        context = get_multiprocessing_context("spawn")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func, context)
         assert healthy_ensured_process.is_ready is False
         task_queue = Queue()
@@ -38,7 +38,7 @@ class TestHealthyEnsuredProcess:
         assert healthy_ensured_process.process.is_alive() is False
 
     def test_unhealthy_process(self):
-        context = get_multiprocessing_context("fork")
+        context = get_multiprocessing_context("spawn")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func_timeout, context)
         assert healthy_ensured_process.is_ready is False
         task_queue = Queue()
@@ -49,7 +49,7 @@ class TestHealthyEnsuredProcess:
         assert healthy_ensured_process.process.is_alive() is False
 
     def test_format_current_process(self):
-        context = get_multiprocessing_context("fork")
+        context = get_multiprocessing_context("spawn")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func, context)
         healthy_ensured_process.process = patch(
             'promptflow.executor._line_execution_process_pool.Process', autospec=True)
@@ -66,7 +66,7 @@ class TestHealthyEnsuredProcess:
 
     @patch('promptflow.executor._line_execution_process_pool.logger.info', autospec=True)
     def test_format_completed_process(self, mock_logger_info):
-        context = get_multiprocessing_context("fork")
+        context = get_multiprocessing_context("spawn")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func, context)
         healthy_ensured_process.process = patch(
             'promptflow.executor._line_execution_process_pool.Process', autospec=True)

--- a/src/promptflow/tests/executor/unittests/processpool/test_healthy_ensured_process.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_healthy_ensured_process.py
@@ -27,7 +27,7 @@ def end_process(healthy_ensured_process):
 class TestHealthyEnsuredProcess:
 
     def test_healthy_ensured_process(self):
-        context = get_multiprocessing_context("spawn")
+        context = get_multiprocessing_context("fork")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func, context)
         assert healthy_ensured_process.is_ready is False
         task_queue = Queue()
@@ -38,7 +38,7 @@ class TestHealthyEnsuredProcess:
         assert healthy_ensured_process.process.is_alive() is False
 
     def test_unhealthy_process(self):
-        context = get_multiprocessing_context("spawn")
+        context = get_multiprocessing_context("fork")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func_timeout, context)
         assert healthy_ensured_process.is_ready is False
         task_queue = Queue()
@@ -49,7 +49,7 @@ class TestHealthyEnsuredProcess:
         assert healthy_ensured_process.process.is_alive() is False
 
     def test_format_current_process(self):
-        context = get_multiprocessing_context("spawn")
+        context = get_multiprocessing_context("fork")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func, context)
         healthy_ensured_process.process = patch(
             'promptflow.executor._line_execution_process_pool.Process', autospec=True)
@@ -66,7 +66,7 @@ class TestHealthyEnsuredProcess:
 
     @patch('promptflow.executor._line_execution_process_pool.logger.info', autospec=True)
     def test_format_completed_process(self, mock_logger_info):
-        context = get_multiprocessing_context("spawn")
+        context = get_multiprocessing_context("fork")
         healthy_ensured_process = HealthyEnsuredProcess(executor_creation_func, context)
         healthy_ensured_process.process = patch(
             'promptflow.executor._line_execution_process_pool.Process', autospec=True)


### PR DESCRIPTION
# Description

Skip test `test_ensure_node_inputs_type` in Python 3.11 due to known enum issue.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
