### PR TITLE
Improve image test case

### DIFF
--- a/src/promptflow/tests/test_configs/flows/chat_flow_with_image/mock_chat.py
+++ b/src/promptflow/tests/test_configs/flows/chat_flow_with_image/mock_chat.py
@@ -12,6 +12,7 @@ def mock_chat(chat_history: list, question: list):
     for item in question:
         if isinstance(item, Image):
             res.append(item)
+    res.append("text response")
     return res
 
 


### PR DESCRIPTION
# Description

Add plain text in chat response.
Refine assert logic in test code, `assert_contain_image_reference` can't raise exception when there doesn't exist image.
_If there is no image reference, say just strings in a list. The method will not raise exception_
![image](https://github.com/microsoft/promptflow/assets/17527303/b7d81866-6feb-42c4-9ef9-183925325336)

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
