### PR TITLE
Fix error message for python 3.11.

### DIFF
--- a/src/promptflow/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow/promptflow/_core/tool_meta_generator.py
@@ -44,7 +44,7 @@ def generate_prompt_tool(name, content, prompt_only=False, source=None):
                 "Generate tool meta failed for {tool_type} tool. Jinja parsing failed at line {line_number}: "
                 "{error_type_and_message}"
             ),
-            tool_type=tool_type,
+            tool_type=tool_type.value,
             line_number=e.lineno,
             error_type_and_message=error_type_and_message,
         ) from e


### PR DESCRIPTION
# Description

For python 3.11, error message change to `ToolType.PROMPT`, but we expect `prompt`.

from chatgpt: In Python 3.11, the default `__str__` method of Enum members has been changed to return the same value as `__repr__`. This means that when you print an Enum member, you'll see the Enum class name and member name, rather than just the value of the member.  

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
