### PR TITLE
Fix default value apply logic.

### DIFF
--- a/src/promptflow/promptflow/_utils/execution_utils.py
+++ b/src/promptflow/promptflow/_utils/execution_utils.py
@@ -11,7 +11,7 @@ from promptflow.contracts.run_info import FlowRunInfo, Status
 def apply_default_value_for_input(inputs: Dict[str, FlowInputDefinition], line_inputs: Mapping) -> Dict[str, Any]:
     updated_inputs = dict(line_inputs or {})
     for key, value in inputs.items():
-        if key not in updated_inputs and (value and value.default):
+        if key not in updated_inputs and (value and value.default is not None):
             updated_inputs[key] = value.default
     return updated_inputs
 

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -97,7 +97,7 @@ class BatchInputsProcessor:
         # For input has default value, we don't try to read data from default mapping.
         # Default value is in higher priority than default mapping.
         for key, value in self._flow_inputs.items():
-            if value and value.default:
+            if value and value.default is not None:
                 del result_mapping[key]
         result_mapping.update(inputs_mapping)
         return result_mapping

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -582,7 +582,7 @@ class FlowExecutor:
             one_input_value = list(aggregation_inputs.values())[0]
             aggregation_lines = len(one_input_value)
         for key, value in inputs.items():
-            if key not in aggregated_flow_inputs and (value and value.default):
+            if key not in aggregated_flow_inputs and (value and value.default is not None):
                 aggregated_flow_inputs[key] = [value.default] * aggregation_lines
         return aggregated_flow_inputs
 

--- a/src/promptflow/tests/executor/unittests/_utils/test_execution_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_execution_utils.py
@@ -38,6 +38,27 @@ class TestFlowExecutor:
                 {"input_from_default": "input_value", "another_key": "input_value"},
                 {"input_from_default": "input_value", "another_key": "input_value"},
             ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.BOOL, default=False),
+                },
+                {},
+                {"input_from_default": False},
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.LIST, default=[]),
+                },
+                {},
+                {"input_from_default": []},
+            ),
+            (
+                {
+                    "input_from_default": FlowInputDefinition(type=ValueType.OBJECT, default={}),
+                },
+                {},
+                {"input_from_default": {}},
+            ),
         ],
     )
     def test_apply_default_value_for_input(self, flow_inputs, inputs, expected_inputs):

--- a/src/promptflow/tests/executor/unittests/batch/test_batch_inputs_processor.py
+++ b/src/promptflow/tests/executor/unittests/batch/test_batch_inputs_processor.py
@@ -141,7 +141,7 @@ class TestBatchInputsProcessor:
         inputs = {
             "question": None,
             "groundtruth": None,
-            "input_with_default_value": FlowInputDefinition(type=ValueType.INT, default="default_value"),
+            "input_with_default_value": FlowInputDefinition(type=ValueType.BOOL, default=False),
         }
         updated_inputs_mapping = BatchInputsProcessor("", inputs)._complete_inputs_mapping_by_default_value(
             inputs_mapping

--- a/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_flow_executor.py
@@ -57,6 +57,17 @@ class TestFlowExecutor:
             ),
             (
                 {
+                    "input_from_default": FlowInputDefinition(type=ValueType.BOOL, default=False),
+                },
+                {"another_key": ["input_value", "input_value"]},
+                {},
+                {
+                    "input_from_default": [False, False],
+                    "another_key": ["input_value", "input_value"],
+                },
+            ),
+            (
+                {
                     "input_from_default": FlowInputDefinition(type=ValueType.STRING, default="default_value"),
                 },
                 {},

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -837,7 +837,13 @@ class TestFlowRun:
             data=f"{DATAS_DIR}/webClassification1.jsonl",
         )
         inputs = pf.runs._get_inputs(run=run)
