### PR TITLE
[PromptFlow] Fix can't raise exception in processpool's run.

### DIFF
--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -379,9 +379,10 @@ class LineExecutionProcessPool:
                     while not async_result.ready():
                         # Check every 1 second
                         async_result.wait(1)
-                    #  If the remote call raised an exception then that exception will be reraised by get().
-                    #  Related link:
-                    #  https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.AsyncResult
+                    # To ensure exceptions in thread-pool calls are propagated to the main process for proper handling
+                    # The exceptions raised will be re-raised by the get() method.
+                    # Related link:
+                    # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.AsyncResult
                     async_result.get()
                 except KeyboardInterrupt:
                     raise

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -380,7 +380,8 @@ class LineExecutionProcessPool:
                         # Check every 1 second
                         async_result.wait(1)
                     #  If the remote call raised an exception then that exception will be reraised by get().
-                    #  Related link: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.AsyncResult
+                    #  Related link:
+                    #  https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.AsyncResult
                     async_result.get()
                 except KeyboardInterrupt:
                     raise

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -379,7 +379,8 @@ class LineExecutionProcessPool:
                     while not async_result.ready():
                         # Check every 1 second
                         async_result.wait(1)
-                    #  Raise exceptions if they are raised.
+                    #  If the remote call raised an exception then that exception will be reraised by get().
+                    #  Related link: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.AsyncResult
                     async_result.get()
                 except KeyboardInterrupt:
                     raise

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -379,6 +379,7 @@ class LineExecutionProcessPool:
                     while not async_result.ready():
                         # Check every 1 second
                         async_result.wait(1)
+                    async_result.get()
                 except KeyboardInterrupt:
                     raise
             except PromptflowException:

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -379,6 +379,7 @@ class LineExecutionProcessPool:
                     while not async_result.ready():
                         # Check every 1 second
                         async_result.wait(1)
+                    #  Raise exceptions if they are raised.
                     async_result.get()
                 except KeyboardInterrupt:
                     raise

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -224,3 +224,38 @@ class TestLineExecutionProcessPool:
         # Not set start method
         context = get_multiprocessing_context()
         assert context.get_start_method() == multiprocessing.get_start_method()
+
+    @pytest.mark.parametrize(
+        "flow_folder",
+        [
+            SAMPLE_FLOW,
+        ],
+    )
+    def test_process_pool_run_with_exception(self, flow_folder, dev_connections, mocker: MockFixture):
+        # mock process pool run execution raise error
+        test_error_msg = "Test user error"
+        mocker.patch(
+            "promptflow.executor._line_execution_process_pool.LineExecutionProcessPool." "_timeout_process_wrapper",
+            side_effect=UserErrorException(message=test_error_msg, target=ErrorTarget.AZURE_RUN_STORAGE),
+        )
+        executor = FlowExecutor.create(
+            get_yaml_file(flow_folder),
+            dev_connections,
+        )
+        run_id = str(uuid.uuid4())
+        bulk_inputs = self.get_bulk_inputs()
+        nlines = len(bulk_inputs)
+        with LineExecutionProcessPool(
+            executor,
+            nlines,
+            run_id,
+            "",
+            False,
+            None,
+        ) as pool:
+            with pytest.raises(UserErrorException) as e:
+                pool.run(zip(range(nlines), bulk_inputs))
+                print(f"eee:{e.value}")
+            assert e.value.message == test_error_msg
+            assert e.value.target == ErrorTarget.AZURE_RUN_STORAGE
+            assert e.value.error_codes[0] == "UserError"

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -255,7 +255,6 @@ class TestLineExecutionProcessPool:
         ) as pool:
             with pytest.raises(UserErrorException) as e:
                 pool.run(zip(range(nlines), bulk_inputs))
-                print(f"eee:{e.value}")
             assert e.value.message == test_error_msg
             assert e.value.target == ErrorTarget.AZURE_RUN_STORAGE
             assert e.value.error_codes[0] == "UserError"


### PR DESCRIPTION
# Description

**Problem**
The wait() method of starmap_async only waits for the result and does not capture exceptions.

**Solution**:
Use async_result.get() to propagate exceptions if they are raised.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
