### PR TITLE
Remove ValueError and add logs for gen_dynamic_list, retrieve_tool_unc_result

### DIFF
--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -193,10 +193,13 @@ def retrieve_tool_func_result(
     func = load_function_from_function_path(func_path)
     # get param names from func signature.
     func_sig_params = inspect.signature(func).parameters
+    module_logger.log(f"func_sig_params of  func_path is: '{func_sig_params}'")
+    module_logger.log(f"func_input_params_dict is: '{func_input_params_dict}'")
     # Validate if func input params are all in func signature params.
     for input_param in func_input_params_dict:
         if input_param not in func_sig_params:
-            raise ValueError(f"Input parameter '{input_param}' not in function's arguments")
+            module_logger.warning(f"Input parameter '{input_param}' not in function's arguments")
+            # raise ValueError(f"Input parameter '{input_param}' not in function's arguments")
     # Append workspace triple to func input params if func signature has kwargs param.
     # Or append ws_triple_dict params that are in func signature.
     combined_func_input_params = append_workspace_triple_to_func_input_params(
@@ -215,10 +218,13 @@ def gen_dynamic_list(func_path: str, func_input_params_dict: Dict, ws_triple_dic
     func = load_function_from_function_path(func_path)
     # get param names from func signature.
     func_sig_params = inspect.signature(func).parameters
+    module_logger.log(f"func_sig_params of  func_path is: '{func_sig_params}'")
+    module_logger.log(f"func_input_params_dict is: '{func_input_params_dict}'")
     # Validate if func input params are all in func signature params.
     for input_param in func_input_params_dict:
         if input_param not in func_sig_params:
-            raise ValueError(f"Input parameter '{input_param}' not in function's arguments")
+            module_logger.warning(f"Input parameter '{input_param}' not in function's arguments")
+            # raise ValueError(f"Input parameter '{input_param}' not in function's arguments")
     combined_func_input_params = append_workspace_triple_to_func_input_params(
         func_sig_params, func_input_params_dict, ws_triple_dict
     )

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -193,8 +193,8 @@ def retrieve_tool_func_result(
     func = load_function_from_function_path(func_path)
     # get param names from func signature.
     func_sig_params = inspect.signature(func).parameters
-    module_logger.log(f"func_sig_params of  func_path is: '{func_sig_params}'")
-    module_logger.log(f"func_input_params_dict is: '{func_input_params_dict}'")
+    module_logger.warning(f"func_sig_params of  func_path is: '{func_sig_params}'")
+    module_logger.warning(f"func_input_params_dict is: '{func_input_params_dict}'")
     # Validate if func input params are all in func signature params.
     for input_param in func_input_params_dict:
         if input_param not in func_sig_params:
@@ -218,8 +218,8 @@ def gen_dynamic_list(func_path: str, func_input_params_dict: Dict, ws_triple_dic
     func = load_function_from_function_path(func_path)
     # get param names from func signature.
     func_sig_params = inspect.signature(func).parameters
-    module_logger.log(f"func_sig_params of  func_path is: '{func_sig_params}'")
-    module_logger.log(f"func_input_params_dict is: '{func_input_params_dict}'")
+    module_logger.warning(f"func_sig_params of  func_path is: '{func_sig_params}'")
+    module_logger.warning(f"func_input_params_dict is: '{func_input_params_dict}'")
     # Validate if func input params are all in func signature params.
     for input_param in func_input_params_dict:
         if input_param not in func_sig_params:

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -193,13 +193,8 @@ def retrieve_tool_func_result(
     func = load_function_from_function_path(func_path)
     # get param names from func signature.
     func_sig_params = inspect.signature(func).parameters
-    module_logger.warning(f"func_sig_params of  func_path is: '{func_sig_params}'")
+    module_logger.warning(f"func_sig_params of func_path is: '{func_sig_params}'")
     module_logger.warning(f"func_input_params_dict is: '{func_input_params_dict}'")
-    # Validate if func input params are all in func signature params.
-    for input_param in func_input_params_dict:
-        if input_param not in func_sig_params:
-            module_logger.warning(f"Input parameter '{input_param}' not in function's arguments")
-            # raise ValueError(f"Input parameter '{input_param}' not in function's arguments")
     # Append workspace triple to func input params if func signature has kwargs param.
     # Or append ws_triple_dict params that are in func signature.
     combined_func_input_params = append_workspace_triple_to_func_input_params(
@@ -218,13 +213,8 @@ def gen_dynamic_list(func_path: str, func_input_params_dict: Dict, ws_triple_dic
     func = load_function_from_function_path(func_path)
     # get param names from func signature.
     func_sig_params = inspect.signature(func).parameters
-    module_logger.warning(f"func_sig_params of  func_path is: '{func_sig_params}'")
+    module_logger.warning(f"func_sig_params of func_path is: '{func_sig_params}'")
     module_logger.warning(f"func_input_params_dict is: '{func_input_params_dict}'")
-    # Validate if func input params are all in func signature params.
-    for input_param in func_input_params_dict:
-        if input_param not in func_sig_params:
-            module_logger.warning(f"Input parameter '{input_param}' not in function's arguments")
-            # raise ValueError(f"Input parameter '{input_param}' not in function's arguments")
     combined_func_input_params = append_workspace_triple_to_func_input_params(
         func_sig_params, func_input_params_dict, ws_triple_dict
     )


### PR DESCRIPTION
# Description
1. Remove ValueError of `gen_dynamic_list` and `retrieve_tool_func_result` to unblock vectordb wrapper case:
    1. The func has a required input.
    2. The func is inside a wrapper.
    
    Then the signature we get is wrapper's signature, when the required input provided, it's not in func signature:
    ![image](https://github.com/microsoft/promptflow/assets/20365062/aac51fcb-e04b-46ea-874b-60b98d08d149)
2. Add log of func signature for better trouble shooting.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

