### PR TITLE
Raise user error for non literal value for init parameter

### DIFF
--- a/src/promptflow/promptflow/_core/_errors.py
+++ b/src/promptflow/promptflow/_core/_errors.py
@@ -1,6 +1,6 @@
 from traceback import TracebackException
 
-from promptflow._utils.exception_utils import ADDITIONAL_INFO_USER_EXECUTION_ERROR, last_frame_info, is_pf_core_frame
+from promptflow._utils.exception_utils import ADDITIONAL_INFO_USER_EXECUTION_ERROR, is_pf_core_frame, last_frame_info
 from promptflow.exceptions import ErrorTarget, SystemErrorException, UserErrorException, ValidationException
 
 
@@ -25,6 +25,10 @@ class PackageToolNotFoundError(ValidationException):
 
 
 class MissingRequiredInputs(ValidationException):
+    pass
+
+
+class InputTypeMismatch(ValidationException):
     pass
 
 
@@ -136,4 +140,5 @@ class ProcessPoolError(SystemErrorException):
 
 class DuplicateToolMappingError(ValidationException):
     """Exception raised when multiple tools are linked to the same deprecated tool id."""
+
     pass

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -282,9 +282,8 @@ class BuiltinsManager:
             if v.value_type != InputValueType.LITERAL:
                 raise InputTypeMismatch(
                     message_format=(
-                        "The input for flow is incorrect. The tool '{tool_name}' requires a literal value for "
-                        "the input '{input_name}', however, a value '{input_value}' was provided which is not a "
-                        "literal value. Please provide a literal value for '{input_name}' to correct this issue."
+                        "Invalid input for '{tool_name}': Initialization input '{input_name}' requires a literal "
+                        "value, but {input_value} was received."
                     ),
                     tool_name=tool_name,
                     input_name=k,

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -296,8 +296,7 @@ class TestBuiltinsManager:
         with pytest.raises(InputTypeMismatch) as ex:
             BuiltinsManager._load_tool_from_module(module, tool_name, module_name, class_name, method_name, node_inputs)
         expected_message = (
-            "The input for flow is incorrect. The tool 'test_tool' requires a literal value for the input 'input1', "
-            "however, a value '${flow.value1}' was provided which is not a literal value. "
-            "Please provide a literal value for 'input1' to correct this issue."
+            "Invalid input for 'test_tool': Initialization input 'input1' requires a literal value, "
+            "but ${flow.value1} was received."
         )
         assert expected_message == str(ex.value)

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -3,18 +3,20 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from mock import MagicMock
 from ruamel.yaml import YAML
 
 from promptflow import tool
-from promptflow._core._errors import NotSupported, PackageToolNotFoundError
+from promptflow._core._errors import InputTypeMismatch, NotSupported, PackageToolNotFoundError
 from promptflow._core.tools_manager import (
+    BuiltinsManager,
     NodeSourcePathEmpty,
     ToolLoader,
     collect_package_tools,
     collect_package_tools_and_connections,
     gen_tool_by_source,
 )
-from promptflow.contracts.flow import Node, ToolSource, ToolSourceType
+from promptflow.contracts.flow import InputAssignment, InputValueType, Node, ToolSource, ToolSourceType
 from promptflow.contracts.tool import Tool, ToolType
 from promptflow.exceptions import UserErrorException
 
@@ -83,9 +85,11 @@ class TestToolLoader:
     def test_load_tool_for_package_node_with_legacy_tool_id(self, mocker):
         package_tools = {
             "new_tool_1": Tool(
-                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_1"]).serialize(),
+                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_1"]
+            ).serialize(),
             "new_tool_2": Tool(
-                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_2"]).serialize(),
+                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_2"]
+            ).serialize(),
             "old_tool_2": Tool(name="old tool 2", type=ToolType.PYTHON, inputs={}).serialize(),
         }
         mocker.patch("promptflow._core.tools_manager.collect_package_tools", return_value=package_tools)
@@ -168,9 +172,7 @@ class TestToolsManager:
 
     @pytest.mark.skip(reason="enable this test after the tool is ready")
     def test_collect_package_tools_if_node_source_tool_is_legacy(self):
-        legacy_node_source_tools = [
-            "content_safety_text.tools.content_safety_text_tool.analyze_text"
-        ]
+        legacy_node_source_tools = ["content_safety_text.tools.content_safety_text_tool.analyze_text"]
         package_tools = collect_package_tools(legacy_node_source_tools)
         assert "promptflow.tools.azure_content_safety.analyze_text" in package_tools.keys()
 
@@ -249,3 +251,53 @@ class TestToolsManager:
         with patch("promptflow._cli._utils.get_workspace_triad_from_local", return_value=mocked_ws_triple):
             result = _gen_dynamic_list({"func_path": func_path, "func_kwargs": func_kwargs})
             assert len(result) == 2
+
+
+@pytest.mark.unittest
+class TestBuiltinsManager:
+    def test_load_tool_from_module(
+        self,
+    ):
+        # Test case 1: When class_name is None
+        module = MagicMock()
+        tool_name = "test_tool"
+        module_name = "test_module"
+        class_name = None
+        method_name = "test_method"
+        node_inputs = {"input1": InputAssignment(value_type=InputValueType.LITERAL, value="value1")}
+
+        # Mock the behavior of the module and class
+        module.test_method = MagicMock()
+
+        # Call the method
+        api, init_inputs = BuiltinsManager._load_tool_from_module(
+            module, tool_name, module_name, class_name, method_name, node_inputs
+        )
+
+        # Assertions
+        assert api == module.test_method
+        assert init_inputs == {}
+
+        # Non literal input for init parameter will raise exception.
+        module = MagicMock()
+        tool_name = "test_tool"
+        module_name = "test_module"
+        class_name = "TestClass"
+        method_name = "test_method"
+        node_inputs = {"input1": InputAssignment(value_type=InputValueType.FLOW_INPUT, value="value1")}
+
+        # Mock the behavior of the module and class
+        module.TestClass = MagicMock()
+        module.TestClass.get_initialize_inputs = MagicMock(return_value=["input1"])
+        module.TestClass.get_required_initialize_inputs = MagicMock(return_value=["input1"])
+        module.TestClass.test_method = MagicMock()
+
+        # Call the method
+        with pytest.raises(InputTypeMismatch) as ex:
+            BuiltinsManager._load_tool_from_module(module, tool_name, module_name, class_name, method_name, node_inputs)
+        expected_message = (
+            "The input for flow is incorrect. The tool 'test_tool' requires a literal value for the input 'input1', "
+            "however, a value '${flow.value1}' was provided which is not a literal value. "
+            "Please provide a literal value for 'input1' to correct this issue."
+        )
+        assert expected_message == str(ex.value)


### PR DESCRIPTION
# Description

For tool's **init parameter**, we only accept literal value. (Flow input or node reference should not be used)
Change error type to user error and improve error message.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
