### PR TITLE
[CLI] Add param "--user-agent" in CLI

### DIFF
--- a/src/promptflow/promptflow/_cli/_params.py
+++ b/src/promptflow/promptflow/_cli/_params.py
@@ -50,6 +50,11 @@ def add_param_yes(parser):
     )
 
 
+def add_param_ua(parser):
+    # suppress user agent for now since it's only used in vscode extension
+    parser.add_argument("--user-agent", help=argparse.SUPPRESS)
+
+
 def add_param_flow_display_name(parser):
     parser.add_argument("--flow", type=str, required=True, help="the flow name to create.")
 
@@ -293,6 +298,9 @@ def add_param_config(parser):
 
 
 logging_params = [add_param_verbose, add_param_debug]
+base_params = logging_params + [
+    add_param_ua,
+]
 
 
 def add_param_archived_only(parser):

--- a/src/promptflow/promptflow/_cli/_pf/_config.py
+++ b/src/promptflow/promptflow/_cli/_pf/_config.py
@@ -1,7 +1,7 @@
 import argparse
 import json
 
-from promptflow._cli._params import add_param_set_positional, logging_params
+from promptflow._cli._params import add_param_set_positional, base_params
 from promptflow._cli._utils import activate_action, list_of_dict_to_dict
 from promptflow._sdk._configuration import Configuration, InvalidConfigValue
 from promptflow._sdk._constants import LOGGER_NAME
@@ -22,7 +22,7 @@ def add_config_set(subparsers):
         name="set",
         description="Set prompt flow configs for current user.",
         epilog=epilog,
-        add_params=[add_param_set_positional] + logging_params,
+        add_params=[add_param_set_positional] + base_params,
         subparsers=subparsers,
         help_message="Set prompt flow configs for current user, configs will be stored at ~/.promptflow/pf.yaml.",
         action_param_name="sub_action",
@@ -40,7 +40,7 @@ def add_config_show(subparsers):
         name="show",
         description="Show prompt flow configs for current user.",
         epilog=epilog,
-        add_params=logging_params,
+        add_params=base_params,
         subparsers=subparsers,
         help_message="Show prompt flow configs for current user.",
         action_param_name="sub_action",

--- a/src/promptflow/promptflow/_cli/_pf/_connection.py
+++ b/src/promptflow/promptflow/_cli/_pf/_connection.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from functools import partial
 
-from promptflow._cli._params import add_param_all_results, add_param_max_results, add_param_set, logging_params
+from promptflow._cli._params import add_param_all_results, add_param_max_results, add_param_set, base_params
 from promptflow._cli._utils import activate_action, confirm, exception_handler, get_secret_input, print_yellow_warning
 from promptflow._sdk._constants import LOGGER_NAME, MAX_LIST_CLI_RESULTS
 from promptflow._sdk._load_functions import load_connection
@@ -67,7 +67,7 @@ pf connection create -f .env --name custom
         name="create",
         description="Create a connection.",
         epilog=epilog,
-        add_params=[add_param_set, add_param_file, add_param_name] + logging_params,
+        add_params=[add_param_set, add_param_file, add_param_name] + base_params,
         subparsers=subparsers,
         help_message="Create a connection.",
         action_param_name="sub_action",
@@ -85,7 +85,7 @@ pf connection update -n my_connection --set api_key="my_api_key"
         name="update",
         description="Update a connection.",
         epilog=epilog,
-        add_params=[add_param_set, partial(add_param_name, required=True)] + logging_params,
+        add_params=[add_param_set, partial(add_param_name, required=True)] + base_params,
         subparsers=subparsers,
         help_message="Update a connection.",
         action_param_name="sub_action",
@@ -103,7 +103,7 @@ pf connection show -n my_connection_name
         name="show",
         description="Show a connection for promptflow.",
         epilog=epilog,
-        add_params=[partial(add_param_name, required=True)] + logging_params,
+        add_params=[partial(add_param_name, required=True)] + base_params,
         subparsers=subparsers,
         help_message="Show a connection for promptflow.",
         action_param_name="sub_action",
