### PR TITLE
Optimise docker image build: copy python requirements file only before install them

### DIFF
--- a/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
+++ b/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
@@ -10,7 +10,7 @@ FROM docker.io/continuumio/miniconda3:latest
 
 WORKDIR /
 
-COPY ./flow /flow
+COPY ./flow/{{env.python_requirements_txt}} /flow/{{env.python_requirements_txt}}
 
 # create conda environment
 {% if env.conda_file %}
@@ -33,6 +33,8 @@ RUN conda create -n {{env.conda_env_name}} python=3.9.16 pip=23.0.1 -q -y && \
     conda run -n {{env.conda_env_name}} pip install gunicorn==20.1.0 && \
     conda run -n {{env.conda_env_name}} pip cache purge && \
     conda clean -a -y
+
+COPY ./flow /flow
 
 {% if env.setup_sh %}
 RUN conda run -n {{env.conda_env_name}} sh /flow/{{ env.setup_sh }}

--- a/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
+++ b/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
@@ -12,10 +12,12 @@ WORKDIR /
 
 {% if env.python_requirements_txt %}
 COPY ./flow/{{env.python_requirements_txt}} /flow/{{env.python_requirements_txt}}
-{% end %}
+{% endif %}
 
 # create conda environment
 {% if env.conda_file %}
+COPY ./flow/{{env.conda_file}} /flow/{{env.conda_file}}
+
 RUN conda create -f flow/{{env.conda_file}} -q && \
 {% else %}
 RUN conda create -n {{env.conda_env_name}} python=3.9.16 pip=23.0.1 -q -y && \

--- a/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
+++ b/src/promptflow/promptflow/_sdk/data/docker/Dockerfile.jinja2
@@ -10,7 +10,9 @@ FROM docker.io/continuumio/miniconda3:latest
 
 WORKDIR /
 
+{% if env.python_requirements_txt %}
 COPY ./flow/{{env.python_requirements_txt}} /flow/{{env.python_requirements_txt}}
+{% end %}
 
 # create conda environment
 {% if env.conda_file %}


### PR DESCRIPTION
# Description

When build the docker image, the whole `flow` directory is added to docker image before installing the dependencies (python and debian packages, etc). However any minor changes results in re-installing the dependencies. To avoid the unneccessary time-consuming installation, only copy the `requirements.txt` that's required by `pip install` first, and then install the depedencies.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.

