### PR TITLE
[Fundamental] Refine stale workflow: Increase operations-per-run and exclude long-term PR

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
+          operations-per-run: 256
           exempt-issue-labels: 'long-term'  # syntax: <label1>,<label2>
           # stale issue/pull request
           stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 30 days. We need more information about this issue to help address it. Please be sure to give us your input."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           operations-per-run: 256
           exempt-issue-labels: 'long-term'  # syntax: <label1>,<label2>
+          exempt-pr-labels: 'long-term'
           # stale issue/pull request
           stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 30 days. We need more information about this issue to help address it. Please be sure to give us your input."
           stale-issue-label: 'no-recent-activity'


### PR DESCRIPTION
# Description

This PR targets to refine stale workflow:

- Increase `operations-per-run`: according to https://github.com/microsoft/promptflow/actions/runs/7120514752, in our scenario, we need to increase this limit.
- Exclude PR with label `long-term`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
