### PR TITLE
[promptflow][fundamental] Exclude PF Azure test from current sdk-cli-test workflow

### DIFF
--- a/.github/workflows/promptflow-sdk-cli-test.yml
+++ b/.github/workflows/promptflow-sdk-cli-test.yml
@@ -79,7 +79,7 @@ jobs:
         az account show
         python "../../scripts/building/run_coverage_tests.py" `
           -p promptflow `
-          -t ${{ github.workspace }}/src/promptflow/tests/sdk_cli_azure_test ${{ github.workspace }}/src/promptflow/tests/sdk_cli_test `
+          -t ${{ github.workspace }}/src/promptflow/tests/sdk_cli_test `
           -l eastus `
           -m "unittest or e2etest" `
           -n ${{ steps.cpu-cores.outputs.count }} `


### PR DESCRIPTION
# Description

Exclude `sdk_cli_azure_test` from `sdk-cli-test` workflow, as we have replay tests and daily live test to cover.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
