### PR TITLE
Fixing other cross-python version test failure issues

### DIFF
--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -107,7 +107,7 @@ def raise_promptflow_exception_without_inner_exception():
 TOOL_EXECUTION_ERROR_TRACEBACK = r"""Traceback \(most recent call last\):
   File ".*test_exception_utils.py", line .*, in code_with_bug
     1 / 0
-ZeroDivisionError: division by zero
+(?:    .*\n)?ZeroDivisionError: division by zero
 """
 
 TOOL_EXCEPTION_TRACEBACK = r"""


### PR DESCRIPTION
# Description

1. **Error position in traceback**
In Python 3.11, the addition of caret symbols (^) pointing to the exact location of an error within a line is part of the improvements to error messages and tracebacks. This enhancement is designed to make debugging easier by providing more precise information about where an error occurred in the code.
This feature is related to PEP 657 -- Include Fine Grained Error Locations in Tracebacks. PEP 657 introduces several enhancements to Python tracebacks

**Example**
![image](https://github.com/microsoft/promptflow/assets/95913588/85da92ec-57dc-4412-93ba-41a1d9aef543)

**Action**
Just ignore the position info the traceback message pattern

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
