### PR TITLE
Add `batch_run_source` property to `OperationContext` for better batch run source insight

### DIFF
--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -1,10 +1,12 @@
 import asyncio
 import uuid
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 from promptflow._constants import LINE_NUMBER_KEY
 from promptflow._core._errors import UnexpectedError
+from promptflow._core.operation_context import OperationContext
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.execution_utils import (
     apply_default_value_for_input,
@@ -25,6 +27,11 @@ from promptflow.executor.flow_validator import FlowValidator
 from promptflow.storage._run_storage import AbstractRunStorage
 
 OUTPUT_FILE_NAME = "output.jsonl"
+
+
+class BatchRunSource(Enum):
+    Data = "Data"
+    Run = "Run"
 
 
 class BatchEngine:
@@ -95,6 +102,10 @@ class BatchEngine:
         :return: The result of this batch run
         :rtype: ~promptflow.executor._result.BatchResult
         """
+        # set operation context batch run source property
+        OperationContext.get_instance().batch_run_source = (
+            BatchRunSource.Run.name if "run.outputs" in input_dirs else BatchRunSource.Data.name
+        )
         # resolve input data from input dirs and apply inputs mapping
         batch_input_processor = BatchInputsProcessor(self._working_dir, self._flow.inputs, max_lines_count)
         batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -102,7 +102,10 @@ class BatchEngine:
         :return: The result of this batch run
         :rtype: ~promptflow.executor._result.BatchResult
         """
-        # set operation context batch run source property
+        # Add property on operation context to indicate batch run source, which is used to differentiate the input
+        # source of a batch run. The batch run source can be either "Data" or "Run".
+        # If the input source is "Data", it means the input data is provided by the user.
+        # If the input source is "Run", it means the input data is provided by a previous run.
         OperationContext.get_instance().batch_run_source = (
             BatchRunSource.Run.name if "run.outputs" in input_dirs else BatchRunSource.Data.name
         )


### PR DESCRIPTION
# Description

This PR introduces a new property `batch_run_source` to the `OperationContext` to better differentiate the data source for batch runs. A new Enum class `BatchRunSource` with two enums `Run` and `Data` has been defined. The `run` interface of the `BatchEngine` object now checks the `input_dirs` parameter to determine if the batch run is sourced from a previous run or raw data. If `run.outputs` is present in `input_dirs`, the `batch_run_source` is set to `BatchRunSource.Run`, otherwise, it is set to `BatchRunSource.Data`. This enhancement facilitates improved tracking and handling of batch run sources.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
