### PR TITLE
Add line number info in error message when failed to parse jinja template.

### DIFF
--- a/src/promptflow/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow/promptflow/_core/tool_meta_generator.py
@@ -14,6 +14,7 @@ from dataclasses import asdict
 from pathlib import Path
 from traceback import TracebackException
 
+from jinja2 import TemplateSyntaxError
 from jinja2.environment import COMMENT_END_STRING, COMMENT_START_STRING
 
 from promptflow._core._errors import MetaFileNotFound, MetaFileReadError, NotSupported
@@ -36,6 +37,17 @@ def generate_prompt_tool(name, content, prompt_only=False, source=None):
     tool_type = ToolType.PROMPT if prompt_only else ToolType.LLM
     try:
         inputs = get_inputs_for_prompt_template(content)
+    except TemplateSyntaxError as e:
+        error_type_and_message = f"({e.__class__.__name__}) {e}"
+        raise JinjaParsingError(
+            message_format=(
+                "Generate tool meta failed for {tool_type} tool. Jinja parsing failed at line {line_number}: "
+                "{error_type_and_message}"
+            ),
+            tool_type=tool_type,
+            line_number=e.lineno,
+            error_type_and_message=error_type_and_message,
+        ) from e
     except Exception as e:
         error_type_and_message = f"({e.__class__.__name__}) {e}"
         raise JinjaParsingError(

--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+from jinja2 import TemplateSyntaxError
+
 from promptflow._utils.exception_utils import ExceptionPresenter, infer_error_code_from_class
 from promptflow.exceptions import (
     ErrorTarget,
@@ -207,6 +209,11 @@ class ResolveToolError(PromptflowException):
         error_type_and_message = None
         if self.inner_exception:
             error_type_and_message = f"({self.inner_exception.__class__.__name__}) {self.inner_exception}"
+            if isinstance(self.inner_exception, TemplateSyntaxError):
+                error_type_and_message = (
+                    f"({self.inner_exception.__class__.__name__}) in line "
+                    f"{self.inner_exception.lineno}: {self.inner_exception}"
+                )
 
         return {
             "node_name": self._node_name,

--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -211,8 +211,7 @@ class ResolveToolError(PromptflowException):
             error_type_and_message = f"({self.inner_exception.__class__.__name__}) {self.inner_exception}"
             if isinstance(self.inner_exception, TemplateSyntaxError):
                 error_type_and_message = (
-                    f"({self.inner_exception.__class__.__name__}) in line "
-                    f"{self.inner_exception.lineno}: {self.inner_exception}"
+                    f"Jinja parsing failed at line {self.inner_exception.lineno}: {error_type_and_message}"
                 )
 
         return {

--- a/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
@@ -203,14 +203,14 @@ class TestToolMetaUtils:
             pytest.param(
                 "{% zzz",
                 JinjaParsingError,
-                "Generate tool meta failed for llm tool. Jinja parsing failed: "
+                "Generate tool meta failed for llm tool. Jinja parsing failed at line 1: "
                 "(TemplateSyntaxError) Encountered unknown tag 'zzz'.",
                 id="JinjaParsingError_Code",
             ),
             pytest.param(
                 "no_end.jinja2",
                 JinjaParsingError,
-                "Generate tool meta failed for llm tool. Jinja parsing failed: "
+                "Generate tool meta failed for llm tool. Jinja parsing failed at line 2: "
                 "(TemplateSyntaxError) Unexpected end of template. Jinja was looking for the following tags: "
                 "'endfor' or 'else'. The innermost block that needs to be closed is 'for'.",
                 id="JinjaParsingError_File",
@@ -240,14 +240,14 @@ class TestToolMetaUtils:
             pytest.param(
                 "{% zzz",
                 JinjaParsingError,
-                "Generate tool meta failed for prompt tool. Jinja parsing failed: "
+                "Generate tool meta failed for prompt tool. Jinja parsing failed at line 1: "
                 "(TemplateSyntaxError) Encountered unknown tag 'zzz'.",
                 id="JinjaParsingError_Code",
             ),
             pytest.param(
                 "no_end.jinja2",
                 JinjaParsingError,
-                "Generate tool meta failed for prompt tool. Jinja parsing failed: "
+                "Generate tool meta failed for prompt tool. Jinja parsing failed at line 2: "
                 "(TemplateSyntaxError) Unexpected end of template. Jinja was looking for the following tags: "
                 "'endfor' or 'else'. The innermost block that needs to be closed is 'for'.",
                 id="JinjaParsingError_File",

--- a/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
@@ -173,8 +173,8 @@ class TestToolResolver:
 
         assert isinstance(exec_info.value.inner_exception, TemplateSyntaxError)
         expected_message = (
-            "Tool load failed in 'node': (TemplateSyntaxError) in line 1: "
-            "expected token 'end of print statement', got 'context'"
+            "Tool load failed in 'node': Jinja parsing failed at line 1: "
+            "(TemplateSyntaxError) expected token 'end of print statement', got 'context'"
         )
         assert expected_message in exec_info.value.message
 

--- a/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import List
 
 import pytest
+from jinja2 import TemplateSyntaxError
 
 from promptflow._core.tools_manager import ToolLoader
 from promptflow._internal import tool
@@ -160,6 +161,22 @@ class TestToolResolver:
 
         assert isinstance(exec_info.value.inner_exception, NodeInputValidationError)
         assert "These inputs are duplicated" in exec_info.value.message
+
+    def test_resolve_tool_by_node_with_invalid_template(self, resolver, mocker):
+        node = mocker.Mock(tool=None, inputs={})
+        node.name = "node"
+        node.type = ToolType.PROMPT
+        mocker.patch.object(resolver, "_load_source_content", return_value="{{current context}}")
+
+        with pytest.raises(ResolveToolError) as exec_info:
+            resolver.resolve_tool_by_node(node)
+
+        assert isinstance(exec_info.value.inner_exception, TemplateSyntaxError)
+        expected_message = (
+            "Tool load failed in 'node': (TemplateSyntaxError) in line 1: "
+            "expected token 'end of print statement', got 'context'"
+        )
+        assert expected_message in exec_info.value.message
 
     def test_ensure_node_inputs_type(self):
         # Case 1: conn_name not in connections, should raise conn_name not found error


### PR DESCRIPTION
# Description
For `TemplateSyntaxError` from jinja package, add line number info in error message.

Need to add this info for 2 scenarios (meta generation and tool resolve)


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
