### PR TITLE
[promptflow][infrastructure] Make tests honor environment variables

### DIFF
--- a/src/promptflow/tests/_constants.py
+++ b/src/promptflow/tests/_constants.py
@@ -6,3 +6,9 @@ EXECUTOR_REQUESTS_ROOT = Path(PROMOTFLOW_ROOT / "tests/test_configs/executor_api
 MODEL_ROOT = Path(PROMOTFLOW_ROOT / "tests/test_configs/e2e_samples")
 CONNECTION_FILE = (PROMOTFLOW_ROOT / "connections.json").resolve().absolute().as_posix()
 ENV_FILE = (PROMOTFLOW_ROOT / ".env").resolve().absolute().as_posix()
+
+# below constants are used for pfazure and global config tests
+DEFAULT_SUBSCRIPTION_ID = "96aede12-2f73-41cb-b983-6d11a904839b"
+DEFAULT_RESOURCE_GROUP_NAME = "promptflow"
+DEFAULT_WORKSPACE_NAME = "promptflow-eastus"
+DEFAULT_RUNTIME_NAME = "test-runtime-ci"

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from _constants import CONNECTION_FILE, ENV_FILE
 from _pytest.monkeypatch import MonkeyPatch
+from dotenv import load_dotenv
 from filelock import FileLock
 from pytest_mock import MockerFixture
 
@@ -18,6 +19,8 @@ from promptflow._core.connection_manager import ConnectionManager
 from promptflow._core.openai_injector import inject_openai_api
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow.connections import AzureOpenAIConnection
+
+load_dotenv()
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -7,7 +7,14 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from _constants import CONNECTION_FILE, ENV_FILE
+from _constants import (
+    CONNECTION_FILE,
+    DEFAULT_RESOURCE_GROUP_NAME,
+    DEFAULT_RUNTIME_NAME,
+    DEFAULT_SUBSCRIPTION_ID,
+    DEFAULT_WORKSPACE_NAME,
+    ENV_FILE,
+)
 from _pytest.monkeypatch import MonkeyPatch
 from dotenv import load_dotenv
 from filelock import FileLock
@@ -78,26 +85,6 @@ def azure_open_ai_connection() -> AzureOpenAIConnection:
 def temp_output_dir() -> str:
     with tempfile.TemporaryDirectory() as temp_dir:
         yield temp_dir
-
-
-@pytest.fixture
-def default_subscription_id() -> str:
-    return "96aede12-2f73-41cb-b983-6d11a904839b"
-
-
-@pytest.fixture
-def default_resource_group() -> str:
-    return "promptflow"
-
-
-@pytest.fixture
-def default_workspace() -> str:
-    return "promptflow-eastus"
-
-
-@pytest.fixture
-def workspace_with_acr_access() -> str:
-    return "promptflow-eastus-dev"
 
 
 @pytest.fixture
@@ -175,3 +162,24 @@ def mock_module_with_list_func(mock_list_func):
 
         mock_import.side_effect = side_effect
         yield
+
+
+# below fixtures are used for pfazure and global config tests
+@pytest.fixture
+def subscription_id() -> str:
+    return os.getenv("PROMPT_FLOW_SUBSCRIPTION_ID", DEFAULT_SUBSCRIPTION_ID)
+
+
+@pytest.fixture
+def resource_group_name() -> str:
+    return os.getenv("PROMPT_FLOW_RESOURCE_GROUP_NAME", DEFAULT_RESOURCE_GROUP_NAME)
+
+
+@pytest.fixture
+def workspace_name() -> str:
+    return os.getenv("PROMPT_FLOW_WORKSPACE_NAME", DEFAULT_WORKSPACE_NAME)
+
+
+@pytest.fixture
+def runtime_name() -> str:
+    return os.getenv("PROMPT_FLOW_RUNTIME_NAME", DEFAULT_RUNTIME_NAME)

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -16,7 +16,6 @@ from azure.ai.ml import MLClient
 from azure.ai.ml.constants._common import AZUREML_RESOURCE_PROVIDER, RESOURCE_ID_FORMAT
 from azure.ai.ml.entities import Data
 from azure.core.exceptions import ResourceNotFoundError
-from dotenv import load_dotenv
 from pytest_mock import MockerFixture
 
 from promptflow._telemetry.telemetry import TELEMETRY_ENABLED
@@ -28,8 +27,6 @@ from .recording_utilities import PFAzureIntegrationTestRecording, get_pf_client_
 
 FLOWS_DIR = "./tests/test_configs/flows"
 DATAS_DIR = "./tests/test_configs/datas"
-
-load_dotenv()
 
 
 @pytest.fixture

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -41,23 +41,23 @@ def tenant_id() -> str:
 
 @pytest.fixture
 def ml_client(
-    default_subscription_id: str,
-    default_resource_group: str,
-    default_workspace: str,
+    subscription_id: str,
+    resource_group_name: str,
+    workspace_name: str,
 ) -> MLClient:
     """return a machine learning client using default e2e testing workspace"""
 
     return MLClient(
         credential=get_cred(),
-        subscription_id=default_subscription_id,
-        resource_group_name=default_resource_group,
-        workspace_name=default_workspace,
+        subscription_id=subscription_id,
+        resource_group_name=resource_group_name,
+        workspace_name=workspace_name,
         cloud="AzureCloud",
     )
 
 
 @pytest.fixture
-def remote_client() -> PFClient:
+def remote_client(subscription_id: str, resource_group_name: str, workspace_name: str) -> PFClient:
     if is_replay():
         yield get_pf_client_for_replay()
     else:
@@ -65,33 +65,17 @@ def remote_client() -> PFClient:
         with environment_variable_overwrite(TELEMETRY_ENABLED, "true"):
             yield PFClient(
                 credential=get_cred(),
-                subscription_id="96aede12-2f73-41cb-b983-6d11a904839b",
-                resource_group_name="promptflow",
-                workspace_name="promptflow-eastus",
+                subscription_id=subscription_id,
+                resource_group_name=resource_group_name,
+                workspace_name=workspace_name,
             )
 
 
 @pytest.fixture()
-def remote_workspace_resource_id() -> str:
+def remote_workspace_resource_id(subscription_id: str, resource_group_name: str, workspace_name: str) -> str:
     return "azureml:" + RESOURCE_ID_FORMAT.format(
-        "96aede12-2f73-41cb-b983-6d11a904839b", "promptflow", AZUREML_RESOURCE_PROVIDER, "promptflow-eastus"
+        subscription_id, resource_group_name, AZUREML_RESOURCE_PROVIDER, workspace_name
     )
-
-
-@pytest.fixture
-def remote_client_int() -> PFClient:
-    if is_replay():
-        yield get_pf_client_for_replay()
-    else:
-        # enable telemetry for non-playback CI
-        with environment_variable_overwrite(TELEMETRY_ENABLED, "true"):
-            client = MLClient(
-                credential=get_cred(),
-                subscription_id="96aede12-2f73-41cb-b983-6d11a904839b",
-                resource_group_name="promptflow",
-                workspace_name="promptflow-int",
-            )
-            yield PFClient(ml_client=client)
 
 
 @pytest.fixture()
@@ -111,62 +95,8 @@ def remote_web_classification_data(remote_client: PFClient) -> Data:
 
 
 @pytest.fixture
-def runtime() -> str:
-    return "test-runtime-ci"
-
-
-@pytest.fixture
-def runtime_int() -> str:
-    return "daily-image-mir"
-
-
-@pytest.fixture
-def ml_client_with_acr_access(
-    default_subscription_id: str,
-    default_resource_group: str,
-    workspace_with_acr_access: str,
-) -> MLClient:
-    """return a machine learning client using default e2e testing workspace"""
-
-    return MLClient(
-        credential=get_cred(),
-        subscription_id=default_subscription_id,
-        resource_group_name=default_resource_group,
-        workspace_name=workspace_with_acr_access,
-        cloud="AzureCloud",
-    )
-
-
-@pytest.fixture
-def ml_client_int(
-    default_subscription_id: str,
-    default_resource_group: str,
-) -> MLClient:
-    """return a machine learning client using default e2e testing workspace"""
-
-    return MLClient(
-        credential=get_cred(),
-        subscription_id="d128f140-94e6-4175-87a7-954b9d27db16",
-        resource_group_name=default_resource_group,
-        workspace_name="promptflow-int",
-        cloud="AzureCloud",
-    )
-
-
-@pytest.fixture
-def ml_client_canary(
-    default_subscription_id: str,
-    default_resource_group: str,
-) -> MLClient:
-    """return a machine learning client using default e2e testing workspace"""
-
-    return MLClient(
-        credential=get_cred(),
-        subscription_id=default_subscription_id,
-        resource_group_name=default_resource_group,
-        workspace_name="promptflow-canary-dev",
-        cloud="AzureCloud",
-    )
+def runtime(runtime_name: str) -> str:
+    return runtime_name
 
 
 PROMPTFLOW_ROOT = Path(__file__) / "../../.."

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_cli.py
@@ -26,14 +26,14 @@ def run_pf_command(*args, cwd=None):
 
 
 @pytest.fixture
-def operation_scope_args(default_subscription_id, default_resource_group, default_workspace):
+def operation_scope_args(subscription_id: str, resource_group_name: str, workspace_name: str):
     return [
         "--subscription",
-        default_subscription_id,
+        subscription_id,
         "--resource-group",
-        default_resource_group,
+        resource_group_name,
         "--workspace-name",
-        default_workspace,
+        workspace_name,
     ]
 
 
@@ -90,9 +90,9 @@ class TestAzureCli:
         self,
         mocker: MockFixture,
         operation_scope_args,
-        default_subscription_id,
-        default_resource_group,
-        default_workspace,
+        subscription_id: str,
+        resource_group_name: str,
+        workspace_name: str,
     ):
         mocked_run = MagicMock()
         mocked_run._to_dict.return_value = {"name": "test_run"}
