### PR TITLE
[Bugfix] Add variant_id back for legacy runtime contract

### DIFF
--- a/src/promptflow/promptflow/_core/flow_execution_context.py
+++ b/src/promptflow/promptflow/_core/flow_execution_context.py
@@ -146,6 +146,7 @@ class FlowExecutionContext(ThreadLocalSingleton):
             index=self._line_number,
         )
         run_info.index = self._line_number
+        run_info.variant_id = self._variant_id
         self._run_tracker.set_inputs(node_run_id, {key: value for key, value in all_args.items() if key != "self"})
         return run_info
 

--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -160,11 +160,11 @@ def mock_module_with_list_func(mock_list_func):
 
     with patch.object(importlib, "import_module") as mock_import:
 
-        def side_effect(module_name):
+        def side_effect(module_name, *args, **kwargs):
             if module_name == "my_tool_package.tools.tool_with_dynamic_list_input":
                 return mock_module
             else:
-                return original_import_module(module_name)
+                return original_import_module(module_name, *args, **kwargs)
 
         mock_import.side_effect = side_effect
         yield


### PR DESCRIPTION
# Description

In the previous PR, we forgot to set variant_id when moving the codes.
It is used in legacy contract to indicate the variants.
Added it back in this PR.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.

