### PR TITLE
[promptflow][BugFix] Fix output padding when some inputs are missing

### DIFF
--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -261,14 +261,9 @@ class LocalStorageOperations(AbstractRunStorage):
                 df = pd.read_json(f, orient="records", lines=True)
                 return df.to_dict("list")
 
-        # get total number of line runs from inputs
-        num_line_runs = len(list(self.load_inputs().values())[0])
         with open(self._outputs_path, mode="r", encoding=DEFAULT_ENCODING) as f:
             df = pd.read_json(f, orient="records", lines=True)
-            # if all line runs are failed, no need to fill
             if len(df) > 0:
-                df = self._outputs_padding(df, num_line_runs)
-                df.fillna(value="(Failed)", inplace=True)  # replace nan with explicit prompt
                 df = df.set_index(LINE_NUMBER)
             return df.to_dict("list")
 
@@ -429,12 +424,12 @@ class LocalStorageOperations(AbstractRunStorage):
         return path
 
     @staticmethod
-    def _outputs_padding(df: pd.DataFrame, expected_rows: int) -> pd.DataFrame:
-        if len(df) == expected_rows:
+    def _outputs_padding(df: pd.DataFrame, inputs_line_numbers: List[int]) -> pd.DataFrame:
+        if len(df) == len(inputs_line_numbers):
             return df
         missing_lines = []
         lines_set = set(df[LINE_NUMBER].values)
-        for i in range(expected_rows):
+        for i in inputs_line_numbers:
             if i not in lines_set:
                 missing_lines.append({LINE_NUMBER: i})
         df_to_append = pd.DataFrame(missing_lines)
@@ -452,7 +447,7 @@ class LocalStorageOperations(AbstractRunStorage):
                 outputs = pd.read_json(f, orient="records", lines=True)
                 # if all line runs are failed, no need to fill
                 if len(outputs) > 0:
-                    outputs = self._outputs_padding(outputs, len(inputs))
+                    outputs = self._outputs_padding(outputs, inputs["line_number"].tolist())
                     outputs.fillna(value="(Failed)", inplace=True)  # replace nan with explicit prompt
                     outputs = outputs.set_index(LINE_NUMBER)
         return inputs, outputs

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_local_storage_operations.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_local_storage_operations.py
@@ -17,12 +17,20 @@ class TestLocalStorageOperations:
             {LINE_NUMBER: 2, "col": "b"},
         ]
         df = pd.DataFrame(data)
-        expected_rows = 5
-        df_with_padding = LocalStorageOperations._outputs_padding(df, expected_rows)
+
+        df_with_padding = LocalStorageOperations._outputs_padding(df, inputs_line_numbers=[0, 1, 2, 3, 4])
         df_with_padding.fillna("", inplace=True)
-        assert len(df_with_padding) == expected_rows
+        assert len(df_with_padding) == 5
         assert df_with_padding.iloc[0].to_dict() == {LINE_NUMBER: 0, "col": ""}
         assert df_with_padding.iloc[1].to_dict() == {LINE_NUMBER: 1, "col": "a"}
         assert df_with_padding.iloc[2].to_dict() == {LINE_NUMBER: 2, "col": "b"}
         assert df_with_padding.iloc[3].to_dict() == {LINE_NUMBER: 3, "col": ""}
         assert df_with_padding.iloc[4].to_dict() == {LINE_NUMBER: 4, "col": ""}
+
+        # in evaluation run, inputs may not have all line number
+        df_with_padding = LocalStorageOperations._outputs_padding(df, inputs_line_numbers=[1, 2, 4])
+        df_with_padding.fillna("", inplace=True)
+        assert len(df_with_padding) == 3
+        assert df_with_padding.iloc[0].to_dict() == {LINE_NUMBER: 1, "col": "a"}
+        assert df_with_padding.iloc[1].to_dict() == {LINE_NUMBER: 2, "col": "b"}
+        assert df_with_padding.iloc[2].to_dict() == {LINE_NUMBER: 4, "col": ""}


### PR DESCRIPTION
# Description

In some cases, inputs line number may not have full set (e.g. line 1, 2, 4), so that we should not pad the outputs from line number 0. This PR updates the padding function parameter, so that padding will be applied according to the real line number.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
