### PR TITLE
Fix Upload in sdk cli test

### DIFF
--- a/.github/workflows/promptflow-sdk-cli-test.yml
+++ b/.github/workflows/promptflow-sdk-cli-test.yml
@@ -105,7 +105,7 @@ jobs:
           -l eastus `
           -m "unittest or e2etest" `
           --coverage-config ${{ github.workspace }}/src/promptflow/tests/sdk_cli_test/.coveragerc `
-          -o "${{ github.workspace }}/test-results-sdk-cli.xml" `
+          -o "${{ env.testWorkingDirectory }}/test-results-sdk-cli.xml" `
           --ignore-glob ${{ github.workspace }}/src/promptflow/tests/sdk_cli_test/e2etests/test_executable.py
     - name: Install pf executable
       shell: pwsh
@@ -125,14 +125,14 @@ jobs:
           -t ${{ github.workspace }}/src/promptflow/tests/sdk_cli_test/e2etests/test_executable.py `
           -l eastus `
           -m "unittest or e2etest" `
-          -o "${{ github.workspace }}/test-results-sdk-cli-executable.xml"
+          -o "${{ env.testWorkingDirectory }}/test-results-sdk-cli-executable.xml"
     - name: Upload Test Results
       if: always()
       uses: actions/upload-artifact@v3
       with:
         name: Test Results (Python ${{ matrix.pythonVersion }}) (OS ${{ matrix.os }})
         path: |
-          ${{ github.workspace }}/*.xml
+          ${{ env.testWorkingDirectory }}/*.xml
           ${{ env.testWorkingDirectory }}/htmlcov/
   publish-test-results:
     name: "Publish Tests Results"


### PR DESCRIPTION
# Description

Fix Upload in sdk cli test when call run_coverage_test with -o parameter

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
