### PR TITLE
[Executor] Initial version of mixed async/sync tools in async scheduler

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -99,7 +99,7 @@ class AsyncNodesScheduler:
             task = context.invoke_tool_async(node, f, kwargs)
         else:
             task = self._sync_function_to_async_task(executor, context, node, f, kwargs)
-        return asyncio.get_event_loop().create_task(task)
+        return asyncio.create_task(task)
 
     @staticmethod
     def _invoke_sync_tool(context, node, f, kwargs):
@@ -119,6 +119,6 @@ class AsyncNodesScheduler:
         f,
         kwargs,
     ):
-        return await asyncio.get_event_loop().run_in_executor(
+        return await asyncio.get_running_loop().run_in_executor(
             executor, AsyncNodesScheduler._invoke_sync_tool, context, node, f, kwargs
         )

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -81,7 +81,10 @@ class AsyncNodesScheduler:
                 context.bypass_node(node)
             nodes_to_bypass = dag_manager.pop_bypassable_nodes()
         # Create tasks for ready nodes
-        return {self._create_node_task(node, dag_manager, context, executor): node for node in dag_manager.pop_ready_nodes()}
+        return {
+            self._create_node_task(node, dag_manager, context, executor): node
+            for node in dag_manager.pop_ready_nodes()
+        }
 
     def _create_node_task(
         self,

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -3,15 +3,19 @@
 # ---------------------------------------------------------
 
 import asyncio
+import inspect
+import contextvars
 from asyncio import Task
 from typing import Any, Dict, List, Tuple
 
 from promptflow._core.flow_execution_context import FlowExecutionContext
 from promptflow._core.tools_manager import ToolsManager
 from promptflow._utils.logger_utils import flow_logger
+from promptflow._utils.utils import set_context
 from promptflow.contracts.flow import Node
 from promptflow.executor._dag_manager import DAGManager
 from promptflow.executor._errors import NoNodeExecutedError
+from concurrent.futures import ThreadPoolExecutor
 
 
 class AsyncNodesScheduler:
@@ -30,12 +34,25 @@ class AsyncNodesScheduler:
         inputs: Dict[str, Any],
         context: FlowExecutionContext,
     ) -> Tuple[dict, dict]:
+        parent_context = contextvars.copy_context()
+        with ThreadPoolExecutor(
+            max_workers=self._node_concurrency, initializer=set_context, initargs=(parent_context,)
+        ) as executor:
+            return await self._execute_with_thread_pool(executor, nodes, inputs, context)
+
+    async def _execute_with_thread_pool(
+        self,
+        executor: ThreadPoolExecutor,
+        nodes: List[Node],
+        inputs: Dict[str, Any],
+        context: FlowExecutionContext,
+    ) -> Tuple[dict, dict]:
         flow_logger.info(f"Start to run {len(nodes)} nodes with the current event loop.")
         dag_manager = DAGManager(nodes, inputs)
-        task2nodes = self._execute_nodes(dag_manager, context)
+        task2nodes = self._execute_nodes(dag_manager, context, executor)
         while not dag_manager.completed():
             task2nodes = await self._wait_and_complete_nodes(task2nodes, dag_manager)
-            submitted_tasks2nodes = self._execute_nodes(dag_manager, context)
+            submitted_tasks2nodes = self._execute_nodes(dag_manager, context, executor)
             task2nodes.update(submitted_tasks2nodes)
         for node in dag_manager.bypassed_nodes:
             dag_manager.completed_nodes_outputs[node] = None
@@ -55,6 +72,7 @@ class AsyncNodesScheduler:
         self,
         dag_manager: DAGManager,
         context: FlowExecutionContext,
+        executor: ThreadPoolExecutor,
     ) -> Dict[Task, Node]:
         # Bypass nodes and update node run info until there are no nodes to bypass
         nodes_to_bypass = dag_manager.pop_bypassable_nodes()
