### PR TITLE
Introduce Interface for Batch Input Source Inference on OperationContext 

### DIFF
--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -125,7 +125,7 @@ class OperationContext(Dict):
             self.user_agent = user_agent
 
     def set_batch_input_source_from_inputs_mapping(self, inputs_mapping: Mapping[str, str]):
-        """Set the batch input source from the input mapping and set it in the OperationContext instance.
+        """Infer the batch input source from the input mapping and set it in the OperationContext instance.
 
         This method analyzes the `inputs_mapping` to ascertain the origin of the inputs for a batch operation.
         The `inputs_mapping` should be a dictionary with keys representing input names and values specifying the sources
@@ -159,11 +159,12 @@ class OperationContext(Dict):
         Returns:
             None
         """
-        self.batch_input_source = "Data"
         if inputs_mapping and any(
             isinstance(value, str) and value.startswith("${run.outputs") for value in inputs_mapping.values()
         ):
             self.batch_input_source = "Run"
+        else:
+            self.batch_input_source = "Data"
 
     def get_context_dict(self):
         """Get the context dictionary.

--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -124,8 +124,8 @@ class OperationContext(Dict):
         else:
             self.user_agent = user_agent
 
-    def infer_batch_input_source_from_inputs_mapping(self, inputs_mapping: Mapping[str, str]):
-        """Infer the batch input source from the input mapping and set it in the OperationContext instance.
+    def set_batch_input_source_from_inputs_mapping(self, inputs_mapping: Mapping[str, str]):
+        """Set the batch input source from the input mapping and set it in the OperationContext instance.
 
         This method analyzes the `inputs_mapping` to ascertain the origin of the inputs for a batch operation.
         The `inputs_mapping` should be a dictionary with keys representing input names and values specifying the sources
@@ -160,7 +160,9 @@ class OperationContext(Dict):
             None
         """
         self.batch_input_source = "Data"
-        if inputs_mapping and any(value.startswith("${run.outputs") for value in inputs_mapping.values()):
+        if inputs_mapping and any(
+            isinstance(value, str) and value.startswith("${run.outputs") for value in inputs_mapping.values()
+        ):
             self.batch_input_source = "Run"
 
     def get_context_dict(self):

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -1,13 +1,11 @@
 import asyncio
 import uuid
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 from promptflow._constants import LINE_NUMBER_KEY
 from promptflow._core._errors import UnexpectedError
-from promptflow._core.operation_context import OperationContext
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.execution_utils import (
     apply_default_value_for_input,
@@ -29,11 +27,6 @@ from promptflow.executor.flow_validator import FlowValidator
 from promptflow.storage._run_storage import AbstractRunStorage
 
 OUTPUT_FILE_NAME = "output.jsonl"
-
-
-class BatchRunSource(Enum):
-    Data = "Data"
-    Run = "Run"
 
 
 class BatchEngine:
@@ -105,13 +98,6 @@ class BatchEngine:
         :rtype: ~promptflow.batch._result.BatchResult
         """
         self._start_time = datetime.utcnow()
-        # Add property on operation context to indicate batch run source, which is used to differentiate the input
-        # source of a batch run. The batch run source can be either "Data" or "Run".
-        # If the input source is "Data", it means the input data is provided by the user.
-        # If the input source is "Run", it means the input data is provided by a previous run.
-        OperationContext.get_instance().batch_run_source = (
-            BatchRunSource.Run.name if "run.outputs" in input_dirs else BatchRunSource.Data.name
-        )
         # resolve input data from input dirs and apply inputs mapping
         batch_input_processor = BatchInputsProcessor(self._working_dir, self._flow.inputs, max_lines_count)
         batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -100,7 +100,7 @@ class BatchEngine:
         """
         self._start_time = datetime.utcnow()
         # infer batch input source from input mapping
-        OperationContext.get_instance().infer_batch_input_source_from_input_mapping(inputs_mapping)
+        OperationContext.get_instance().infer_batch_input_source_from_inputs_mapping(inputs_mapping)
         # resolve input data from input dirs and apply inputs mapping
         batch_input_processor = BatchInputsProcessor(self._working_dir, self._flow.inputs, max_lines_count)
         batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -99,8 +99,8 @@ class BatchEngine:
         :rtype: ~promptflow.batch._result.BatchResult
         """
         self._start_time = datetime.utcnow()
