### PR TITLE
[promptflow] Bump SQLAlchemy to 2.x using local import

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Add env variable 'PF_NO_INTERACTIVE_LOGIN' to disable interactive login if using azureml connection provider in promptflow sdk.
 - Improved CLI invoke time.
 - Bump `pydash` upper bound to 8.0.0.
+- Bump `SQLAlchemy` upper bound to 3.0.0.
 
 ## 1.0.0 (2023.11.09)
 

--- a/src/promptflow/promptflow/storage/_sqlite_client.py
+++ b/src/promptflow/promptflow/storage/_sqlite_client.py
@@ -9,8 +9,6 @@ from datetime import datetime
 from sqlite3 import OperationalError
 from typing import List
 
-import dataset
-from dataset.types import Types
 from sqlalchemy.exc import IntegrityError
 
 from promptflow._utils.retry_utils import retry
@@ -21,6 +19,8 @@ INDEX = "INDEX"
 
 
 def _get_type(t: type):
+    from dataset.types import Types
+
     if issubclass(t, str):
         return Types.string
     elif issubclass(t, int):
@@ -36,7 +36,7 @@ def _get_type(t: type):
 
 
 class TableInfo:
-    def __init__(self, db: dataset.Database, table: dataset.Table, primary_key: str):
+    def __init__(self, db, table, primary_key: str):
         self.db = db
         self.table = table
         self.primary_key = primary_key
@@ -74,6 +74,8 @@ class SqliteClient:
 
         db_path = ":memory:" if in_memory else f"{db_folder_path}/{db_name}"
         # Set check_same_thread=False because different threads might use the same db.
+        import dataset
+
         db = dataset.connect(
             f"sqlite:///{db_path}?check_same_thread=False",
             on_connect_statements=[f"PRAGMA busy_timeout = {timeout_seconds * 1000}"],

--- a/src/promptflow/setup.py
+++ b/src/promptflow/setup.py
@@ -26,8 +26,7 @@ REQUIRES = [
     "openai>=0.27.8,<0.28.0",  # promptflow.core.api_injector
     "flask>=2.2.3,<3.0.0",  # Serving endpoint requirements
     "flask-restx>=1.2.0,<1.3.0",  # Serving endpoint requirements
-    "dataset>=1.6.0,<2.0.0",  # promptflow.storage
-    "sqlalchemy>=1.4.48,<2.0.0",  # sqlite requirements
+    "sqlalchemy>=1.4.48,<3.0.0",  # sqlite requirements
     # note that pandas 1.5.3 is the only version to test in ci before promptflow 0.1.0b7 is released
     # and pandas 2.x.x will be the only version to test in ci after that.
     "pandas>=1.5.3,<3.0.0",  # load data requirements


### PR DESCRIPTION
# Description

This PR targets to bump `SQLAlchemy` to 2.x. Different from #1254 , use local import to remove dependency to `dataset`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
