### PR TITLE
Fix not recursive load the tool yamls files in sub-directory

### DIFF
--- a/scripts/tool/templates/MANIFEST.in.j2
+++ b/scripts/tool/templates/MANIFEST.in.j2
@@ -1,1 +1,1 @@
-include {{ package_name }}/yamls/*.yaml
+include {{ package_name }}/yamls/**/*.yaml


### PR DESCRIPTION
# Description
**relevant issues**: https://github.com/microsoft/promptflow/issues/1257

**Analyse**：
utils.py ：collect_tools_from_directory 
 for f in Path(base_dir).glob("**/*.yaml")  ---- recursive sub-directory

MANIFEST.in 
include {{ package_name }}/yamls/*.yaml --- not  recursive sub-directory.

MANIFEST.in  should add ****/**   to recursive the subdirecotry


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [*] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