-        # infer batch input source from input mapping
-        OperationContext.get_instance().infer_batch_input_source_from_inputs_mapping(inputs_mapping)
+        # set batch input source from input mapping
+        OperationContext.get_instance().set_batch_input_source_from_inputs_mapping(inputs_mapping)
         # resolve input data from input dirs and apply inputs mapping
         batch_input_processor = BatchInputsProcessor(self._working_dir, self._flow.inputs, max_lines_count)
         batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -1,11 +1,13 @@
 import asyncio
 import uuid
 from datetime import datetime
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 from promptflow._constants import LINE_NUMBER_KEY
 from promptflow._core._errors import UnexpectedError
+from promptflow._core.operation_context import OperationContext
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.execution_utils import (
     apply_default_value_for_input,
@@ -27,6 +29,11 @@ from promptflow.executor.flow_validator import FlowValidator
 from promptflow.storage._run_storage import AbstractRunStorage
 
 OUTPUT_FILE_NAME = "output.jsonl"
+
+
+class BatchRunSource(Enum):
+    Data = "Data"
+    Run = "Run"
 
 
 class BatchEngine:
@@ -98,6 +105,13 @@ class BatchEngine:
         :rtype: ~promptflow.batch._result.BatchResult
         """
         self._start_time = datetime.utcnow()
+        # Add property on operation context to indicate batch run source, which is used to differentiate the input
+        # source of a batch run. The batch run source can be either "Data" or "Run".
+        # If the input source is "Data", it means the input data is provided by the user.
+        # If the input source is "Run", it means the input data is provided by a previous run.
+        OperationContext.get_instance().batch_run_source = (
+            BatchRunSource.Run.name if "run.outputs" in input_dirs else BatchRunSource.Data.name
+        )
         # resolve input data from input dirs and apply inputs mapping
         batch_input_processor = BatchInputsProcessor(self._working_dir, self._flow.inputs, max_lines_count)
         batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -1,7 +1,6 @@
 import asyncio
 import uuid
 from datetime import datetime
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -29,11 +28,6 @@ from promptflow.executor.flow_validator import FlowValidator
 from promptflow.storage._run_storage import AbstractRunStorage
 
 OUTPUT_FILE_NAME = "output.jsonl"
-
-
-class BatchRunSource(Enum):
-    Data = "Data"
-    Run = "Run"
 
 
 class BatchEngine:

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -105,13 +105,8 @@ class BatchEngine:
         :rtype: ~promptflow.batch._result.BatchResult
         """
         self._start_time = datetime.utcnow()
-        # Add property on operation context to indicate batch run source, which is used to differentiate the input
-        # source of a batch run. The batch run source can be either "Data" or "Run".
-        # If the input source is "Data", it means the input data is provided by the user.
-        # If the input source is "Run", it means the input data is provided by a previous run.
-        OperationContext.get_instance().batch_run_source = (
-            BatchRunSource.Run.name if "run.outputs" in input_dirs else BatchRunSource.Data.name
-        )
+        # infer batch input source from input mapping
+        OperationContext.get_instance().infer_batch_input_source_from_input_mapping(inputs_mapping)
         # resolve input data from input dirs and apply inputs mapping
         batch_input_processor = BatchInputsProcessor(self._working_dir, self._flow.inputs, max_lines_count)
         batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -3,26 +3,17 @@
 # ---------------------------------------------------------
 
 import re
-from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 from promptflow._constants import LINE_NUMBER_KEY
 from promptflow._core._errors import UnexpectedError
-from promptflow._core.operation_context import OperationContext
 from promptflow._utils.load_data import load_data
 from promptflow._utils.logger_utils import logger
 from promptflow._utils.multimedia_utils import resolve_multimedia_data_recursively
 from promptflow._utils.utils import resolve_dir_to_absolute
 from promptflow.batch._errors import EmptyInputsData, InputMappingError
 from promptflow.contracts.flow import FlowInputDefinition
-
-
-class InputSource(Enum):
-    """The source of the input."""
-
-    UserProvided = "UserProvided"
-    PreviousRun = "PreviousRun"
 
 
 class BatchInputsProcessor:
@@ -269,10 +260,6 @@ def apply_inputs_mapping(
     """
     result = {}
     notfound_mapping_relations = []
-    # Add property on operation context, which is used to differentiate the input source of a run.
-    # Set input source to user provided by default.
-    operation_context = OperationContext.get_instance()
-    operation_context.input_source = InputSource.UserProvided.name
     for map_to_key, map_value in inputs_mapping.items():
         # Ignore reserved key configuration from input mapping.
         if map_to_key == LINE_NUMBER_KEY:
@@ -280,9 +267,6 @@ def apply_inputs_mapping(
         if not isinstance(map_value, str):  # All non-string values are literal values.
             result[map_to_key] = map_value
             continue
-        # If map_value is a previous run output, set input source to previous run.
-        if map_value.startswith("${run.outputs"):
-            operation_context.input_source = InputSource.PreviousRun.name
         match = re.search(r"^\${([^{}]+)}$", map_value)
         if match is not None:
             pattern = match.group(1)

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -3,17 +3,26 @@
 # ---------------------------------------------------------
 
 import re
+from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
 from promptflow._constants import LINE_NUMBER_KEY
 from promptflow._core._errors import UnexpectedError
+from promptflow._core.operation_context import OperationContext
 from promptflow._utils.load_data import load_data
 from promptflow._utils.logger_utils import logger
 from promptflow._utils.multimedia_utils import resolve_multimedia_data_recursively
 from promptflow._utils.utils import resolve_dir_to_absolute
 from promptflow.batch._errors import EmptyInputsData, InputMappingError
 from promptflow.contracts.flow import FlowInputDefinition
+
+
+class InputSource(Enum):
+    """The source of the input."""
+
+    UserProvided = "UserProvided"
+    PreviousRun = "PreviousRun"
 
 
 class BatchInputsProcessor:
@@ -260,6 +269,10 @@ def apply_inputs_mapping(
     """
     result = {}
     notfound_mapping_relations = []
+    # Add property on operation context, which is used to differentiate the input source of a run.
+    # Set input source to user provided by default.
+    operation_context = OperationContext.get_instance()
+    operation_context.input_source = InputSource.UserProvided.name
     for map_to_key, map_value in inputs_mapping.items():
         # Ignore reserved key configuration from input mapping.
         if map_to_key == LINE_NUMBER_KEY:
@@ -267,6 +280,9 @@ def apply_inputs_mapping(
         if not isinstance(map_value, str):  # All non-string values are literal values.
             result[map_to_key] = map_value
             continue
+        # If map_value is a previous run output, set input source to previous run.
+        if map_value.startswith("${run.outputs"):
+            operation_context.input_source = InputSource.PreviousRun.name
         match = re.search(r"^\${([^{}]+)}$", map_value)
         if match is not None:
             pattern = match.group(1)

--- a/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
@@ -100,6 +100,24 @@ class TestOperationContext:
         context2 = OperationContext.get_instance()
         assert context1 is context2
 
+    def test_infer_batch_input_source_from_input_mapping_run(self):
+        input_mapping = {"input1": "${run.outputs.output1}", "input2": "${run.outputs.output2}"}
+        context = OperationContext()
+        context.infer_batch_input_source_from_input_mapping(input_mapping)
+        assert context.batch_input_source == "Run"
+
+    def test_infer_batch_input_source_from_input_mapping_data(self):
+        input_mapping = {"url": "${data.url}"}
+        context = OperationContext()
+        context.infer_batch_input_source_from_input_mapping(input_mapping)
+        assert context.batch_input_source == "Data"
+
+    def test_infer_batch_input_source_from_input_mapping_none(self):
+        input_mapping = None
+        context = OperationContext()
+        context.infer_batch_input_source_from_input_mapping(input_mapping)
+        assert not hasattr(self.context, "batch_input_source")
+
     def test_different_thread_have_different_instance(self):
         # create a list to store the OperationContext instances from each thread
         instances = []

--- a/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
@@ -100,22 +100,28 @@ class TestOperationContext:
         context2 = OperationContext.get_instance()
         assert context1 is context2
 
-    def test_infer_batch_input_source_from_input_mapping_run(self):
+    def test_infer_batch_input_source_from_inputs_mapping_run(self):
         input_mapping = {"input1": "${run.outputs.output1}", "input2": "${run.outputs.output2}"}
         context = OperationContext()
-        context.infer_batch_input_source_from_input_mapping(input_mapping)
+        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
         assert context.batch_input_source == "Run"
 
-    def test_infer_batch_input_source_from_input_mapping_data(self):
+    def test_infer_batch_input_source_from_inputs_mapping_data(self):
         input_mapping = {"url": "${data.url}"}
         context = OperationContext()
-        context.infer_batch_input_source_from_input_mapping(input_mapping)
+        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
         assert context.batch_input_source == "Data"
 
-    def test_infer_batch_input_source_from_input_mapping_none(self):
+    def test_infer_batch_input_source_from_inputs_mapping_none(self):
         input_mapping = None
         context = OperationContext()
-        context.infer_batch_input_source_from_input_mapping(input_mapping)
+        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        assert not hasattr(context, "batch_input_source")
+
+    def test_infer_batch_input_source_from_inputs_mapping_empty(self):
+        input_mapping = {}
+        context = OperationContext()
+        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
         assert not hasattr(context, "batch_input_source")
 
     def test_different_thread_have_different_instance(self):

--- a/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
@@ -100,30 +100,30 @@ class TestOperationContext:
         context2 = OperationContext.get_instance()
         assert context1 is context2
 
-    def test_infer_batch_input_source_from_inputs_mapping_run(self):
+    def test_set_batch_input_source_from_inputs_mapping_run(self):
         input_mapping = {"input1": "${run.outputs.output1}", "input2": "${run.outputs.output2}"}
         context = OperationContext()
-        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        context.set_batch_input_source_from_inputs_mapping(input_mapping)
         assert context.batch_input_source == "Run"
 
-    def test_infer_batch_input_source_from_inputs_mapping_data(self):
+    def test_set_batch_input_source_from_inputs_mapping_data(self):
         input_mapping = {"url": "${data.url}"}
         context = OperationContext()
-        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        context.set_batch_input_source_from_inputs_mapping(input_mapping)
         assert context.batch_input_source == "Data"
 
-    def test_infer_batch_input_source_from_inputs_mapping_none(self):
+    def test_set_batch_input_source_from_inputs_mapping_none(self):
         input_mapping = None
         context = OperationContext()
         assert not hasattr(context, "batch_input_source")
-        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        context.set_batch_input_source_from_inputs_mapping(input_mapping)
         assert context.batch_input_source == "Data"
 
-    def test_infer_batch_input_source_from_inputs_mapping_empty(self):
+    def test_set_batch_input_source_from_inputs_mapping_empty(self):
         input_mapping = {}
         context = OperationContext()
         assert not hasattr(context, "batch_input_source")
-        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        context.set_batch_input_source_from_inputs_mapping(input_mapping)
         assert context.batch_input_source == "Data"
 
     def test_different_thread_have_different_instance(self):

--- a/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
@@ -116,7 +116,7 @@ class TestOperationContext:
         input_mapping = None
         context = OperationContext()
         context.infer_batch_input_source_from_input_mapping(input_mapping)
-        assert not hasattr(self.context, "batch_input_source")
+        assert not hasattr(context, "batch_input_source")
 
     def test_different_thread_have_different_instance(self):
         # create a list to store the OperationContext instances from each thread

--- a/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
@@ -115,14 +115,16 @@ class TestOperationContext:
     def test_infer_batch_input_source_from_inputs_mapping_none(self):
         input_mapping = None
         context = OperationContext()
-        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
         assert not hasattr(context, "batch_input_source")
+        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        assert context.batch_input_source == "Data"
 
     def test_infer_batch_input_source_from_inputs_mapping_empty(self):
         input_mapping = {}
         context = OperationContext()
-        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
         assert not hasattr(context, "batch_input_source")
+        context.infer_batch_input_source_from_inputs_mapping(input_mapping)
+        assert context.batch_input_source == "Data"
 
     def test_different_thread_have_different_instance(self):
         # create a list to store the OperationContext instances from each thread


### PR DESCRIPTION
# Description

This PR introduces a new interface within `OperationContext` to infer the source of batch input through an input mapping dictionary. This dictionary maps each input to its corresponding data source, providing a unified method for external calls and simplifying management of future changes. The interface encapsulates and extends the logic initially implemented in PR #1223, offering a more streamlined approach to handling input source references.  
  
By abstracting this functionality into a dedicated interface, we improve the maintainability and readability of the codebase. This change is intended to allow other components of the system to more easily integrate with the input source inference process without needing to understand the underlying mapping logic.  

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
