### PR TITLE
[promptflow][fundamental] Loose path for CI workflows

### DIFF
--- a/.github/workflows/promptflow-executor-e2e-test.yml
+++ b/.github/workflows/promptflow-executor-e2e-test.yml
@@ -5,8 +5,8 @@ on:
   pull_request_target:
     paths:
       - src/promptflow/**
-      - scripts/**
-      - '**promptflow-executor-e2e-test.yml'
+      - scripts/building/**
+      - .github/workflows/promptflow-executor-e2e-test.yml
   workflow_dispatch:
 env:
   packageSetupType: promptflow_with_extra

--- a/.github/workflows/promptflow-executor-unit-test.yml
+++ b/.github/workflows/promptflow-executor-unit-test.yml
@@ -5,8 +5,8 @@ on:
   pull_request_target:
     paths:
       - src/promptflow/**
-      - scripts/**
-      - '**promptflow-executor-unit-test.yml'
+      - scripts/building/**
+      - .github/workflows/promptflow-executor-unit-test.yml
   workflow_dispatch:
 env:
   packageSetupType: promptflow_with_extra

--- a/.github/workflows/promptflow-global-config-test.yml
+++ b/.github/workflows/promptflow-global-config-test.yml
@@ -5,8 +5,8 @@ on:
   pull_request_target:
     paths:
       - src/promptflow/**
-      - scripts/**
-      - '**promptflow-global-config-test.yml'
+      - scripts/building/**
+      - .github/workflows/promptflow-global-config-test.yml
   workflow_dispatch:
 env:
   packageSetupType: promptflow_with_extra

--- a/.github/workflows/promptflow-replay-test.yml
+++ b/.github/workflows/promptflow-replay-test.yml
@@ -3,8 +3,7 @@ on:
   pull_request:
     paths:
       - src/promptflow/**
-      - scripts/building/run_coverage_tests.py
-      - scripts/building/utils.py
+      - scripts/building/**
       - .github/workflows/promptflow-replay-test.yml
   workflow_dispatch:
 env:

--- a/.github/workflows/promptflow-sdk-cli-test.yml
+++ b/.github/workflows/promptflow-sdk-cli-test.yml
@@ -5,8 +5,8 @@ on:
   pull_request_target:
     paths:
       - src/promptflow/**
-      - scripts/**
-      - '**promptflow-sdk-cli-test.yml'
+      - scripts/building/**
+      - .github/workflows/promptflow-sdk-cli-test.yml
   workflow_dispatch:
 env:
   packageSetupType: promptflow_with_extra

--- a/.github/workflows/promptflow-sdk-pfs-e2e-test.yml
+++ b/.github/workflows/promptflow-sdk-pfs-e2e-test.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - src/promptflow/**
-      - scripts/**
+      - scripts/building/**
       - .github/workflows/promptflow-sdk-pfs-e2e-test.yml
 
   workflow_dispatch:

--- a/.github/workflows/sdk-cli-azure-test.yml
+++ b/.github/workflows/sdk-cli-azure-test.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
     paths:
       - src/promptflow/**
-      - scripts/building/run_coverage_tests.py
+      - scripts/building/**
       - .github/workflows/promptflow-sdk-cli-azure-test.yml
 
   schedule:


### PR DESCRIPTION
# Description

This PR updates listen path for several workflows triggered during PR:

- `scripts/**` to `scripts/building/**`
- use abs path for workflow YAML file

So that we won't trigger many workflows when update `scripts` folder.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
