### PR TITLE
Fix exception definition for loading image from url.

### DIFF
--- a/src/promptflow/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow/promptflow/_utils/multimedia_utils.py
@@ -1,5 +1,4 @@
 import base64
-import filetype
 import os
 import re
 import uuid
@@ -8,6 +7,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict
 from urllib.parse import urlparse
 
+import filetype
 import requests
 
 from promptflow.contracts._errors import InvalidImageInput
@@ -88,9 +88,12 @@ def _create_image_from_url(url: str, mime_type: str = None):
         return Image(response.content, mime_type=mime_type, source_url=url)
     else:
         raise InvalidImageInput(
-            message_format=f"Error while fetching image from URL: {url}. "
-            "Error code: {response.status_code}. Error message: {response.text}.",
+            message_format="Failed to fetch image from URL: {url}. Error code: {error_code}. "
+            "Error message: {error_message}.",
             target=ErrorTarget.EXECUTOR,
+            url=url,
+            error_code=response.status_code,
+            error_message=response.text,
         )
 
 

--- a/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
@@ -1,11 +1,13 @@
-import pytest
 import re
 from pathlib import Path
-from unittest.mock import mock_open
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
 
 from promptflow._utils.multimedia_utils import (
     _create_image_from_base64,
     _create_image_from_file,
+    _create_image_from_url,
     _process_multimedia_dict_recursively,
     _process_recursively,
     convert_multimedia_data_to_base64,
@@ -32,9 +34,35 @@ class TestMultimediaUtils:
         base64_str = image.to_base64()
         image_from_base64 = _create_image_from_base64(base64_str)
         assert str(image) == str(image_from_base64)
-        format = image_path.split('.')[-1]
+        format = image_path.split(".")[-1]
         mime_type = f"image/{format}" if format != "jpg" else "image/jpeg"
         assert mime_type == image_from_base64._mime_type
+
+    @patch("requests.get")
+    def test_create_image_from_url_with_mime_type(self, mock_get):
+        url = "https://example.com/image.jpg"
+        content = b"image content"
+        mime_type = "image/jpeg"
+        mock_get.return_value = MagicMock(status_code=200, content=content)
+
+        image = _create_image_from_url(url, mime_type)
+
+        assert isinstance(image, Image)
+        assert image._mime_type == mime_type
+        assert image.source_url == url
+
+    @patch("requests.get")
+    def test_create_image_from_url_failure(self, mock_get):
+        url = "https://example.com/image.jpg"
+        message = "Failed to fetch image"
+        code = 404
+        mock_get.return_value = MagicMock(status_code=code, text=message)
+
+        with pytest.raises(InvalidImageInput) as ex:
+            _create_image_from_url(url)
+
+        expected_message = f"Failed to fetch image from URL: {url}. Error code: {code}. Error message: {message}."
+        assert str(ex.value) == expected_message
 
     def test_create_image_with_dict(self, mocker):
         ## From path
@@ -58,7 +86,7 @@ class TestMultimediaUtils:
         mocker.patch("requests.get", return_value=mocker.Mock(content=None, status_code=404))
         with pytest.raises(InvalidImageInput) as ex:
             create_image(image_dict)
-        assert "Error while fetching image from URL" in ex.value.message_format
+        assert "Failed to fetch image from URL" in ex.value.message_format
 
     def test_create_image_with_string(self, mocker):
         ## From path
@@ -96,7 +124,7 @@ class TestMultimediaUtils:
 
     def test_persist_multimedia_date(self, mocker):
         image = _create_image_from_file(TEST_IMAGE_PATH)
-        mocker.patch('builtins.open', mock_open())
+        mocker.patch("builtins.open", mock_open())
         data = {"image": image, "images": [image, image, "other_data"], "other_data": "other_data"}
         persisted_data = persist_multimedia_data(data, base_dir=Path(__file__).parent)
         file_name = re.compile(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}.jpg$")
@@ -133,27 +161,27 @@ class TestMultimediaUtils:
         line_inputs = {
             "image": image_dict,
             "images": [image_dict, image_dict],
-            "object": {"image": image_dict, "other_data": "other_data"}
+            "object": {"image": image_dict, "other_data": "other_data"},
         }
         updated_inputs = load_multimedia_data(inputs, line_inputs)
         image = _create_image_from_file(TEST_IMAGE_PATH)
         assert updated_inputs == {
             "image": image,
             "images": [image, image],
-            "object": {"image": image, "other_data": "other_data"}
+            "object": {"image": image, "other_data": "other_data"},
         }
 
         # Case 2: Test aggregation node
         line_inputs = {
             "image": [image_dict, image_dict],
             "images": [[image_dict, image_dict], [image_dict]],
-            "object": [{"image": image_dict, "other_data": "other_data"}, {"other_data": "other_data"}]
+            "object": [{"image": image_dict, "other_data": "other_data"}, {"other_data": "other_data"}],
         }
         updated_inputs = load_multimedia_data(inputs, line_inputs)
         assert updated_inputs == {
             "image": [image, image],
             "images": [[image, image], [image]],
-            "object": [{"image": image, "other_data": "other_data"}, {"other_data": "other_data"}]
+            "object": [{"image": image, "other_data": "other_data"}, {"other_data": "other_data"}],
         }
 
     def test_resolve_multimedia_data_recursively(self):
@@ -161,7 +189,7 @@ class TestMultimediaUtils:
         value = {
             "image": image_dict,
             "images": [image_dict, image_dict],
-            "object": {"image": image_dict, "other_data": "other_data"}
+            "object": {"image": image_dict, "other_data": "other_data"},
         }
         input_dir = TEST_IMAGE_PATH
         updated_value = resolve_multimedia_data_recursively(input_dir, value)
@@ -169,23 +197,19 @@ class TestMultimediaUtils:
         assert updated_value == {
             "image": updated_image_dict,
             "images": [updated_image_dict, updated_image_dict],
-            "object": {"image": updated_image_dict, "other_data": "other_data"}
+            "object": {"image": updated_image_dict, "other_data": "other_data"},
         }
 
     def test_process_recursively(self):
         image = _create_image_from_file(TEST_IMAGE_PATH)
-        value = {
-            "image": image,
-            "images": [image, image],
-            "object": {"image": image, "other_data": "other_data"}
-        }
+        value = {"image": image, "images": [image, image], "object": {"image": image, "other_data": "other_data"}}
         process_funcs = {Image: lambda x: str(x)}
         updated_value = _process_recursively(value, process_funcs)
         image_str = str(image)
         assert updated_value == {
             "image": image_str,
             "images": [image_str, image_str],
-            "object": {"image": image_str, "other_data": "other_data"}
+            "object": {"image": image_str, "other_data": "other_data"},
         }
 
     def test_process_multimedia_dict_recursively(self):
@@ -196,11 +220,11 @@ class TestMultimediaUtils:
         value = {
             "image": image_dict,
             "images": [image_dict, image_dict],
-            "object": {"image": image_dict, "other_data": "other_data"}
+            "object": {"image": image_dict, "other_data": "other_data"},
         }
         updated_value = _process_multimedia_dict_recursively(value, process_func)
         assert updated_value == {
             "image": "image_placeholder",
             "images": ["image_placeholder", "image_placeholder"],
-            "object": {"image": "image_placeholder", "other_data": "other_data"}
+            "object": {"image": "image_placeholder", "other_data": "other_data"},
         }


### PR DESCRIPTION
# Description

Fix exception definition for loading image from url.
Previous logic didn't use `message_format` in right way.
Will throw exception as we try to get error message and lose the actual error info in portal scenario.

![image](https://github.com/microsoft/promptflow/assets/17527303/ca0663d8-ed2f-433f-a573-e93f6583638f)

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
