### PR TITLE
[SDK]fix leading space in UA

### DIFF
--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -109,8 +109,6 @@ class OperationContext(Dict):
 
         # strip to avoid leading or trailing spaces, which may cause error when sending request
         ua = " ".join(parts()).strip()
-        if ua.startswith(" "):
-            raise ValueError("User agent string cannot start with a space, got {}".format(ua))
         return ua
 
     def append_user_agent(self, user_agent: str):
@@ -128,8 +126,6 @@ class OperationContext(Dict):
         else:
             self.user_agent = user_agent
         self.user_agent = self.user_agent.strip()
-        if self.user_agent.startswith(" "):
-            raise ValueError("User agent string cannot start with a space, got {}".format(self.user_agent))
 
     def set_batch_input_source_from_inputs_mapping(self, inputs_mapping: Mapping[str, str]):
         """Infer the batch input source from the input mapping and set it in the OperationContext instance.

--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -108,7 +108,10 @@ class OperationContext(Dict):
             yield f"promptflow/{VERSION}"
 
         # strip to avoid leading or trailing spaces, which may cause error when sending request
-        return " ".join(parts()).strip()
+        ua = " ".join(parts()).strip()
+        if ua.startswith(" "):
+            raise ValueError("User agent string cannot start with a space, got {}".format(ua))
+        return ua
 
     def append_user_agent(self, user_agent: str):
         """Append the user agent string.
@@ -124,6 +127,8 @@ class OperationContext(Dict):
                 self.user_agent = f"{self.user_agent} {user_agent}"
         else:
             self.user_agent = user_agent
+        if self.user_agent.startswith(" "):
+            raise ValueError("User agent string cannot start with a space, got {}".format(self.user_agent))
 
     def set_batch_input_source_from_inputs_mapping(self, inputs_mapping: Mapping[str, str]):
         """Infer the batch input source from the input mapping and set it in the OperationContext instance.

--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -127,6 +127,7 @@ class OperationContext(Dict):
                 self.user_agent = f"{self.user_agent} {user_agent}"
         else:
             self.user_agent = user_agent
+        self.user_agent = self.user_agent.strip()
         if self.user_agent.startswith(" "):
             raise ValueError("User agent string cannot start with a space, got {}".format(self.user_agent))
 


### PR DESCRIPTION
This pull request to `src/promptflow/promptflow/_core/operation_context.py` fixes an issue where the user agent string was starting with a space in the `OperationContext` class. Two changes were made in the `append_user_agent` method and the `parts` function to ensure that the user agent string does not start with a space.

* <a href="diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR130-R132">`src/promptflow/promptflow/_core/operation_context.py`</a>: Fixed an issue where the user agent string was starting with a space in the `OperationContext` class. <a href="diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR130-R132">[1]</a> <a href="diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aL111-R114">[2]</a># Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