@@ -122,9 +122,9 @@ class TestAzureCli:
         mocker.patch.dict(
             os.environ,
             {
-                "AZUREML_ARM_WORKSPACE_NAME": default_workspace,
-                "AZUREML_ARM_SUBSCRIPTION": default_subscription_id,
-                "AZUREML_ARM_RESOURCEGROUP": default_resource_group,
+                "AZUREML_ARM_WORKSPACE_NAME": workspace_name,
+                "AZUREML_ARM_SUBSCRIPTION": subscription_id,
+                "AZUREML_ARM_RESOURCEGROUP": resource_group_name,
             },
         )
         run_pf_command(
@@ -138,9 +138,9 @@ class TestAzureCli:
 
     def test_run_visualize(
         self,
-        default_subscription_id: str,
-        default_resource_group: str,
-        default_workspace: str,
+        subscription_id: str,
+        resource_group_name: str,
+        workspace_name: str,
         operation_scope_args: List[str],
         capfd: pytest.CaptureFixture,
     ) -> None:
@@ -155,9 +155,9 @@ class TestAzureCli:
         )
         captured = capfd.readouterr()
         expected_portal_url = VIS_PORTAL_URL_TMPL.format(
-            subscription_id=default_subscription_id,
-            resource_group_name=default_resource_group,
-            workspace_name=default_workspace,
+            subscription_id=subscription_id,
+            resource_group_name=resource_group_name,
+            workspace_name=workspace_name,
             names=names,
         )
         assert expected_portal_url in captured.out

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_pf_client.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_pf_client.py
@@ -15,7 +15,7 @@ from promptflow._sdk.operations._local_azure_connection_operations import LocalA
 class TestPFClient:
     # Test pf client when connection provider is azureml.
     # This tests suites need azure dependencies.
