### PR TITLE
[promptflow][BugFix] Empty logs in visualize HTML to avoid large file

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - [SDK/CLI] Removing telemetry warning when running commands.
+- Empty node stdout & stderr to avoid large visualize HTML.
 
 ## 1.1.1 (2023.12.1)
 

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -284,6 +284,13 @@ class RunOperations(TelemetryMixin):
 
             local_storage = LocalStorageOperations(run)
             detail = local_storage.load_detail()
+            # ad-hoc step: make logs field empty to avoid too big HTML file
+            # we don't provide logs view in visualization page for now
+            # when we enable, we will save those big data (e.g. logs) in separate file(s)
+            # JS load can be faster than static HTML
+            for i in range(len(detail["node_runs"])):
+                detail["node_runs"][i]["logs"] = {"stdout": "", "stderr": ""}
+
             metadata = RunMetadata(
                 name=run.name,
                 display_name=run.display_name,


### PR DESCRIPTION
# Description

#1354 mentions that logs can lead to large visualize HTML file and browser cannot open. As we do not provide logs view in visualize page, empty the logs field as work around.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
