### PR TITLE
[Executor] Inject openai api in single node run

### DIFF
--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -289,6 +289,10 @@ class FlowExecutor:
         :param raise_ex: Whether to raise exceptions or not. Default is False.
         :type raise_ex: Optional[bool]
         """
+        # Inject OpenAI API to make sure traces and headers injection works and
+        # update OpenAI API configs from environment variables.
+        inject_openai_api()
+
         OperationContext.get_instance().run_mode = RunMode.SingleNode.name
         dependency_nodes_outputs = dependency_nodes_outputs or {}
 

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -109,9 +109,10 @@ class TestExecutor:
 
     def test_executor_exec_node_with_llm_node(self, dev_connections):
         # Run the test in a new process to ensure the openai api is injected correctly for the single node run
-        queue = multiprocessing.Queue()
-        process = multiprocessing.Process(
-            target=target_func,
+        context = multiprocessing.get_context("spawn")
+        queue = context.Queue()
+        process = context.Process(
+            target=exec_node_within_process,
             args=(queue, "llm_tool", "joke", {"topic": "fruit"}, {}, dev_connections, True)
         )
         process.start()
@@ -241,7 +242,7 @@ class TestExecutor:
         assert flow_result.output["output"] == "Hello World"
 
 
-def target_func(queue, flow_file, node_name, flow_inputs, dependency_nodes_outputs, connections, raise_ex):
+def exec_node_within_process(queue, flow_file, node_name, flow_inputs, dependency_nodes_outputs, connections, raise_ex):
     try:
         result = FlowExecutor.load_and_exec_node(
             flow_file=get_yaml_file(flow_file),

--- a/src/promptflow/tests/test_configs/flows/llm_tool/echo.py
+++ b/src/promptflow/tests/test_configs/flows/llm_tool/echo.py
@@ -1,0 +1,13 @@
+from promptflow import tool
+
+# The inputs section will change based on the arguments of the tool function, after you save the code
+# Adding type to arguments and return value will help the system show the types properly
+# Please update the function name/signature per need
+
+# In Python tool you can do things like calling external services or
+# pre/post processing of data, pretty much anything you want
+
+
+@tool
+def echo(input: str) -> str:
+    return input

--- a/src/promptflow/tests/test_configs/flows/llm_tool/echo.py
+++ b/src/promptflow/tests/test_configs/flows/llm_tool/echo.py
@@ -1,12 +1,5 @@
 from promptflow import tool
 
-# The inputs section will change based on the arguments of the tool function, after you save the code
-# Adding type to arguments and return value will help the system show the types properly
-# Please update the function name/signature per need
-
-# In Python tool you can do things like calling external services or
-# pre/post processing of data, pretty much anything you want
-
 
 @tool
 def echo(input: str) -> str:

--- a/src/promptflow/tests/test_configs/flows/llm_tool/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/llm_tool/flow.dag.yaml
@@ -1,0 +1,36 @@
+inputs:
+  topic:
+    type: string
+    default: hello world
+    is_chat_input: false
+outputs:
+  joke:
+    type: string
+    reference: ${echo.output}
+nodes:
+- name: echo
+  type: python
+  source:
+    type: code
+    path: echo.py
+  inputs:
+    input: ${joke.output}
+  use_variants: false
+- name: joke
+  type: llm
+  source:
+    type: code
+    path: joke.jinja2
+  inputs:
+    deployment_name: gpt-35-turbo
+    temperature: 1
+    top_p: 1
+    max_tokens: 256
+    presence_penalty: 0
+    frequency_penalty: 0
+    topic: ${inputs.topic}
+  provider: AzureOpenAI
+  connection: azure_open_ai_connection
+  api: chat
+  module: promptflow.tools.aoai
+  use_variants: false

--- a/src/promptflow/tests/test_configs/flows/llm_tool/joke.jinja2
+++ b/src/promptflow/tests/test_configs/flows/llm_tool/joke.jinja2
@@ -1,0 +1,9 @@
+{# Prompt is a jinja2 template that generates prompt for LLM #}
+
+system:
+
+You are a bot can tell good jokes
+
+user:
+
+A joke about {{topic}} please


### PR DESCRIPTION
# Description

We only injected openai api when initializing `Executor` previously, but when running a single node run, it wasn't injected due to no need to create an `Executor`, so we should also inject openai api in single node run.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
