### PR TITLE
Fixing the enum related failing test under python 3.11

### DIFF
--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -627,7 +627,7 @@ class TestExceptions:
         assert e.reference_code == ErrorTarget.TOOL
         module = "promptflow_vectordb.tool.faiss_index_loopup"
         e.module = module
-        assert e.reference_code == f"{ErrorTarget.TOOL}/{module}"
+        assert e.reference_code == f"{ErrorTarget.TOOL.value}/{module}"
 
     @pytest.mark.parametrize(
         "func_that_raises_exception",

--- a/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_exception_utils.py
@@ -624,7 +624,7 @@ class TestExceptions:
             raise_tool_execution_error()
 
         e = e.value
-        assert e.reference_code == ErrorTarget.TOOL
+        assert e.reference_code == ErrorTarget.TOOL.value
         module = "promptflow_vectordb.tool.faiss_index_loopup"
         e.module = module
         assert e.reference_code == f"{ErrorTarget.TOOL.value}/{module}"


### PR DESCRIPTION
# Description

This is to fixing the failing test: test_reference_code under python 3.11

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
