### PR TITLE
[PromptFlow] Set the process startup mode to fork on Mac.

### DIFF
--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -59,7 +59,7 @@ def test_fork_mode_parallelism_in_subprocess(
         is_set_environ_pf_worker_count,
         pf_worker_count,
         n_process):
-
+    os.environ["PF_BATCH_METHOD"] = "fork"
     if is_set_environ_pf_worker_count:
         os.environ["PF_WORKER_COUNT"] = pf_worker_count
     executor = FlowExecutor.create(

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -52,8 +52,7 @@ def get_bulk_inputs(nlinee=4, flow_folder="", sample_inputs_file="", return_dict
     return [get_line_inputs() for _ in range(nlinee)]
 
 
-@pytest.mark.skip("This is a subprocess function used for testing and cannot be tested alone.")
-def test_fork_mode_parallelism_in_subprocess(
+def execute_in_fork_mode_subprocess(
         dev_connections,
         flow_folder,
         is_set_environ_pf_worker_count,
@@ -95,8 +94,7 @@ def test_fork_mode_parallelism_in_subprocess(
                 )
 
 
-@pytest.mark.skip("This is a subprocess function used for testing and cannot be tested alone.")
-def test_spawn_mode_parallelism_in_subprocess(
+def execute_in_spawn_mode_subprocess(
         dev_connections,
         flow_folder,
         is_set_environ_pf_worker_count,
@@ -387,7 +385,7 @@ class TestLineExecutionProcessPool:
         if "fork" not in multiprocessing.get_all_start_methods():
             pytest.skip("Unsupported start method: fork")
         p = multiprocessing.Process(
-            target=test_fork_mode_parallelism_in_subprocess,
+            target=execute_in_fork_mode_subprocess,
             args=(dev_connections,
                   flow_folder,
                   is_set_environ_pf_worker_count,
@@ -425,7 +423,7 @@ class TestLineExecutionProcessPool:
         if "spawn" not in multiprocessing.get_all_start_methods():
             pytest.skip("Unsupported start method: spawn")
         p = multiprocessing.Process(
-            target=test_spawn_mode_parallelism_in_subprocess,
+            target=execute_in_spawn_mode_subprocess,
             args=(dev_connections,
                   flow_folder,
                   is_set_environ_pf_worker_count,


### PR DESCRIPTION
# Description

On macOS, the default process start method is spawn after version 3.8. 
Set the process start method to fork on macOS.
[Related Link](https://docs.python.org/3/library/multiprocessing.html#:~:text=Changed%20in%20version%203.8%3A%20On%20macOS%2C%20the%20spawn%20start%20method%20is%20now%20the%20default.%20The%20fork%20start%20method%20should%20be%20considered%20unsafe%20as%20it%20can%20lead%20to%20crashes%20of%20the%20subprocess%20as%20macOS%20system%20libraries%20may%20start%20threads.%20See%20bpo%2D33725.)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
