### PR TITLE
[promptflow] Add raise_on_error for stream run API

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `pfazure flow show/list` to show or list flows from Azure AI.
 - Display node status in run visualize page graph view.
 - Add support for image input and output in prompt flow.
+- Add `raise_on_error` for stream run API, by default we raise.
 
 ### Bugs Fixed
 

--- a/src/promptflow/promptflow/_sdk/_pf_client.py
+++ b/src/promptflow/promptflow/_sdk/_pf_client.py
@@ -125,15 +125,17 @@ class PFClient:
         )
         return self.runs.create_or_update(run=run, **kwargs)
 
-    def stream(self, run: Union[str, Run]) -> Run:
+    def stream(self, run: Union[str, Run], raise_on_error: bool = True) -> Run:
         """Stream run logs to the console.
 
         :param run: Run object or name of the run.
         :type run: Union[str, ~promptflow.sdk.entities.Run]
+        :param raise_on_error: Raises an exception if an error is encountered. By default we raise.
+        :type raise_on_error: bool
         :return: flow run info.
         :rtype: ~promptflow.sdk.entities.Run
         """
-        return self.runs.stream(run)
+        return self.runs.stream(run, raise_on_error=raise_on_error)
 
     def get_details(
         self, run: Union[str, Run], max_results: int = MAX_SHOW_DETAILS_RESULTS, all_results: bool = False

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -153,7 +153,7 @@ class RunOperations(TelemetryMixin):
             if raise_on_error:
                 raise e
             else:
-                error_message = f"Got internal error when streaming run {name!r}: {str(e)}"
+                error_message = f"Got internal error when streaming run: {str(e)}"
                 print_red_error(error_message)
 
     @monitor_operation(activity_name="pf.runs.archive", activity_type=ActivityType.PUBLICAPI)

--- a/src/promptflow/promptflow/azure/_pf_client.py
+++ b/src/promptflow/promptflow/azure/_pf_client.py
@@ -257,16 +257,18 @@ class PFClient:
         )
         return self.runs.create_or_update(run=run, **kwargs)
 
-    def stream(self, run: Union[str, Run]) -> Run:
+    def stream(self, run: Union[str, Run], raise_on_error: bool = True) -> Run:
         """Stream run logs to the console.
 
         :param run: Run object or name of the run.
         :type run: Union[str, ~promptflow.sdk.entities.Run]
+        :param raise_on_error: Raises an exception if an error is encountered. By default we raise.
+        :type raise_on_error: bool
         :return: flow run info.
         """
         if isinstance(run, Run):
             run = run.name
-        return self.runs.stream(run)
+        return self.runs.stream(run, raise_on_error=raise_on_error)
 
     def get_details(
         self, run: Union[str, Run], max_results: int = MAX_SHOW_DETAILS_RESULTS, all_results: bool = False

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_pf_client_azure.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_pf_client_azure.py
@@ -1,6 +1,6 @@
 import pytest
 
-from promptflow._sdk._errors import RunOperationParameterError
+from promptflow._sdk._errors import InvalidRunError, RunOperationParameterError
 from promptflow.azure import PFClient
 
 
@@ -47,3 +47,14 @@ class TestPFClientAzure:
                 resource_group="fake_resource_group",
                 workspace_name="fake_workspace_name",
             )
+
+    def test_stream_raise_on_error(self, pf: PFClient, capfd: pytest.CaptureFixture) -> None:
+        name = dict()  # use a dict to trigger exception
+        # raise_on_error=True (by default), raise exception
+        with pytest.raises(InvalidRunError):
+            pf.stream(run=name)
+        # raise_on_error=False, error message printed
+        pf.stream(run=name, raise_on_error=False)
+        out, _ = capfd.readouterr()
+        assert "Got internal error when streaming run" in out
+        assert "expected 'str' or 'Run' object but got <class 'dict'>." in out

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -942,13 +942,3 @@ class TestFlowRun:
             assert Path(input_image_path).is_absolute()
             output_image_path = details["outputs.output"][i]["data:image/png;path"]
             assert Path(output_image_path).is_absolute()
-
-    def test_stream_raise_on_error(self, pf: PFClient, capfd: pytest.CaptureFixture) -> None:
-        name = str(uuid.uuid4())
-        # raise_on_error=True (by default), raise exception
-        with pytest.raises(RunNotFoundError):
-            pf.stream(run=name)
-        # raise_on_error=False, error message printed
-        pf.stream(run=name, raise_on_error=False)
-        out, _ = capfd.readouterr()
-        assert f"Got internal error when streaming run {name!r}: Run name {name!r} cannot be found." in out

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -942,3 +942,13 @@ class TestFlowRun:
             assert Path(input_image_path).is_absolute()
             output_image_path = details["outputs.output"][i]["data:image/png;path"]
             assert Path(output_image_path).is_absolute()
+
+    def test_stream_raise_on_error(self, pf: PFClient, capfd: pytest.CaptureFixture) -> None:
+        name = str(uuid.uuid4())
+        # raise_on_error=True (by default), raise exception
+        with pytest.raises(RunNotFoundError):
+            pf.stream(run=name)
+        # raise_on_error=False, error message printed
+        pf.stream(run=name, raise_on_error=False)
+        out, _ = capfd.readouterr()
+        assert f"Got internal error when streaming run {name!r}: Run name {name!r} cannot be found." in out


### PR DESCRIPTION
# Description

Add parameter `raise_on_error` for `pf.stream`, by default we raise.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