@@ -63,15 +81,41 @@ class AsyncNodesScheduler:
                 context.bypass_node(node)
             nodes_to_bypass = dag_manager.pop_bypassable_nodes()
         # Create tasks for ready nodes
-        return {self._create_node_task(node, dag_manager, context): node for node in dag_manager.pop_ready_nodes()}
+        return {self._create_node_task(node, dag_manager, context, executor): node for node in dag_manager.pop_ready_nodes()}
 
     def _create_node_task(
         self,
         node: Node,
         dag_manager: DAGManager,
         context: FlowExecutionContext,
+        executor: ThreadPoolExecutor,
     ) -> Task:
         f = self._tools_manager.get_tool(node.name)
         kwargs = dag_manager.get_node_valid_inputs(node, f)
-        task = context.invoke_tool_async(node, f, kwargs)
+        if inspect.iscoroutinefunction(f):
+            task = context.invoke_tool_async(node, f, kwargs)
+        else:
+            task = self._sync_function_to_async_task(executor, context, node, f, kwargs)
         return asyncio.get_event_loop().create_task(task)
+
+    @staticmethod
+    def _invoke_sync_tool(context, node, f, kwargs):
+        try:
+            context.start()
+            context.current_node = node
+            result = f(**kwargs)
+            context.current_node = None
+            return result
+        finally:
+            context.end()
+
+    @staticmethod
+    async def _sync_function_to_async_task(
+        executor: ThreadPoolExecutor,
+        context, node,
+        f,
+        kwargs,
+    ):
+        return await asyncio.get_event_loop().run_in_executor(
+            executor, AsyncNodesScheduler._invoke_sync_tool, context, node, f, kwargs
+        )

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -5,6 +5,7 @@ import asyncio
 import copy
 import functools
 import inspect
+import os
 import uuid
 from pathlib import Path
 from threading import current_thread

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -866,7 +866,9 @@ class FlowExecutor:
         batch_nodes = [node for node in self._flow.nodes if not node.aggregation]
         outputs = {}
         #  TODO: Use a mixed scheduler to support both async and thread pool mode.
-        should_use_async = all(inspect.iscoroutinefunction(f) for f in self._tools_manager._tools.values())
+        should_use_async = all(
+            inspect.iscoroutinefunction(f) for f in self._tools_manager._tools.values()
+        ) or os.environ.get("PF_USE_ASYNC", "false").lower() == "true"
         if should_use_async:
             flow_logger.info("Start executing nodes in async mode.")
             scheduler = AsyncNodesScheduler(self._tools_manager, self._node_concurrency)


### PR DESCRIPTION
# Description
This is the initial version to run mixed async/sync tools in async scheduler, it is only enabled when all tools are async or the environment variable `PF_USE_ASYNC` is set for debugging purpose.

This pull request introduces new functionality to execute synchronous tools in a separate thread using a thread pool executor in the `AsyncNodesScheduler` class. It also modifies the condition in the `_traverse_nodes` method of the `FlowExecutor` class to check if all values in the `_tools` dictionary are coroutine functions or if the `PF_USE_ASYNC` environment variable is set to "true", indicating that the flow should be executed in async mode.

Main functionality changes:

* <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fR36-R55">`src/promptflow/promptflow/executor/_async_nodes_scheduler.py`</a>: Added functionality to execute synchronous tools in a separate thread using a thread pool executor in the `AsyncNodesScheduler` class. <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fR36-R55">[1]</a> <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fR75">[2]</a> <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fR6-R18">[3]</a> <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fL66-R124">[4]</a>
* <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69L869-R872">`src/promptflow/promptflow/executor/flow_executor.py`</a>: Modified the condition in the `_traverse_nodes` method of the `FlowExecutor` class to check if all values in the `_tools` dictionary are coroutine functions or if the `PF_USE_ASYNC` environment variable is set to "true". <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69L869-R872">[1]</a> <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69R8">[2]</a>

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
