### PR TITLE
[Connection] Refine workspace connection to require limited permission

### DIFF
--- a/src/promptflow/promptflow/_sdk/operations/_local_azure_connection_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_azure_connection_operations.py
@@ -18,20 +18,27 @@ logger = LoggerFactory.get_logger(name=LOGGER_NAME, verbosity=logging.WARNING)
 class LocalAzureConnectionOperations(TelemetryMixin):
     def __init__(self, connection_provider, **kwargs):
 
-        from promptflow.azure._pf_client import PFClient as PFAzureClient
-
         super().__init__(**kwargs)
-        subscription_id, resource_group, workspace_name = self._extract_workspace(connection_provider)
-        self._pfazure_client = PFAzureClient(
-            # TODO: disable interactive credential when starting as a service
-            credential=self.get_credential(),
-            subscription_id=subscription_id,
-            resource_group_name=resource_group,
-            workspace_name=workspace_name,
-        )
+        self._subscription_id, self._resource_group, self._workspace_name = self._extract_workspace(connection_provider)
+        # Lazy init client as ml_client initialization require workspace read permission
+        self._pfazure_client = None
+        self._credential = self._get_credential()
+
+    def _get_client(self):
+        if self._pfazure_client is None:
+            from promptflow.azure._pf_client import PFClient as PFAzureClient
+
+            self._pfazure_client = PFAzureClient(
+                # TODO: disable interactive credential when starting as a service
+                credential=self._credential,
+                subscription_id=self._subscription_id,
+                resource_group_name=self._resource_group,
+                workspace_name=self._workspace_name,
+            )
+        return self._pfazure_client
 
     @classmethod
-    def get_credential(cls):
+    def _get_credential(cls):
         from azure.identity import DefaultAzureCredential, DeviceCodeCredential
 
         if is_from_cli():
@@ -95,7 +102,7 @@ class LocalAzureConnectionOperations(TelemetryMixin):
             logger.warning(
                 "max_results and all_results are not supported for workspace connection and will be ignored."
             )
-        return self._pfazure_client._connections.list()
+        return self._get_client()._connections.list()
 
     @monitor_operation(activity_name="pf.connections.azure.get", activity_type=ActivityType.PUBLICAPI)
     def get(self, name: str, **kwargs) -> _Connection:
@@ -108,8 +115,14 @@ class LocalAzureConnectionOperations(TelemetryMixin):
         """
         with_secrets = kwargs.get("with_secrets", False)
         if with_secrets:
-            return self._pfazure_client._arm_connections.get(name)
-        return self._pfazure_client._connections.get(name)
+            # Do not use pfazure_client here as it requires workspace read permission
+            # Get secrets from arm only requires workspace listsecrets permission
+            from promptflow.azure.operations._arm_connection_operations import ArmConnectionOperations
+
+            return ArmConnectionOperations._direct_get(
+                name, self._subscription_id, self._resource_group, self._workspace_name, self._credential
+            )
+        return self._get_client()._connections.get(name)
 
     @monitor_operation(activity_name="pf.connections.azure.delete", activity_type=ActivityType.PUBLICAPI)
     def delete(self, name: str) -> None:

--- a/src/promptflow/promptflow/_sdk/operations/_local_azure_connection_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_azure_connection_operations.py
@@ -24,7 +24,8 @@ class LocalAzureConnectionOperations(TelemetryMixin):
         self._pfazure_client = None
         self._credential = self._get_credential()
 
-    def _get_client(self):
+    @property
+    def _client(self):
         if self._pfazure_client is None:
             from promptflow.azure._pf_client import PFClient as PFAzureClient
 
@@ -102,7 +103,7 @@ class LocalAzureConnectionOperations(TelemetryMixin):
             logger.warning(
                 "max_results and all_results are not supported for workspace connection and will be ignored."
             )
-        return self._get_client()._connections.list()
+        return self._client._connections.list()
 
     @monitor_operation(activity_name="pf.connections.azure.get", activity_type=ActivityType.PUBLICAPI)
     def get(self, name: str, **kwargs) -> _Connection:
@@ -122,7 +123,7 @@ class LocalAzureConnectionOperations(TelemetryMixin):
             return ArmConnectionOperations._direct_get(
                 name, self._subscription_id, self._resource_group, self._workspace_name, self._credential
             )
-        return self._get_client()._connections.get(name)
+        return self._client._connections.get(name)
 
     @monitor_operation(activity_name="pf.connections.azure.delete", activity_type=ActivityType.PUBLICAPI)
     def delete(self, name: str) -> None:

--- a/src/promptflow/promptflow/azure/operations/_arm_connection_operations.py
+++ b/src/promptflow/promptflow/azure/operations/_arm_connection_operations.py
@@ -71,7 +71,7 @@ class ArmConnectionOperations(_ScopeDependentOperations):
     @classmethod
     def _direct_get(cls, name, subscription_id, resource_group_name, workspace_name, credential):
         """
-        This method is added for local pf_client with workspace provider to ensure we only requires limited
+        This method is added for local pf_client with workspace provider to ensure we only require limited
         permission(workspace/list secrets). As create azure pf_client requires workspace read permission.
         """
         connection_dict = cls._build_connection_dict(


### PR DESCRIPTION
# Description

When specifying workspace connection provider and get connection with secrets, sdk will call arm, this path does not requires create pf azure client, as pf azure client creation requires workspace read permission.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