@@ -121,7 +121,7 @@ pf connection delete -n my_connection_name
         name="delete",
         description="Delete a connection with specific name.",
         epilog=epilog,
-        add_params=[partial(add_param_name, required=True)] + logging_params,
+        add_params=[partial(add_param_name, required=True)] + base_params,
         subparsers=subparsers,
         help_message="Delete a connection with specific name.",
         action_param_name="sub_action",
@@ -139,7 +139,7 @@ pf connection list
         name="list",
         description="List all connections.",
         epilog=epilog,
-        add_params=[add_param_max_results, add_param_all_results] + logging_params,
+        add_params=[add_param_max_results, add_param_all_results] + base_params,
         subparsers=subparsers,
         help_message="List all connections.",
         action_param_name="sub_action",

--- a/src/promptflow/promptflow/_cli/_pf/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf/_flow.py
@@ -6,10 +6,10 @@ import argparse
 import importlib
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import webbrowser
-import subprocess
 from pathlib import Path
 
 from promptflow._cli._params import (
@@ -23,7 +23,7 @@ from promptflow._cli._params import (
     add_param_source,
     add_param_yes,
     add_parser_build,
-    logging_params,
+    base_params,
 )
 from promptflow._cli._pf._init_entry_generators import (
     AzureOpenAIConnectionGenerator,
@@ -111,7 +111,7 @@ pf flow init --flow intent_copilot --entry intent.py --function extract_intent -
         add_param_prompt_template,
         add_param_connection,
         add_param_deployment,
-    ] + logging_params
+    ] + base_params
     activate_action(
         name="init",
         description="Creating a flow folder with code/prompts and yaml definitions of the flow.",
@@ -154,7 +154,7 @@ pf flow serve --source <path_to_flow> --port 8080 --host localhost --environment
             add_param_environment_variables,
             add_param_config,
         ]
-        + logging_params,
+        + base_params,
         subparsers=subparsers,
         help_message="Serving a flow as an endpoint.",
         action_param_name="sub_action",
@@ -227,7 +227,7 @@ pf flow test --flow my-awesome-flow --node node_name --interactive
         add_param_multi_modal,
         add_param_ui,
         add_param_config,
-    ] + logging_params
+    ] + base_params
     activate_action(
         name="test",
         description="Test the flow.",
@@ -441,6 +441,7 @@ def serve_flow(args):
 
 def serve_flow_csharp(args, source):
     from promptflow.batch._csharp_executor_proxy import EXECUTOR_SERVICE_DLL
+
     try:
         # Change working directory to model dir
         logger.info(f"Change working directory to model dir {source}")
@@ -458,7 +459,7 @@ def serve_flow_csharp(args, source):
             "",
             "--log_path",
             "",
-            "--serving"
+            "--serving",
         ]
         subprocess.run(command, stdout=sys.stdout, stderr=sys.stderr)
     except KeyboardInterrupt:
@@ -467,6 +468,7 @@ def serve_flow_csharp(args, source):
 
 def serve_flow_python(args, source):
     from promptflow._sdk._serving.app import create_app
+
     static_folder = args.static_folder
     if static_folder:
         static_folder = Path(static_folder).absolute().as_posix()

