### PR TITLE
[fundamental] Exclude examples/flows/integrations from workflows

### DIFF
--- a/.github/workflows/samples_configuration.yml
+++ b/.github/workflows/samples_configuration.yml
@@ -9,7 +9,7 @@ on:
     - cron: "40 22 * * *" # Every day starting at 6:40 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, examples/*requirements.txt, .github/workflows/samples_configuration.yml ]
+    paths: [ examples/**, examples/*requirements.txt, .github/workflows/samples_configuration.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_flowinpipeline_pipeline.yml
+++ b/.github/workflows/samples_flowinpipeline_pipeline.yml
@@ -9,7 +9,7 @@ on:
     - cron: "28 19 * * *" # Every day starting at 3:28 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_flowinpipeline_pipeline.yml ]
+    paths: [ examples/**, .github/workflows/samples_flowinpipeline_pipeline.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_getstarted_flowasfunction.yml
+++ b/.github/workflows/samples_getstarted_flowasfunction.yml
@@ -9,7 +9,7 @@ on:
     - cron: "17 21 * * *" # Every day starting at 5:17 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_getstarted_flowasfunction.yml ]
+    paths: [ examples/**, .github/workflows/samples_getstarted_flowasfunction.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_getstarted_quickstart.yml
+++ b/.github/workflows/samples_getstarted_quickstart.yml
@@ -9,7 +9,7 @@ on:
     - cron: "55 21 * * *" # Every day starting at 5:55 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_getstarted_quickstart.yml ]
+    paths: [ examples/**, .github/workflows/samples_getstarted_quickstart.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_getstarted_quickstartazure.yml
+++ b/.github/workflows/samples_getstarted_quickstartazure.yml
@@ -9,7 +9,7 @@ on:
     - cron: "24 20 * * *" # Every day starting at 4:24 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_getstarted_quickstartazure.yml ]
+    paths: [ examples/**, .github/workflows/samples_getstarted_quickstartazure.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_runmanagement_cloudrunmanagement.yml
+++ b/.github/workflows/samples_runmanagement_cloudrunmanagement.yml
@@ -9,7 +9,7 @@ on:
     - cron: "24 20 * * *" # Every day starting at 4:24 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_runmanagement_cloudrunmanagement.yml ]
+    paths: [ examples/**, .github/workflows/samples_runmanagement_cloudrunmanagement.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_runmanagement_runmanagement.yml
+++ b/.github/workflows/samples_runmanagement_runmanagement.yml
@@ -9,7 +9,7 @@ on:
     - cron: "51 20 * * *" # Every day starting at 4:51 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_runmanagement_runmanagement.yml ]
+    paths: [ examples/**, .github/workflows/samples_runmanagement_runmanagement.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -9,7 +9,7 @@ on:
     - cron: "1 19 * * *" # Every day starting at 3:1 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml ]
+    paths: [ examples/**, .github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -9,7 +9,7 @@ on:
     - cron: "48 20 * * *" # Every day starting at 4:48 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml ]
+    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -9,7 +9,7 @@ on:
     - cron: "59 21 * * *" # Every day starting at 5:59 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml ]
+    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -9,7 +9,7 @@ on:
     - cron: "53 20 * * *" # Every day starting at 4:53 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_docker.yml ]
+    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_docker.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -9,7 +9,7 @@ on:
     - cron: "19 19 * * *" # Every day starting at 3:19 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_kubernetes.yml ]
+    paths: [ examples/**, .github/workflows/samples_tutorials_flow_deploy_kubernetes.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -9,7 +9,7 @@ on:
     - cron: "15 19 * * *" # Every day starting at 3:15 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, .github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml ]
+    paths: [ examples/**, .github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml, '!examples/flow/integrations/**' ]
   workflow_dispatch:
 
 env:

--- a/scripts/readme/workflow_generator.py
+++ b/scripts/readme/workflow_generator.py
@@ -58,7 +58,7 @@ def write_notebook_workflow(notebook, name, output_telemetry=Telemetry()):
     schedule_hour = (name_hash // 60) % 4 + 19  # 19-22 UTC
 
     if "tutorials" in gh_working_dir:
-        path_filter = f"[ examples/**, .github/workflows/{workflow_name}.yml ]"
+        path_filter = f"[ examples/**, .github/workflows/{workflow_name}.yml, '!examples/flow/integrations/**' ]"
     else:
         path_filter = f"[ {gh_working_dir}/**, examples/*requirements.txt, .github/workflows/{workflow_name}.yml ]"
 


### PR DESCRIPTION
# Description

`examples/flows/integrations` folder tagrtes to be 3P contributed examples folder, we shouldn't apply workflow covering this.

- Updated all existing workflows, triggered/founded in #1097 
- Update the workflow generator

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
