### PR TITLE
[promptflow][BugFix] Print error message when run status is failed

### DIFF
--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -430,13 +430,13 @@ class LocalStorageOperations(AbstractRunStorage):
 
     @staticmethod
     def _outputs_padding(df: pd.DataFrame, expected_rows: int) -> pd.DataFrame:
+        if len(df) == expected_rows:
+            return df
         missing_lines = []
         lines_set = set(df[LINE_NUMBER].values)
         for i in range(expected_rows):
             if i not in lines_set:
                 missing_lines.append({LINE_NUMBER: i})
-        if len(missing_lines) == 0:
-            return df
         df_to_append = pd.DataFrame(missing_lines)
         res = pd.concat([df, df_to_append], ignore_index=True)
         res = res.sort_values(by=LINE_NUMBER, ascending=True)

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -140,7 +140,10 @@ class RunOperations(TelemetryMixin):
             available_logs = local_storage.logger.get_logs()
             incremental_print(available_logs, printed, file_handler)
             self._print_run_summary(run)
-            # won't print error here, put it in run dict
+            # print error message when run is failed
+            if run.status == RunStatus.FAILED:
+                error_message = local_storage.load_exception()["message"]
+                file_handler.write(f"{error_message}\n")
         except KeyboardInterrupt:
             error_message = "The output streaming for the run was interrupted, but the run is still executing."
             print(error_message)

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -22,7 +22,7 @@ from promptflow._sdk._constants import (
 )
 from promptflow._sdk._errors import InvalidRunStatusError, RunExistsError, RunNotFoundError, RunOperationParameterError
 from promptflow._sdk._orm import RunInfo as ORMRun
-from promptflow._sdk._utils import incremental_print, safe_parse_object_list
+from promptflow._sdk._utils import incremental_print, print_red_error, safe_parse_object_list
 from promptflow._sdk._visualize_functions import dump_html, generate_html_string
 from promptflow._sdk.entities import Run
 from promptflow._sdk.operations._local_storage_operations import LocalStorageOperations
@@ -143,7 +143,7 @@ class RunOperations(TelemetryMixin):
             # print error message when run is failed
             if run.status == RunStatus.FAILED:
                 error_message = local_storage.load_exception()["message"]
-                file_handler.write(f"{error_message}\n")
+                print_red_error(error_message)
         except KeyboardInterrupt:
             error_message = "The output streaming for the run was interrupted, but the run is still executing."
             print(error_message)


### PR DESCRIPTION
# Description

If run status is failed, print error message; otherwise, user cannot know why the run is failed in SDK experience.

SDK experience:

<img width="1112" alt="image" src="https://github.com/microsoft/promptflow/assets/38847871/8441b759-da46-4268-aadf-26a72ea8c670">

CLI experience:

<img width="1115" alt="image" src="https://github.com/microsoft/promptflow/assets/38847871/702a1596-0a0b-45b1-b40e-549d0614b927">

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
