### PR TITLE
[Fundamental] Introduce stale for issue/PR status monitor

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
+          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
+          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
+          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
+          days-before-issue-stale: 30
+          days-before-pr-stale: 45
+          days-before-issue-close: 5
+          days-before-pr-close: 10

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,8 @@
-name: 'Close stale issues and PRs'
+name: 'Close stale issues and pull requests'
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 21 * * *'  # 5:30 Beijing Time (GMT+8)
+  workflow_dispatch:
 
 jobs:
   stale:
@@ -12,11 +13,14 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 5 days.'
-          stale-pr-message: 'This PR is stale because it has been open 45 days with no activity. Remove stale label or comment or this will be closed in 10 days.'
-          close-issue-message: 'This issue was closed because it has been stalled for 5 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 10 days with no activity.'
-          days-before-issue-stale: 30
-          days-before-pr-stale: 45
-          days-before-issue-close: 5
-          days-before-pr-close: 10
+          # stale issue/pull request
+          stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 7 days. We need more information about this issue to help address it. Please be sure to give us your input."
+          stale-issue-label: 'no-recent-activity'
+          stale-pr-message: "Hi, thank you for your interest in helping to improve the prompt flow experience and for your contribution. We've noticed that there hasn't been recent engagement on this pull request. If this is still an active work stream, please let us know by pushing some changes or leaving a comment."
+          stale-pr-label: 'no-recent-activity'
+          days-before-issue-stale: 7
+          days-before-pr-stale: 7
+          # # close issue/pull request
+          # close-pr-message: 'Hi, thank you for your contribution. Since there hasn't been recent engagement, we're going to close this out.'
+          # days-before-issue-close: 14
+          # days-before-pr-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,14 +13,15 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
+          exempt-issue-labels: 'long-term'  # syntax: <label1>,<label2>
           # stale issue/pull request
-          stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 7 days. We need more information about this issue to help address it. Please be sure to give us your input."
+          stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 30 days. We need more information about this issue to help address it. Please be sure to give us your input."
           stale-issue-label: 'no-recent-activity'
           stale-pr-message: "Hi, thank you for your interest in helping to improve the prompt flow experience and for your contribution. We've noticed that there hasn't been recent engagement on this pull request. If this is still an active work stream, please let us know by pushing some changes or leaving a comment."
           stale-pr-label: 'no-recent-activity'
-          days-before-issue-stale: 7
+          days-before-issue-stale: 30
           days-before-pr-stale: 7
           # # close issue/pull request
           # close-pr-message: 'Hi, thank you for your contribution. Since there hasn't been recent engagement, we're going to close this out.'
-          # days-before-issue-close: 14
+          # days-before-issue-close: 7
           # days-before-pr-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
           stale-pr-message: "Hi, thank you for your interest in helping to improve the prompt flow experience and for your contribution. We've noticed that there hasn't been recent engagement on this pull request. If this is still an active work stream, please let us know by pushing some changes or leaving a comment."
           stale-pr-label: 'no-recent-activity'
           days-before-issue-stale: 30
-          days-before-pr-stale: 7
+          days-before-pr-stale: 14
           # # close issue/pull request
           # close-pr-message: 'Hi, thank you for your contribution. Since there hasn't been recent engagement, we're going to close this out.'
           # days-before-issue-close: 7

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v8
         with:


### PR DESCRIPTION
# Description

This PR targets to leverage [actions/stale](https://github.com/actions/stale) to add label for stale issue/PR.

In short, issue will be tagged label `no-recent-activity` after 30 days, and stale PR will be tagged after 7 days. Issues with label `long-term` will be excluded.

**References**

- Azure SDK stale issue: <https://github.com/Azure/azure-sdk-for-python/issues/32959>
- Azure SDK stale pull request: <https://github.com/Azure/azure-sdk-for-python/pull/32182>

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