-    def test_connection_provider(self):
+    def test_connection_provider(self, subscription_id: str, resource_group_name: str, workspace_name: str):
         target = "promptflow._sdk._pf_client.Configuration"
         with mock.patch(target) as mocked:
             mocked.return_value.get_connection_provider.return_value = "abc"
@@ -38,7 +38,7 @@ class TestPFClient:
 
         with mock.patch(target) as mocked:
             mocked.return_value.get_connection_provider.return_value = "azureml:" + RESOURCE_ID_FORMAT.format(
-                "96aede12-2f73-41cb-b983-6d11a904839b", "promptflow", AZUREML_RESOURCE_PROVIDER, "promptflow-eastus"
+                subscription_id, resource_group_name, AZUREML_RESOURCE_PROVIDER, workspace_name
             )
             client = PFClient()
             assert isinstance(client.connections, LocalAzureConnectionOperations)
@@ -47,7 +47,7 @@ class TestPFClient:
             config={
                 "connection.provider": "azureml:"
                 + RESOURCE_ID_FORMAT.format(
-                    "96aede12-2f73-41cb-b983-6d11a904839b", "promptflow", AZUREML_RESOURCE_PROVIDER, "promptflow-eastus"
+                    subscription_id, resource_group_name, AZUREML_RESOURCE_PROVIDER, workspace_name
                 )
             }
         )

