### PR TITLE
[PromptFlow]Skip test when process startup mode is not supported

### DIFF
--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -384,6 +384,8 @@ class TestLineExecutionProcessPool:
             is_set_environ_pf_worker_count,
             pf_worker_count,
             n_process):
+        if "fork" not in multiprocessing.get_all_start_methods():
+            pytest.skip("Unsupported start method: fork")
         p = multiprocessing.Process(
             target=test_fork_mode_parallelism_in_subprocess,
             args=(dev_connections,
@@ -410,7 +412,7 @@ class TestLineExecutionProcessPool:
             (SAMPLE_FLOW, False, True, None, 2, 2)
         ],
     )
-    def test_process_pool_parallelism_in_non_spawn_mode(
+    def test_process_pool_parallelism_in_spawn_mode(
         self,
         dev_connections,
         flow_folder,
@@ -420,6 +422,8 @@ class TestLineExecutionProcessPool:
         estimated_available_worker_count,
         n_process
     ):
+        if "spawn" not in multiprocessing.get_all_start_methods():
+            pytest.skip("Unsupported start method: spawn")
         p = multiprocessing.Process(
             target=test_spawn_mode_parallelism_in_subprocess,
             args=(dev_connections,


### PR DESCRIPTION
# Description

Skip test when process startup mode is not supported.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
