### PR TITLE
[promptflow][Test] Make SDK PFS E2E use pull_request

### DIFF
--- a/.github/workflows/promptflow-sdk-pfs-e2e-test.yml
+++ b/.github/workflows/promptflow-sdk-pfs-e2e-test.yml
@@ -1,43 +1,31 @@
 name: promptflow-sdk-pfs-e2e-test
+
 on:
-  schedule:
-    - cron: "40 18 * * *" # Every day starting at 2:40 BJT
-  pull_request_target:
+  pull_request:
     paths:
       - src/promptflow/**
       - scripts/**
-      - '**promptflow-sdk-pfs-e2e-test.yml'
+      - .github/workflows/promptflow-sdk-pfs-e2e-test.yml
+
   workflow_dispatch:
+
 env:
   packageSetupType: promptflow_with_extra
   testWorkingDirectory: ${{ github.workspace }}/src/promptflow
   PYTHONPATH: ${{ github.workspace }}/src/promptflow
   IS_IN_CI_PIPELINE: "true"
+
 jobs:
-  authorize:
-    environment:
-      # forked prs from pull_request_target will be run in external environment, domain prs will be run in internal environment
-      ${{ github.event_name == 'pull_request_target' &&
-      github.event.pull_request.head.repo.full_name != github.repository &&
-      'external' || 'internal' }}
-    runs-on: ubuntu-latest
-    steps:
-      - run: true
   sdk_pfs_e2e_test:
-    needs: authorize
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
       uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
-        fetch-depth: 0
-    - name: merge main to current branch
-      uses: "./.github/actions/step_merge_main"
+
     - name: Display and Set Environment Variables
       run: |
         if [ "ubuntu-latest" == "${{ matrix.os }}" ]; then
@@ -51,26 +39,22 @@ jobs:
         env | sort >> $GITHUB_OUTPUT
       id: display_env
       shell: bash -el {0}
+
     - name: Conda Setup - ${{ matrix.os }} - Python Version ${{ steps.display_env.outputs.pyVersion }}
       uses: "./.github/actions/step_create_conda_environment"
       with:
         pythonVersion: ${{ steps.display_env.outputs.pyVersion }}
+
     - name: Build wheel
       uses: "./.github/actions/step_sdk_setup"
       with:
         setupType: ${{ env.packageSetupType }}
         scriptPath: ${{ env.testWorkingDirectory }}
-    - name: Azure Login
-      uses: azure/login@v1
-      with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
-    - name: Generate Configs
-      uses: "./.github/actions/step_generate_configs"
-      with:
-        targetFolder: ${{ env.testWorkingDirectory }}
+
     - name: Get number of CPU cores
       uses: SimenB/github-actions-cpu-cores@v1
       id: cpu-cores
+
     - name: Run Test
       shell: pwsh
       working-directory: ${{ env.testWorkingDirectory }}
@@ -84,6 +68,7 @@ jobs:
           -m "e2etest" `
           -n ${{ steps.cpu-cores.outputs.count }} `
           --coverage-config ${{ github.workspace }}/src/promptflow/tests/sdk_pfs_test/.coveragerc
+
     - name: Upload pytest test results
       if: always()
       uses: actions/upload-artifact@v3
@@ -92,6 +77,7 @@ jobs:
         path: |
           ${{ env.testWorkingDirectory }}/*.xml
           ${{ env.testWorkingDirectory }}/htmlcov/
+
   publish-test-results:
     name: "Publish Tests Results"
     needs: sdk_pfs_e2e_test
@@ -101,9 +87,8 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+        uses: actions/checkout@v4
+
       - name: Publish Test Results
         uses: "./.github/actions/step_publish_test_results"
         with:

--- a/src/promptflow/tests/sdk_pfs_test/conftest.py
+++ b/src/promptflow/tests/sdk_pfs_test/conftest.py
@@ -2,21 +2,13 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-import json
-from pathlib import Path
-
 import pytest
 from flask.app import Flask
 
 from promptflow import PFClient
-from promptflow._sdk.entities import AzureOpenAIConnection
-from promptflow._sdk.entities._connection import _Connection as Connection
 from promptflow._sdk._service.app import create_app
 
 from .utils import PFSOperations
-
-PROMOTFLOW_ROOT = Path(__file__) / "../../.."
-CONNECTION_FILE = (PROMOTFLOW_ROOT / "connections.json").resolve().absolute().as_posix()
 
 
 @pytest.fixture
@@ -35,30 +27,3 @@ def pfs_op(app: Flask) -> PFSOperations:
 @pytest.fixture(scope="session")
 def pf_client() -> PFClient:
     return PFClient()
-
-
-_connection_setup = False
-
-
-@pytest.fixture
-def setup_local_connection(pf_client: PFClient):
-    global _connection_setup
-    if _connection_setup:
-        return
-    connection_dict = json.loads(open(CONNECTION_FILE, "r").read())
-    for name, _dct in connection_dict.items():
-        if _dct["type"] == "BingConnection":
-            continue
-        pf_client.connections.create_or_update(Connection.from_execution_connection_dict(name=name, data=_dct))
-    _connection_setup = True
-
-
-@pytest.fixture
-def local_aoai_connection(pf_client: PFClient, azure_open_ai_connection: AzureOpenAIConnection) -> Connection:
-    conn = AzureOpenAIConnection(
-        name="azure_open_ai_connection",
-        api_key=azure_open_ai_connection.api_key,
-        api_base=azure_open_ai_connection.api_base,
-    )
-    pf_client.connections.create_or_update(conn)
-    return conn

--- a/src/promptflow/tests/sdk_pfs_test/e2etests/test_run_apis.py
+++ b/src/promptflow/tests/sdk_pfs_test/e2etests/test_run_apis.py
@@ -9,27 +9,26 @@ import pytest
 
 from promptflow import PFClient
 from promptflow._sdk.entities import Run
-from promptflow._sdk.entities._connection import _Connection as Connection
 from promptflow.contracts._run_management import RunDetail, RunMetadata
 
 from ..utils import PFSOperations
 
 
 def create_run_against_multi_line_data(client: PFClient) -> Run:
-    flow = "./tests/test_configs/flows/web_classification"
-    data = "./tests/test_configs/datas/webClassification3.jsonl"
-    return client.run(flow=flow, data=data, column_mapping={"url": "${data.url}"})
+    flow = "./tests/test_configs/flows/print_env_var"
+    data = "./tests/test_configs/datas/env_var_names.jsonl"
+    return client.run(flow=flow, data=data)
 
 
 @pytest.mark.usefixtures("use_secrets_config_file")
 @pytest.mark.e2etest
 class TestRunAPIs:
-    def test_list_runs(self, pf_client: PFClient, local_aoai_connection: Connection, pfs_op: PFSOperations) -> None:
+    def test_list_runs(self, pf_client: PFClient, pfs_op: PFSOperations) -> None:
         create_run_against_multi_line_data(pf_client)
         runs = pfs_op.list_runs().json
         assert len(runs) >= 1
 
-    def test_get_run(self, pf_client: PFClient, local_aoai_connection: Connection, pfs_op: PFSOperations) -> None:
+    def test_get_run(self, pf_client: PFClient, pfs_op: PFSOperations) -> None:
         run = create_run_against_multi_line_data(pf_client)
         run_from_pfs = pfs_op.get_run(name=run.name).json
         assert run_from_pfs["name"] == run.name
@@ -40,9 +39,7 @@ class TestRunAPIs:
         response = pfs_op.get_run(name=random_name)
         assert response.status_code == 404
 
-    def test_get_run_metadata(
-        self, pf_client: PFClient, local_aoai_connection: Connection, pfs_op: PFSOperations
-    ) -> None:
+    def test_get_run_metadata(self, pf_client: PFClient, pfs_op: PFSOperations) -> None:
         run = create_run_against_multi_line_data(pf_client)
         metadata = pfs_op.get_run_metadata(name=run.name).json
         for field in fields(RunMetadata):
@@ -50,13 +47,11 @@ class TestRunAPIs:
         assert metadata["name"] == run.name
         assert metadata["display_name"] == run.display_name
 
-    def test_get_run_detail(
-        self, pf_client: PFClient, local_aoai_connection: Connection, pfs_op: PFSOperations
-    ) -> None:
+    def test_get_run_detail(self, pf_client: PFClient, pfs_op: PFSOperations) -> None:
         run = create_run_against_multi_line_data(pf_client)
         detail = pfs_op.get_run_detail(name=run.name).json
         for field in fields(RunDetail):
             assert field.name in detail
         assert isinstance(detail["flow_runs"], list)
-        assert len(detail["flow_runs"]) == 3
+        assert len(detail["flow_runs"]) == 1
         assert isinstance(detail["node_runs"], list)


### PR DESCRIPTION
# Description

This PR targets to make workflow `promptflow-sdk-pfs-e2e-test` use `pull_request`, which means this workflow will not use any secrets in repo. Therefore, also update the run tests to use a flow that does not require any connection.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