-        assert inputs == {"line_number": [0], "question": ["input value from default"]}
+        assert inputs == {
+            "line_number": [0],
+            "input_bool": [False],
+            "input_dict": [{}],
+            "input_list": [[]],
+            "input_str": ["input value from default"],
+        }
 
         # inputs should be persisted when data value are used
         run = pf.run(

--- a/src/promptflow/tests/test_configs/flows/default_input/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/default_input/flow.dag.yaml
@@ -1,8 +1,17 @@
 
 inputs:
-  question:
+  input_str:
     type: string
     default: input value from default
+  input_bool:
+    type: bool
+    default: False
+  input_list:
+    type: list
+    default: []
+  input_dict:
+    type: object
+    default: {}
 outputs:
   output:
     type: string
@@ -14,13 +23,19 @@ nodes:
     type: code
     path: test_print_input.py
   inputs:
-    input: ${inputs.question}
+    input_str: ${inputs.input_str}
+    input_bool: ${inputs.input_bool}
+    input_list: ${inputs.input_list}
+    input_dict: ${inputs.input_dict}
 - name: aggregate_node
   type: python
   source:
     type: code
     path: test_print_aggregation.py
   inputs:
-    inputs: ${inputs.question}
+    input_str: ${inputs.input_str}
+    input_bool: ${inputs.input_bool}
+    input_list: ${inputs.input_list}
+    input_dict: ${inputs.input_dict}
   aggregation: true
   use_variants: false

--- a/src/promptflow/tests/test_configs/flows/default_input/test_print_aggregation.py
+++ b/src/promptflow/tests/test_configs/flows/default_input/test_print_aggregation.py
@@ -2,6 +2,10 @@ from typing import List
 from promptflow import tool
 
 @tool
-def test_print_input(inputs: List[str]):
-    print(inputs)
-    return inputs
+def test_print_input(input_str: List[str], input_bool: List[bool], input_list: List[List], input_dict: List[dict]):
+    assert input_bool[0] == False
+    assert input_list[0] == []
+    assert input_dict[0] == {}
+
+    print(input_str)
+    return input_str

--- a/src/promptflow/tests/test_configs/flows/default_input/test_print_input.py
+++ b/src/promptflow/tests/test_configs/flows/default_input/test_print_input.py
@@ -2,6 +2,9 @@ from promptflow import tool
 
 
 @tool
-def test_print_input(input: str):
-    print(input)
-    return input
+def test_print_input(input_str: str, input_bool: bool, input_list: list, input_dict: dict):
+    assert not input_bool
+    assert input_list == []
+    assert input_dict == {}
+    print(input_str)
+    return input_str


### PR DESCRIPTION
# Description

To apply default value correctly, we need to check if default value is None or not.
Previous logic will not apply `False`/`[]`/`{}` from default value.

Behavior changes:

* <a href="diffhunk://#diff-113cef506fb37cf3588f2246fec675adec478ddd47b9de5b246778fc8d03f23cL14-R14">`src/promptflow/promptflow/_utils/execution_utils.py`</a>: Updated the condition for checking if a key is not in `updated_inputs` and has a default value to also check if the default value is not `None`.

* <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69L585-R585">`src/promptflow/promptflow/executor/flow_executor.py`</a>: Updated the condition in the `_apply_default_value_for_aggregation_input` method to consider only inputs with non-None default values.

* [src/promptflow/promptflow/batch/_batch_inputs_processor.py](https://github.com/microsoft/promptflow/pull/1244/files#diff-df655e2eb38738cb9ba6769d25b6fd6bf42cc104c2cabe7565125cba9b70dc17) Update the condition to generate default input mapping according to default value

Test changes:
* <a href="diffhunk://#diff-a93d76662d836cbac55b6af09edc90c4dbce4fae48d7a17a37f9d63484b64ff4R41-R61">`src/promptflow/tests/executor/unittests/_utils/test_execution_utils.py`</a>: Added new test cases to verify the behavior of applying default values for different types of input.

* <a href="diffhunk://#diff-94a59a05643476869fa3c6bc45466f1582944a935488075e2e63b6a6a196958fL840-R846">`src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py`</a>: Added additional assertions for new input variables with their default values.

* <a href="diffhunk://#diff-a8c03f3ea59cc12d393693071c8c95e8be181cceb3d688cfa240beb9cc36c042L5-R10">`src/promptflow/tests/test_configs/flows/default_input/test_print_input.py`</a>: Updated the `test_print_input` function to include new inputs and assertions to verify their default values.




# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