--- a/src/promptflow/tests/sdk_cli_global_config_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_global_config_test/conftest.py
@@ -9,12 +9,12 @@ from promptflow import PFClient
 from promptflow._sdk._configuration import Configuration
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def pf() -> PFClient:
     return PFClient()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def global_config(subscription_id: str, resource_group_name: str, workspace_name: str) -> None:
     config = Configuration.get_instance()
     if Configuration.CONNECTION_PROVIDER in config._config:

--- a/src/promptflow/tests/sdk_cli_global_config_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_global_config_test/conftest.py
@@ -15,14 +15,12 @@ def pf() -> PFClient:
 
 
 @pytest.fixture(scope="session")
-def global_config():
+def global_config(subscription_id: str, resource_group_name: str, workspace_name: str) -> None:
     config = Configuration.get_instance()
     if Configuration.CONNECTION_PROVIDER in config._config:
         return
     config.set_config(
         Configuration.CONNECTION_PROVIDER,
         "azureml:"
-        + RESOURCE_ID_FORMAT.format(
-            "96aede12-2f73-41cb-b983-6d11a904839b", "promptflow", AZUREML_RESOURCE_PROVIDER, "promptflow-eastus"
-        ),
+        + RESOURCE_ID_FORMAT.format(subscription_id, resource_group_name, AZUREML_RESOURCE_PROVIDER, workspace_name),
     )

--- a/src/promptflow/tests/sdk_cli_global_config_test/e2etests/test_global_config.py
+++ b/src/promptflow/tests/sdk_cli_global_config_test/e2etests/test_global_config.py
@@ -2,6 +2,8 @@ from pathlib import Path
 
 import pytest
 
+from promptflow import PFClient
+
 FLOWS_DIR = Path(__file__).parent.parent.parent / "test_configs" / "flows"
 DATAS_DIR = Path(__file__).parent.parent.parent / "test_configs" / "datas"
 
@@ -9,7 +11,7 @@ DATAS_DIR = Path(__file__).parent.parent.parent / "test_configs" / "datas"
 @pytest.mark.usefixtures("global_config")
 @pytest.mark.e2etest
 class TestGlobalConfig:
-    def test_basic_flow_bulk_run(self, pf) -> None:
+    def test_basic_flow_bulk_run(self, pf: PFClient) -> None:
         data_path = f"{DATAS_DIR}/webClassification3.jsonl"
 
         run = pf.run(flow=f"{FLOWS_DIR}/web_classification", data=data_path)
@@ -18,7 +20,7 @@ class TestGlobalConfig:
         run = pf.run(flow=f"{FLOWS_DIR}/web_classification", data=data_path)
         assert run.status == "Completed"
 
-    def test_connection_operations(self, pf):
+    def test_connection_operations(self, pf: PFClient) -> None:
         connections = pf.connections.list()
         assert len(connections) > 0, f"No connection found. Provider: {pf._connection_provider}"
         # Assert create/update/delete not supported.


### PR DESCRIPTION
# Description

Developers can use below environment variables to customize Azure workspace for test:

- `PROMPT_FLOW_SUBSCRIPTION_ID`: subscription id
- `PROMPT_FLOW_RESOURCE_GROUP_NAME`: resource group name
- `PROMPT_FLOW_WORKSPACE_NAME`: workspace name
- `PROMPT_FLOW_RUNTIME_NAME`: runtime name `

If not specified, will use default workspace & runtime.

Also clean some unused fixtures.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
