### PR TITLE
feat: enable function call for csharp flow

### DIFF
--- a/src/promptflow/promptflow/_sdk/entities/_flow.py
+++ b/src/promptflow/promptflow/_sdk/entities/_flow.py
@@ -11,7 +11,7 @@ from typing import Dict, Tuple, Union
 import yaml
 from marshmallow import Schema
 
-from promptflow._constants import FlowLanguage
+from promptflow._constants import LANGUAGE_KEY, FlowLanguage
 from promptflow._sdk._constants import (
     BASE_PATH_CONTEXT_KEY,
     DEFAULT_ENCODING,
@@ -300,16 +300,11 @@ class ProtectedFlow(Flow, SchemaValidatableMixin):
         :param kwargs: flow inputs with key word arguments.
         :return:
         """
-        from promptflow._sdk.operations._flow_context_resolver import FlowContextResolver
 
         if args:
             raise UserErrorException("Flow can only be called with keyword arguments.")
 
-        invoker = FlowContextResolver.resolve(flow=self)
-
-        result = invoker._invoke(
-            data=kwargs,
-        )
+        result = self.invoke(inputs=kwargs)
         return result.output
 
     def invoke(self, inputs: dict) -> "LineResult":
@@ -317,10 +312,7 @@ class ProtectedFlow(Flow, SchemaValidatableMixin):
         from promptflow._sdk._submitter.test_submitter import TestSubmitterViaProxy
         from promptflow._sdk.operations._flow_context_resolver import FlowContextResolver
 
-        if not self._executable:
-            self._executable = self._init_executable()
-
-        if self._executable.program_language == FlowLanguage.CSharp:
+        if self.dag.get(LANGUAGE_KEY, FlowLanguage.Python) == FlowLanguage.CSharp:
             with TestSubmitterViaProxy(flow=self, flow_context=self.context).init() as submitter:
                 result = submitter.exec_with_inputs(
                     inputs=inputs,


### PR DESCRIPTION
# Description

This pull request simplifies the code in the `src/promptflow/promptflow/_sdk/entities/_flow.py` file by removing an unnecessary import statement and changing how the `invoker` object is created. Instead of using the `FlowContextResolver.resolve()` method, the `invoke()` method is called directly on `self` with the `inputs` parameter.

Main code simplification:

* <a href="diffhunk://#diff-339752a6e9c04159a62708efed6b385bd91b016a0f0d2edeb32024fd19886a2bL303-R307">`src/promptflow/promptflow/_sdk/entities/_flow.py`</a>: Removed the import statement for `FlowContextResolver` and changed the creation of the `invoker` object to directly call the `invoke()` method on `self` with the `inputs` parameter.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
