### PR TITLE
Update promptflow-tools test package version generation

### DIFF
--- a/.github/workflows/wheel_distributing.yml
+++ b/.github/workflows/wheel_distributing.yml
@@ -26,7 +26,8 @@ on:
       PackageVersion:
         description: 'The version of the package'
         value: ${{ jobs.sdk_release.outputs.PackageVersion }}
-
+env:
+  versionPath: 'src/promptflow-tools/promptflow/version.txt'
 jobs:
   sdk_release:
     runs-on: ubuntu-latest
@@ -51,9 +52,20 @@ jobs:
         id: override_version
         if: github.event_name == 'push'
         run: |
-          echo "VERSION = \"0.0.${{ github.run_number }}\"" > src/${{ inputs.SourceFolderName }}/promptflow/version.txt
-          echo "VERSION: 0.0.${{ github.run_number }}"
-          echo "version=0.0.${{ github.run_number }}" >> "$GITHUB_OUTPUT"
+          latest_version=$(cat 'src/promptflow-tools/promptflow/version.txt' |  grep -oP '(?<=VERSION = ")[^"]*')
+          echo "latest promptflow-tools version: $latest_version"
+
+          pip install bump2version
+          cp scripts/promptflow_tools_release/.bumpversion.cfg ./
+          echo $latest_version > version.txt
+          bump2version minor --current-version $latest_version
+          next_release_version=$(head -n 1 version.txt)
+          echo "next promptflow-tools version: $next_release_version"
+
+          version="${next_release_version}rc${{ github.run_number }}"
+          echo "VERSION = \"${version}\"" > src/${{ inputs.SourceFolderName }}/promptflow/version.txt
+          echo "VERSION: ${version}"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - name: Set up conda environment
         uses: conda-incubator/setup-miniconda@v2

--- a/scripts/promptflow_tools_release/.bumpversion.cfg
+++ b/scripts/promptflow_tools_release/.bumpversion.cfg
@@ -2,6 +2,5 @@
 parse = (?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}
-current_version = 1.1.0
 
 [bumpversion:file:version.txt]

--- a/scripts/promptflow_tools_release/.bumpversion.cfg
+++ b/scripts/promptflow_tools_release/.bumpversion.cfg
@@ -1,0 +1,7 @@
+[bumpversion]
+parse = (?P<major>\d+).(?P<minor>\d+).(?P<patch>\d+)
+serialize = 
+	{major}.{minor}.{patch}
+current_version = 1.1.0
+
+[bumpversion:file:version.txt]


### PR DESCRIPTION
# Description
This PR updates the CI to generate a test package version for promptflow-tools, using the same logic as the promptflow SDK candidate version.

The public version of promptflow-tools packages can be found in the file: src/promptflow-tools/promptflow/version.txt. 
The versioning follows the {major}.{minor}.{patch} format. For instance, the version could be 1.0.0.

The version for the test packages should be 1.1.0rc{RunNumber}, where the minor version is incremented by 1.

You can see an example run [here](https://github.com/liuyuhang13/promptflow/actions/runs/7126042737/job/19403139884)
![image](https://github.com/microsoft/promptflow/assets/20365062/f3345a46-3037-44ef-b87d-f4020c977f5c)




# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