--- a/src/promptflow/promptflow/_cli/_pf/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf/_run.py
@@ -18,7 +18,7 @@ from promptflow._cli._params import (
     add_param_run_name,
     add_param_set,
     add_parser_build,
-    logging_params,
+    base_params,
 )
 from promptflow._cli._utils import (
     _output_result_list_with_format,
@@ -96,7 +96,7 @@ def add_run_create_common(subparsers, add_param_list, epilog: Optional[str] = No
         add_param_environment_variables,
         add_param_connections,
         add_param_set,
-    ] + logging_params
+    ] + base_params
 
     add_params.extend(add_param_list)
     create_parser = activate_action(
@@ -135,7 +135,7 @@ Example:
 # Cancel a run:
 pf run cancel --name <name>
 """
-    add_params = [add_param_run_name] + logging_params
+    add_params = [add_param_run_name] + base_params
     activate_action(
         name="cancel",
         description=None,
@@ -157,7 +157,7 @@ pf run update --name <name> --set display_name="<display-name>" description="<de
     add_params = [
         add_param_run_name,
         add_param_set,
-    ] + logging_params
+    ] + base_params
     activate_action(
         name="update",
         description=None,
@@ -176,7 +176,7 @@ Example:
 # Stream run logs:
 pf run stream --name <name>
 """
-    add_params = [add_param_run_name] + logging_params
+    add_params = [add_param_run_name] + base_params
     activate_action(
         name="stream",
         description=None,
@@ -211,7 +211,7 @@ pf run list --output table
         add_param_archived_only,
         add_param_include_archived,
         add_param_output_format,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="list",
@@ -231,7 +231,7 @@ Example:
 # Show the status of a run:
 pf run show --name <name>
 """
-    add_params = [add_param_run_name] + logging_params
+    add_params = [add_param_run_name] + base_params
 
     activate_action(
         name="show",
@@ -260,7 +260,7 @@ pf run show-details --name <name>
         help=f"Number of lines to show. Default is {MAX_SHOW_DETAILS_RESULTS}.",
     )
 
-    add_params = [add_param_max_results, add_param_run_name, add_param_all_results] + logging_params
+    add_params = [add_param_max_results, add_param_run_name, add_param_all_results] + base_params
 
     activate_action(
         name="show-details",
@@ -280,7 +280,7 @@ Example:
 # View metrics of a run:
 pf run show-metrics --name <name>
 """
-    add_params = [add_param_run_name] + logging_params
+    add_params = [add_param_run_name] + base_params
 
     activate_action(
         name="show-metrics",
@@ -311,7 +311,7 @@ pf run visualize --names "<name1>, <name2>"
         "--html-path", type=str, default=None, help=argparse.SUPPRESS
     )
 
-    add_params = [add_param_name, add_param_html_path] + logging_params
+    add_params = [add_param_name, add_param_html_path] + base_params
 
     activate_action(
         name="visualize",
@@ -331,7 +331,7 @@ Example:
 # Archive a run:
 pf run archive --name <name>
 """
-    add_params = [add_param_run_name] + logging_params
+    add_params = [add_param_run_name] + base_params
 
     activate_action(
         name="archive",
@@ -351,7 +351,7 @@ Example:
 # Restore an archived run:
 pf run restore --name <name>
 """
-    add_params = [add_param_run_name] + logging_params
+    add_params = [add_param_run_name] + base_params
 
     activate_action(
         name="restore",

--- a/src/promptflow/promptflow/_cli/_pf/_tool.py
+++ b/src/promptflow/promptflow/_cli/_pf/_tool.py
@@ -8,7 +8,7 @@ import re
 import shutil
 from pathlib import Path
 
-from promptflow._cli._params import add_param_set_tool_extra_info, logging_params
+from promptflow._cli._params import add_param_set_tool_extra_info, base_params
 from promptflow._cli._pf._init_entry_generators import (
     InitGenerator,
     ManifestGenerator,
@@ -61,7 +61,7 @@ pf tool init --tool tool_name
         add_param_package,
         add_param_tool,
         add_param_set_tool_extra_info,
-    ] + logging_params
+    ] + base_params
     return activate_action(
         name="init",
         description="Creating a tool.",
@@ -86,7 +86,7 @@ pf tool list --flow flow-path
     add_param_flow = lambda parser: parser.add_argument("--flow", type=str, help="the flow directory")  # noqa: E731
     add_params = [
         add_param_flow,
-    ] + logging_params
+    ] + base_params
     return activate_action(
         name="list",
         description="List tools.",

--- a/src/promptflow/promptflow/_cli/_pf/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf/entry.py
@@ -107,7 +107,8 @@ def entry(argv):
     Control plane CLI tools for promptflow.
     """
     prog, args = get_parser_args(argv)
-    setup_user_agent_to_operation_context(args.user_agent)
+    if hasattr(args, "user_agent"):
+        setup_user_agent_to_operation_context(args.user_agent)
     logger = get_telemetry_logger()
     with log_activity(logger, _get_cli_activity_name(cli=prog, args=args), activity_type=ActivityType.PUBLICAPI):
         run_command(args)

--- a/src/promptflow/promptflow/_cli/_pf/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf/entry.py
@@ -25,8 +25,12 @@ from promptflow._cli._pf._tool import add_tool_parser, dispatch_tool_commands  #
 from promptflow._cli._pf.help import show_privacy_statement, show_welcome_message  # noqa: E402
 from promptflow._cli._user_agent import USER_AGENT  # noqa: E402
 from promptflow._sdk._constants import LOGGER_NAME  # noqa: E402
-from promptflow._sdk._utils import LoggerFactory, get_promptflow_sdk_version, print_pf_version, \
-    setup_user_agent_to_operation_context  # noqa: E402
+from promptflow._sdk._utils import (  # noqa: E402
+    LoggerFactory,
+    get_promptflow_sdk_version,
+    print_pf_version,
+    setup_user_agent_to_operation_context,
+)
 
 # configure logger for CLI
 logger = LoggerFactory.get_logger(name=LOGGER_NAME, verbosity=logging.WARNING)
@@ -103,6 +107,7 @@ def entry(argv):
     Control plane CLI tools for promptflow.
     """
     prog, args = get_parser_args(argv)
+    setup_user_agent_to_operation_context(args.user_agent)
     logger = get_telemetry_logger()
     with log_activity(logger, _get_cli_activity_name(cli=prog, args=args), activity_type=ActivityType.PUBLICAPI):
         run_command(args)

--- a/src/promptflow/promptflow/_cli/_pf_azure/_connection.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/_connection.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from dotenv import dotenv_values
 
-from promptflow._cli._params import add_param_connection_name, add_param_env, logging_params
+from promptflow._cli._params import add_param_connection_name, add_param_env, base_params
 from promptflow._cli._utils import _set_workspace_argument_for_subparsers, activate_action, get_client_for_cli
 from promptflow._sdk._constants import LOGGER_NAME
 from promptflow._utils.logger_utils import LoggerFactory
@@ -38,7 +38,7 @@ def add_connection_create(subparsers):
         add_param_connection_name,
         add_param_type,
         add_param_env,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="create",
@@ -56,7 +56,7 @@ def add_connection_get(subparsers):
         _set_workspace_argument_for_subparsers,
         add_param_connection_name,
         add_param_env,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="get",

--- a/src/promptflow/promptflow/_cli/_pf_azure/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/_flow.py
@@ -14,7 +14,7 @@ from promptflow._cli._params import (
     add_param_max_results,
     add_param_output_format,
     add_param_set,
-    logging_params,
+    base_params,
 )
 from promptflow._cli._pf_azure._utils import _get_azure_pf_client
 from promptflow._cli._utils import (
@@ -69,7 +69,7 @@ pfazure flow create --flow <flow-folder-path> --set display_name=<flow-display-n
         _set_workspace_argument_for_subparsers,
         add_param_source,
         add_param_set,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="create",
@@ -110,7 +110,7 @@ pfazure flow list --include-others
         add_param_include_archived,
         add_param_output_format,
         _set_workspace_argument_for_subparsers,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="list",
@@ -131,7 +131,7 @@ Examples:
 # Get flow:
 pfazure flow show --name <flow-name>
 """
-    add_params = [add_param_flow_name, _set_workspace_argument_for_subparsers] + logging_params
+    add_params = [add_param_flow_name, _set_workspace_argument_for_subparsers] + base_params
 
     activate_action(
         name="show",
@@ -156,7 +156,7 @@ def add_parser_flow_download(subparsers):
         _set_workspace_argument_for_subparsers,
         add_param_source,
         add_param_destination,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="download",

--- a/src/promptflow/promptflow/_cli/_pf_azure/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/_run.py
@@ -17,7 +17,7 @@ from promptflow._cli._params import (
     add_param_run_name,
     add_param_set,
     add_param_verbose,
-    logging_params,
+    base_params,
 )
 from promptflow._cli._pf._run import _parse_metadata_args, add_run_create_common, create_run
 from promptflow._cli._pf_azure._utils import _get_azure_pf_client
@@ -109,7 +109,7 @@ pfazure run list --output table
         add_param_include_archived,
         add_param_output_format,
         _set_workspace_argument_for_subparsers,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="list",
@@ -154,7 +154,7 @@ pfazure run show --name <name>
     add_params = [
         _set_workspace_argument_for_subparsers,
         add_param_run_name,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="show",
@@ -190,7 +190,7 @@ pfazure run show-details --name <name>
         add_param_max_results,
         add_param_run_name,
         add_param_all_results,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="show-details",
@@ -214,7 +214,7 @@ pfazure run show-metrics --name <name>
     add_params = [
         _set_workspace_argument_for_subparsers,
         add_param_run_name,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="show-metrics",
@@ -232,7 +232,7 @@ def add_parser_run_cancel(subparsers):
     add_params = [
         _set_workspace_argument_for_subparsers,
         add_param_run_name,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="cancel",
@@ -267,7 +267,7 @@ pfazure run visualize --names "<name1>, <name2>"
         add_param_name,
         add_param_html_path,
         _set_workspace_argument_for_subparsers,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="visualize",
@@ -291,7 +291,7 @@ pfazure run archive -n <name>
     add_params = [
         _set_workspace_argument_for_subparsers,
         add_param_run_name,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="archive",
@@ -315,7 +315,7 @@ pfazure run restore -n <name>
     add_params = [
         _set_workspace_argument_for_subparsers,
         add_param_run_name,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="restore",
@@ -340,7 +340,7 @@ pf run update --name <name> --set display_name="<display-name>" description="<de
         _set_workspace_argument_for_subparsers,
         add_param_run_name,
         add_param_set,
-    ] + logging_params
+    ] + base_params
 
     activate_action(
         name="update",

--- a/src/promptflow/promptflow/_cli/_pf_azure/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/entry.py
@@ -93,7 +93,8 @@ def entry(argv):
     Control plane CLI tools for promptflow cloud version.
     """
     prog, args = get_parser_args(argv)
-    setup_user_agent_to_operation_context(args.user_agent)
+    if hasattr(args, "user_agent"):
+        setup_user_agent_to_operation_context(args.user_agent)
     logger = get_telemetry_logger()
     with log_activity(logger, _get_cli_activity_name(cli=prog, args=args), activity_type=ActivityType.PUBLICAPI):
         run_command(args)

--- a/src/promptflow/promptflow/_cli/_pf_azure/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/entry.py
@@ -7,8 +7,7 @@ import time
 
 from promptflow._cli._user_agent import USER_AGENT
 from promptflow._cli._utils import _get_cli_activity_name
-
-from promptflow._telemetry.activity import log_activity, ActivityType
+from promptflow._telemetry.activity import ActivityType, log_activity
 from promptflow._telemetry.telemetry import get_telemetry_logger
 
 # Log the start time
@@ -94,6 +93,7 @@ def entry(argv):
     Control plane CLI tools for promptflow cloud version.
     """
     prog, args = get_parser_args(argv)
+    setup_user_agent_to_operation_context(args.user_agent)
     logger = get_telemetry_logger()
     with log_activity(logger, _get_cli_activity_name(cli=prog, args=args), activity_type=ActivityType.PUBLICAPI):
         run_command(args)

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1582,3 +1582,20 @@ class TestCli:
 
         config = Configuration.get_instance()
         assert config.get_run_output_path() is None
+
+    def test_user_agent_in_cli(self):
+        context = OperationContext().get_instance()
+        context.user_agent = ""
+        with pytest.raises(SystemExit):
+            run_pf_command(
+                "run",
+                "show",
+                "--name",
+                "not_exist",
+                "--user-agent",
+                "a/1.0.0 b/2.0",
+            )
+        user_agent = context.get_user_agent()
+        ua_dict = parse_ua_to_dict(user_agent)
+        assert ua_dict.keys() == {"promptflow-sdk", "promptflow-cli", "promptflow", "a", "b"}
+        context.user_agent = ""


### PR DESCRIPTION
# Description
This pull request includes various changes to improve the codebase and enhance functionality. The most important changes include adding a new test method to verify the parsing of the user agent string, replacing the `logging_params` list with `base_params` in multiple files to align with other parts of the codebase, and reorganizing and formatting imports for better readability.

Main changes:

![image](https://github.com/microsoft/promptflow/assets/7776147/467d2736-c104-4299-9bab-a0b6011d5a7f)


* <a href="diffhunk://#diff-7d74ecb42a689e4b7dea2171b91f90db56f79b6efcd70629df1548a1b091f229R1585-R1601">`src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py`</a>: Added a new test method to verify the parsing of the user agent string.
* <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aR9-L12">`src/promptflow/promptflow/_cli/_pf/_flow.py`</a>: Replaced the `logging_params` list, changed the code in the `add_params` list, added comments, and added a new line to support a new command-line argument. <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aR9-L12">[1]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL230-R230">[2]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL114-R114">[3]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aR444">[4]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aR471">[5]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL26-R26">[6]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL157-R157">[7]</a> <a href="diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL461-R462">[8]</a>
* <a href="diffhunk://#diff-3f1dd7459115086f5d3af3d298744079416aebf0a0a99d19883591e7e053cf19L10-R10">`src/promptflow/promptflow/_cli/_pf_azure/entry.py`</a>: Reordered imports and called a new function before `run_command`. <a href="diffhunk://#diff-3f1dd7459115086f5d3af3d298744079416aebf0a0a99d19883591e7e053cf19L10-R10">[1]</a> <a href="diffhunk://#diff-3f1dd7459115086f5d3af3d298744079416aebf0a0a99d19883591e7e053cf19R96">[2]</a>
* <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL20-R20">`src/promptflow/promptflow/_cli/_pf_azure/_run.py`</a>: Replaced the `logging_params` list with `base_params` in multiple functions to align with other parts of the codebase. <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL20-R20">[1]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL112-R112">[2]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL157-R157">[3]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL193-R193">[4]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL217-R217">[5]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL235-R235">[6]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL270-R270">[7]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL294-R294">[8]</a> <a href="diffhunk://#diff-d1106ac9efec0530a00183e566fba9267ce3921980b402013fd4c84472a612fcL318-R318">[9]</a>
* <a href="diffhunk://#diff-7c0d2a6cfd484cf85243d066b97d778262865bf89f5467443fe643448ecc8863L159-R159">`src/promptflow/promptflow/_cli/_pf_azure/_flow.py`</a>: Replaced the `logging_params` list with `base_params` in multiple functions to align with other parts of the codebase. <a href="diffhunk://#diff-7c0d2a6cfd484cf85243d066b97d778262865bf89f5467443fe643448ecc8863L159-R159">[1]</a> <a href="diffhunk://#diff-7c0d2a6cfd484cf85243d066b97d778262865bf89f5467443fe643448ecc8863L113-R113">[2]</a> <a href="diffhunk://#diff-7c0d2a6cfd484cf85243d066b97d778262865bf89f5467443fe643448ecc8863L17-R17">[3]</a> <a href="diffhunk://#diff-7c0d2a6cfd484cf85243d066b97d778262865bf89f5467443fe643448ecc8863L72-R72">[4]</a> <a href="diffhunk://#diff-7c0d2a6cfd484cf85243d066b97d778262865bf89f5467443fe643448ecc8863L134-R134">[5]</a>

Other changes:

* <a href="diffhunk://#diff-7581c5b0944dfe909efffe3e4890ac2994e8663e06b83bd8a51872c1c4e0dd8eL9-R9">`src/promptflow/promptflow/_cli/_pf_azure/_connection.py`</a>: Replaced the `logging_params` list with `base_params` in multiple functions to align with other parts of the codebase. <a href="diffhunk://#diff-7581c5b0944dfe909efffe3e4890ac2994e8663e06b83bd8a51872c1c4e0dd8eL9-R9">[1]</a> <a href="diffhunk://#diff-7581c5b0944dfe909efffe3e4890ac2994e8663e06b83bd8a51872c1c4e0dd8eL41-R41">[2]</a> <a href="diffhunk://#diff-7581c5b0944dfe909efffe3e4890ac2994e8663e06b83bd8a51872c1c4e0dd8eL59-R59">[3]</a>
* <a href="diffhunk://#diff-d1b758c3c4c7480c2257e8db353ac834c1c1d8a961e55269030568b09d7b5ff0L89-R89">`src/promptflow/promptflow/_cli/_pf/_tool.py`</a>: Replaced the `logging_params` list with `base_params` in the `add_parser_list_tool` function and updated imports. <a href="diffhunk://#diff-d1b758c3c4c7480c2257e8db353ac834c1c1d8a961e55269030568b09d7b5ff0L89-R89">[1]</a> <a href="diffhunk://#diff-d1b758c3c4c7480c2257e8db353ac834c1c1d8a961e55269030568b09d7b5ff0L11-R11">[2]</a> <a href="diffhunk://#diff-d1b758c3c4c7480c2257e8db353ac834c1c1d8a961e55269030568b09d7b5ff0L64-R64">[3]</a>
* <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL21-R21">`src/promptflow/promptflow/_cli/_pf/_run.py`</a>: Replaced the `logging_params` list with `base_params` in multiple functions to align with other parts of the codebase. <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL21-R21">[1]</a> <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL99-R99">[2]</a> <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL160-R160">[3]</a> <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL214-R214">[4]</a> <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL263-R263">[5]</a> <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL314-R314">[6]</a> <a href="diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL334-R334">[7]</a>
* <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L142-R142">`src/promptflow/promptflow/_cli/_pf/_connection.py`</a>: Replaced the `logging_params` list with `base_params` in multiple functions to align with other parts of the codebase. <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L142-R142">[1]</a> <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L106-R106">[2]</a> <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L70-R70">[3]</a> <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L9-R9">[4]</a> <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L88-R88">[5]</a> Modified the `add_params` list in the `add_connection_delete` function for consistency. <a href="diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L124-R124">[6]</a>
* <a href="diffhunk://#diff-a3d031491a31d9faf15a922cc09d37ce21f6b5f59a78c9d2355545695661f318L43-R43">`src/promptflow/promptflow/_cli/_pf/_config.py`</a>: Replaced the `logging_params` list with `base_params` and updated the import statement. <a href="diffhunk://#diff-a3d031491a31d9faf15a922cc09d37ce21f6b5f59a78c9d2355545695661f318L43-R43">[1]</a> <a href="diffhunk://#diff-a3d031491a31d9faf15a922cc09d37ce21f6b5f59a78c9d2355545695661f318L4-R4">[2]</a> <a href="diffhunk://#diff-a3d031491a31d9faf15a922cc09d37ce21f6b5f59a78c9d2355545695661f318L25-R25">[3]</a>
* <a href="diffhunk://#diff-b8db1e22a2a3f1affd6de96bc94ffee0363fb5a80a1b3452e5fd6926ce7a914cR110">`src/promptflow/promptflow/_cli/_pf/entry.py`</a>: Added a new function before `run_command` and reorganized and formatted imports for readability. <a href="diffhunk://#diff-b8db1e22a2a3f1affd6de96bc94ffee0363fb5a80a1b3452e5fd6926ce7a914cR110">[1]</a> <a href="diffhunk://#diff-b8db1e22a2a3f1affd6de96bc94ffee0363fb5a80a1b3452e5fd6926ce7a914cL28-R33">[2]</a>
* <a href="diffhunk://#diff-a24d8278b691d05cb31b1f98b6456a2a0e8e7816bc79bbdf1b19fe45eaa8309dR301-R303">`src/promptflow/promptflow/_cli/_params.py`</a>: Added a new parameter to the `base_params` list and defined a new function. <a href="diffhunk://#diff-a24d8278b691d05cb31b1f98b6456a2a0e8e7816bc79bbdf1b19fe45eaa8309dR301-R303">[1]</a> <a href="diffhunk://#diff-a24d8278b691d05cb31b1f98b6456a2a0e8e7816bc79bbdf1b19fe45eaa8309dR53-R57">[2]</a>

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
