### PR TITLE
feat: correct the way to get used connection names for csharp

### DIFF
--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -283,6 +283,11 @@ class ConnectionType(str, Enum):
     CUSTOM = "Custom"
 
 
+ALL_CONNECTION_TYPES = set(
+    map(lambda x: f"{x.value}Connection", filter(lambda x: x != ConnectionType._NOT_SET, ConnectionType))
+)
+
+
 class ConnectionFields(str, Enum):
     CONNECTION = "connection"
     DEPLOYMENT_NAME = "deployment_name"

--- a/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
@@ -13,7 +13,7 @@ from typing import Any, Mapping
 from promptflow._internal import ConnectionManager
 from promptflow._sdk._constants import LOGGER_NAME, PROMPT_FLOW_DIR_NAME
 from promptflow._sdk._utils import dump_flow_result, parse_variant
-from promptflow._sdk.entities._flow import Flow, FlowContext
+from promptflow._sdk.entities._flow import FlowContext, ProtectedFlow
 from promptflow._sdk.operations._local_storage_operations import LoggerOperations
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.exception_utils import ErrorResponse
@@ -32,7 +32,7 @@ logger = LoggerFactory.get_logger(LOGGER_NAME)
 
 
 class TestSubmitter:
-    def __init__(self, flow: Flow, flow_context: FlowContext, client=None):
+    def __init__(self, flow: ProtectedFlow, flow_context: FlowContext, client=None):
         self.flow = flow
         self._origin_flow = flow
         self._dataplane_flow = None
@@ -397,7 +397,7 @@ class TestSubmitter:
 
 
 class TestSubmitterViaProxy(TestSubmitter):
-    def __init__(self, flow: Flow, flow_context: FlowContext, client=None):
+    def __init__(self, flow: ProtectedFlow, flow_context: FlowContext, client=None):
         super().__init__(flow, flow_context, client)
 
     def flow_test(
@@ -413,8 +413,9 @@ class TestSubmitterViaProxy(TestSubmitter):
         from promptflow._constants import LINE_NUMBER_KEY
 
         if not connections:
-            connections = SubmitterHelper.resolve_connection_names_from_tool_meta(
-                tools_meta=CSharpExecutorProxy.generate_tool_metadata(
+            connections = SubmitterHelper.get_used_connection_names(
+                tools_meta=CSharpExecutorProxy.get_tool_metadata(
+                    flow_file=self.flow.flow_dag_path,
                     working_dir=self.flow.code,
                 ),
                 flow_dag=self.flow.dag,
@@ -468,20 +469,22 @@ class TestSubmitterViaProxy(TestSubmitter):
     def exec_with_inputs(self, inputs):
         from promptflow._constants import LINE_NUMBER_KEY
 
-        try:
-            connections = SubmitterHelper.resolve_connection_names_from_tool_meta(
-                tools_meta=CSharpExecutorProxy.generate_tool_metadata(
-                    working_dir=self.flow.code,
-                ),
-                flow_dag=self.flow.dag,
-            )
-            storage = DefaultRunStorage(base_dir=self.flow.code, sub_dir=Path(".promptflow/intermediate"))
-            flow_executor = CSharpExecutorProxy.create(
+        connections = SubmitterHelper.get_used_connection_names(
+            tools_meta=CSharpExecutorProxy.get_tool_metadata(
                 flow_file=self.flow.path,
                 working_dir=self.flow.code,
-                connections=connections,
-                storage=storage,
-            )
+            ),
+            flow_dag=self.flow.dag,
+        )
+        storage = DefaultRunStorage(base_dir=self.flow.code, sub_dir=Path(".promptflow/intermediate"))
+        flow_executor = CSharpExecutorProxy.create(
+            flow_file=self.flow.path,
+            working_dir=self.flow.code,
+            connections=connections,
+            storage=storage,
+        )
+
+        try:
             # validate inputs
             flow_inputs, _ = self.resolve_data(inputs=inputs, dataplane_flow=self.dataplane_flow)
             line_result = async_run_allowing_running_loop(flow_executor.exec_line_async, inputs, index=0)

--- a/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
@@ -413,12 +413,12 @@ class TestSubmitterViaProxy(TestSubmitter):
         from promptflow._constants import LINE_NUMBER_KEY
 
         if not connections:
-            connections = SubmitterHelper.get_used_connection_names(
+            connections = SubmitterHelper.resolve_used_connections(
+                flow=self.flow,
                 tools_meta=CSharpExecutorProxy.get_tool_metadata(
                     flow_file=self.flow.flow_dag_path,
                     working_dir=self.flow.code,
                 ),
-                flow_dag=self.flow.dag,
             )
         credential_list = ConnectionManager(connections).get_secret_list()
 
@@ -469,12 +469,12 @@ class TestSubmitterViaProxy(TestSubmitter):
     def exec_with_inputs(self, inputs):
         from promptflow._constants import LINE_NUMBER_KEY
 
-        connections = SubmitterHelper.get_used_connection_names(
+        connections = SubmitterHelper.resolve_used_connections(
+            flow=self.flow,
             tools_meta=CSharpExecutorProxy.get_tool_metadata(
                 flow_file=self.flow.path,
                 working_dir=self.flow.code,
             ),
-            flow_dag=self.flow.dag,
         )
         storage = DefaultRunStorage(base_dir=self.flow.code, sub_dir=Path(".promptflow/intermediate"))
         flow_executor = CSharpExecutorProxy.create(

--- a/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
@@ -419,6 +419,7 @@ class TestSubmitterViaProxy(TestSubmitter):
                     flow_file=self.flow.flow_dag_path,
                     working_dir=self.flow.code,
                 ),
+                client=self._client,
             )
         credential_list = ConnectionManager(connections).get_secret_list()
 
@@ -475,6 +476,7 @@ class TestSubmitterViaProxy(TestSubmitter):
                 flow_file=self.flow.path,
                 working_dir=self.flow.code,
             ),
+            client=self._client,
         )
         storage = DefaultRunStorage(base_dir=self.flow.code, sub_dir=Path(".promptflow/intermediate"))
         flow_executor = CSharpExecutorProxy.create(

--- a/src/promptflow/promptflow/_sdk/_submitter/utils.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/utils.py
@@ -190,7 +190,7 @@ class SubmitterHelper:
 
     @staticmethod
     def resolve_connections(flow: Flow, client=None, connections_to_ignore=None) -> dict:
-        # TODO: use resolve_used_connections instead of this function to avoid using executable in control-plane
+        # TODO 2856400: use resolve_used_connections instead of this function to avoid using executable in control-plane
         from .._pf_client import PFClient
 
         client = client or PFClient()
@@ -203,9 +203,7 @@ class SubmitterHelper:
         )
 
     @staticmethod
-    def resolve_used_connections(
-        flow: ProtectedFlow, tools_meta: dict, client=None, connections_to_ignore=None
-    ) -> dict:
+    def resolve_used_connections(flow: ProtectedFlow, tools_meta: dict, client, connections_to_ignore=None) -> dict:
         from .._pf_client import PFClient
 
         client = client or PFClient()

--- a/src/promptflow/promptflow/_sdk/_submitter/utils.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/utils.py
@@ -186,6 +186,7 @@ class SubmitterHelper:
 
     @staticmethod
     def resolve_connections(flow: Flow, client=None, connections_to_ignore=None) -> dict:
+        # TODO: refactor this method with get_used_connection_names to avoid using executable in control-plane
         from .._pf_client import PFClient
 
         client = client or PFClient()
@@ -198,7 +199,7 @@ class SubmitterHelper:
         )
 
     @staticmethod
-    def resolve_connection_names_from_tool_meta(tools_meta: dict, flow_dag: dict,):
+    def get_used_connection_names(tools_meta: dict, flow_dag: dict):
         connection_names = set({})
         tool_names = set({})
         if tools_meta:

--- a/src/promptflow/promptflow/_sdk/_submitter/utils.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/utils.py
@@ -5,14 +5,18 @@
 
 import contextlib
 import os
+import re
 import tempfile
+from collections import defaultdict
 from os import PathLike
 from pathlib import Path
 
+import pydash
 from dotenv import load_dotenv
 from pydash import objects
 
 from promptflow._sdk._constants import (
+    ALL_CONNECTION_TYPES,
     DEFAULT_VAR_ID,
     INPUTS,
     NODE,
@@ -32,7 +36,7 @@ from promptflow._sdk._utils import (
     get_used_connection_names_from_dict,
     update_dict_value_with_connections,
 )
-from promptflow._sdk.entities._flow import Flow
+from promptflow._sdk.entities._flow import Flow, ProtectedFlow
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.flow_utils import dump_flow_dag, load_flow_dag
 from promptflow.contracts.flow import Flow as ExecutableFlow
@@ -171,7 +175,7 @@ def variant_overwrite_context(
             overwrite_connections(flow_dag, connections, working_dir=flow_dir_path)
             overwrite_flow(flow_dag, overrides)
             flow_path = dump_flow_dag(flow_dag, Path(temp_dir))
-            flow = Flow(code=flow_dir_path, path=flow_path, dag=flow_dag)
+            flow = ProtectedFlow(code=flow_dir_path, path=flow_path, dag=flow_dag)
             yield flow
 
 
@@ -186,7 +190,7 @@ class SubmitterHelper:
 
     @staticmethod
     def resolve_connections(flow: Flow, client=None, connections_to_ignore=None) -> dict:
-        # TODO: refactor this method with get_used_connection_names to avoid using executable in control-plane
+        # TODO: use resolve_used_connections instead of this function to avoid using executable in control-plane
         from .._pf_client import PFClient
 
         client = client or PFClient()
@@ -199,21 +203,43 @@ class SubmitterHelper:
         )
 
     @staticmethod
+    def resolve_used_connections(
+        flow: ProtectedFlow, tools_meta: dict, client=None, connections_to_ignore=None
+    ) -> dict:
+        from .._pf_client import PFClient
+
+        client = client or PFClient()
+        connection_names = SubmitterHelper.get_used_connection_names(tools_meta=tools_meta, flow_dag=flow.dag)
+        connections_to_ignore = connections_to_ignore or []
+        result = {}
+        for n in connection_names:
+            if n not in connections_to_ignore:
+                conn = client.connections.get(name=n, with_secrets=True)
+                result[n] = conn._to_execution_connection_dict()
+        return result
+
+    @staticmethod
     def get_used_connection_names(tools_meta: dict, flow_dag: dict):
-        connection_names = set({})
-        tool_names = set({})
-        if tools_meta:
-            packages = tools_meta.get("package", {})
-            for key, pkg in packages.items():
-                inputs = pkg.get("inputs", {})
-                if "connection" in inputs and inputs["connection"].get("type", []) == ["object"]:
-                    tool_names.add(key)
-            nodes = flow_dag.get("nodes", [])
-            for node in nodes:
-                if node.get("source", {}).get("tool", "") in tool_names:
-                    connection_names.add(node["inputs"]["connection"])
-            return list(connection_names)
-        return []
+        # TODO: handle code tool meta for python
+        connection_inputs = defaultdict(set)
+        for package_id, package_meta in tools_meta.get("package", {}).items():
+            for tool_input_key, tool_input_meta in package_meta.get("inputs", {}).items():
+                if ALL_CONNECTION_TYPES.intersection(set(tool_input_meta.get("type"))):
+                    connection_inputs[package_id].add(tool_input_key)
+
+        connection_names = set()
+        # TODO: we assume that all variants are resolved here
+        # TODO: only literal connection inputs are supported
+        # TODO: check whether we should put this logic in executor as seems it's not possible to avoid touching
+        #  information for executable
+        for node in flow_dag.get("nodes", []):
+            package_id = pydash.get(node, "source.tool")
+            if package_id in connection_inputs:
+                for connection_input in connection_inputs[package_id]:
+                    connection_name = pydash.get(node, f"inputs.{connection_input}")
+                    if connection_name and not re.match(r"\${.*}", connection_name):
+                        connection_names.add(connection_name)
+        return list(connection_names)
 
     @classmethod
     def resolve_environment_variables(cls, environment_variables: dict, client=None):

--- a/src/promptflow/promptflow/_sdk/entities/_flow.py
+++ b/src/promptflow/promptflow/_sdk/entities/_flow.py
@@ -230,6 +230,10 @@ class ProtectedFlow(Flow, SchemaValidatableMixin):
         return self.dag.get("display_name", None)
 
     @property
+    def language(self) -> str:
+        return self.dag.get(LANGUAGE_KEY, FlowLanguage.Python)
+
+    @property
     def tools_meta_path(self) -> Path:
         target_path = self._flow_dir / PROMPT_FLOW_DIR_NAME / FLOW_TOOLS_JSON
         target_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -365,10 +365,11 @@ class FlowOperations(TelemetryMixin):
 
     def _export_flow_connections(
         self,
-        flow: ProtectedFlow,
+        flow_dag_path: Path,
         *,
         output_dir: Path,
     ):
+        flow: ProtectedFlow = load_flow(flow_dag_path)
         with _change_working_dir(flow.code):
             if flow.language == FlowLanguage.CSharp:
                 from promptflow.batch import CSharpExecutorProxy
@@ -583,7 +584,7 @@ class FlowOperations(TelemetryMixin):
 
         # use new flow dag path below as origin one may miss additional includes
         connection_paths, env_var_names = self._export_flow_connections(
-            flow=flow,
+            flow_dag_path=new_flow_dag_path,
             output_dir=output_dir / "connections",
         )
 

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -365,11 +365,17 @@ class FlowOperations(TelemetryMixin):
 
     def _export_flow_connections(
         self,
-        flow_dag_path: Path,
+        built_flow_dag_path: Path,
         *,
         output_dir: Path,
     ):
-        flow: ProtectedFlow = load_flow(flow_dag_path)
+        """Export flow connections to yaml files.
+
+        :param built_flow_dag_path: path to built flow dag yaml file. Given this is a built flow, we can assume
+        that the flow involves no additional includes, symlink, or variant.
+        :param output_dir: output directory to export connections
+        """
+        flow: ProtectedFlow = load_flow(built_flow_dag_path)
         with _change_working_dir(flow.code):
             if flow.language == FlowLanguage.CSharp:
                 from promptflow.batch import CSharpExecutorProxy
@@ -584,7 +590,7 @@ class FlowOperations(TelemetryMixin):
 
         # use new flow dag path below as origin one may miss additional includes
         connection_paths, env_var_names = self._export_flow_connections(
-            flow_dag_path=new_flow_dag_path,
+            built_flow_dag_path=new_flow_dag_path,
             output_dir=output_dir / "connections",
         )
 

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -365,31 +365,29 @@ class FlowOperations(TelemetryMixin):
 
     def _export_flow_connections(
         self,
-        flow_dag_path: Path,
+        flow: ProtectedFlow,
         *,
         output_dir: Path,
     ):
-        from promptflow.batch._csharp_executor_proxy import CSharpExecutorProxy
-        from promptflow.contracts.flow import Flow as ExecutableFlow
-
-        executable = ExecutableFlow.from_yaml(
-            flow_file=Path(flow_dag_path.name), working_dir=flow_dag_path.parent.absolute()
-        )
-
-        with _change_working_dir(flow_dag_path.parent):
-            if executable.program_language == FlowLanguage.CSharp:
-                connection_names = SubmitterHelper.resolve_connection_names_from_tool_meta(
-                    tools_meta=CSharpExecutorProxy.generate_tool_metadata(
-                        working_dir=flow_dag_path.parent.absolute(),
-                    ),
-                    flow_dag=executable.serialize(),
-                )
+        with _change_working_dir(flow.code):
+            if flow.language == FlowLanguage.CSharp:
+                from promptflow.batch import CSharpExecutorProxy
 
                 return self._migrate_connections(
-                    connection_names=connection_names,
+                    connection_names=SubmitterHelper.get_used_connection_names(
+                        tools_meta=CSharpExecutorProxy.get_tool_metadata(
+                            flow_file=flow.flow_dag_path,
+                            working_dir=flow.code,
+                        ),
+                        flow_dag=flow.dag,
+                    ),
                     output_dir=output_dir,
                 )
             else:
+                # TODO: avoid using executable here
+                from promptflow.contracts.flow import Flow as ExecutableFlow
+
+                executable = ExecutableFlow.from_yaml(flow_file=flow.path, working_dir=flow.code)
                 return self._migrate_connections(
                     connection_names=executable.get_connection_names(),
                     output_dir=output_dir,
@@ -555,7 +553,7 @@ class FlowOperations(TelemetryMixin):
         output_dir = Path(output).absolute()
         output_dir.mkdir(parents=True, exist_ok=True)
 
-        flow = load_flow(flow)
+        flow: ProtectedFlow = load_flow(flow)
         is_csharp_flow = flow.dag.get(LANGUAGE_KEY, "") == FlowLanguage.CSharp
 
         if format not in ["docker", "executable"]:
@@ -585,7 +583,7 @@ class FlowOperations(TelemetryMixin):
 
         # use new flow dag path below as origin one may miss additional includes
         connection_paths, env_var_names = self._export_flow_connections(
-            flow_dag_path=new_flow_dag_path,
+            flow=flow,
             output_dir=output_dir / "connections",
         )
 

--- a/src/promptflow/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_base_executor_proxy.py
@@ -23,6 +23,15 @@ EXECUTOR_UNHEALTHY_MESSAGE = "The executor service is currently not in a healthy
 
 class AbstractExecutorProxy:
     @classmethod
+    def get_tool_metadata(cls, flow_file: Path, working_dir: Optional[Path] = None) -> dict:
+        """Generate tool metadata file for the specified flow."""
+        return cls._get_tool_metadata(flow_file, working_dir or flow_file.parent)
+
+    @classmethod
+    def _get_tool_metadata(cls, flow_file: Path, working_dir: Path) -> dict:
+        raise NotImplementedError()
+
+    @classmethod
     def create(
         cls,
         flow_file: Path,

--- a/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
@@ -96,12 +96,15 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
         return AggregationResult({}, {}, {})
 
     @classmethod
-    def generate_tool_metadata(cls, working_dir: Path) -> dict:
-        promptflow_folder = working_dir / PROMPT_FLOW_DIR_NAME
-        if promptflow_folder.exists():
-            with open(promptflow_folder / FLOW_TOOLS_JSON, mode="r", encoding=DEFAULT_ENCODING) as f:
+    def _get_tool_metadata(cls, flow_file: Path, working_dir: Path) -> dict:
+        flow_tools_json_path = working_dir / PROMPT_FLOW_DIR_NAME / FLOW_TOOLS_JSON
+        if flow_tools_json_path.is_file():
+            with open(flow_tools_json_path, mode="r", encoding=DEFAULT_ENCODING) as f:
                 return json.load(f)
-        return {}
+        raise FileNotFoundError(
+            f"Failed to fetch meta of tools: cannot find {flow_tools_json_path.absolute().as_posix()}, "
+            f"please build the flow project first."
+        )
 
     @classmethod
     def find_available_port(cls) -> str:

--- a/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
@@ -100,7 +100,13 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
         flow_tools_json_path = working_dir / PROMPT_FLOW_DIR_NAME / FLOW_TOOLS_JSON
         if flow_tools_json_path.is_file():
             with open(flow_tools_json_path, mode="r", encoding=DEFAULT_ENCODING) as f:
-                return json.load(f)
+                try:
+                    return json.load(f)
+                except json.JSONDecodeError:
+                    raise RuntimeError(
+                        f"Failed to fetch meta of tools: {flow_tools_json_path.absolute().as_posix()} "
+                        f"is not a valid json file."
+                    )
         raise FileNotFoundError(
             f"Failed to fetch meta of tools: cannot find {flow_tools_json_path.absolute().as_posix()}, "
             f"please build the flow project first."

--- a/src/promptflow/promptflow/batch/_python_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_python_executor_proxy.py
@@ -59,3 +59,13 @@ class PythonExecutorProxy(AbstractExecutorProxy):
             # For bulk run, currently we need to add line results to run_tracker
             self._flow_executor._add_line_results(line_results)
         return line_results
+
+    @classmethod
+    def _get_tool_metadata(cls, flow_file: Path, working_dir: Path) -> dict:
+        from promptflow._sdk._utils import generate_flow_tools_json
+
+        return generate_flow_tools_json(
+            flow_directory=working_dir,
+            dump=False,
+            used_packages_only=True,
+        )

--- a/src/promptflow/tests/executor/unittests/_utils/test_connection_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_connection_utils.py
@@ -86,3 +86,68 @@ class TestConnectionUtils:
             MyCustomConnectionWithDefaultValue, spec, package, package_version
         )
         assert 'api_base: "default value of api-base"' in template
+
+    @pytest.mark.parametrize(
+        "input_value, expected_connection_names",
+        [
+            pytest.param(
+                "new_ai_connection",
+                ["new_ai_connection"],
+                id="standard",
+            ),
+            pytest.param(
+                "${node.output}",
+                [],
+                id="output_reference",
+            ),
+            pytest.param(
+                "${inputs.question}",
+                [],
+                id="input_reference",
+            ),
+        ],
+    )
+    def test_get_used_connection_names_from_flow_meta(self, input_value: str, expected_connection_names: list):
+        from promptflow._sdk._submitter.utils import SubmitterHelper
+
+        connection_names = SubmitterHelper.get_used_connection_names(
+            {
+                "package": {
+                    "(Promptflow.Tools)Promptflow.Tools.BuiltInTools.AOAI.Chat": {
+                        "name": "Promptflow.Tools.BuiltInTools.AOAI.Chat",
+                        "type": "csharp",
+                        "inputs": {
+                            "connection": {"type": ["AzureOpenAIConnection"]},
+                            "prompt": {"type": ["string"]},
+                            "deployment_name": {"type": ["string"]},
+                            "objects": {"type": ["object"]},
+                        },
+                        "description": "",
+                        "class_name": "AOAI",
+                        "module": "Promptflow.Tools.BuiltInTools.AOAI",
+                        "function": "Chat",
+                        "is_builtin": True,
+                        "package": "Promptflow.Tools",
+                        "package_version": "0.0.14.0",
+                        "toolId": "(Promptflow.Tools)Promptflow.Tools.BuiltInTools.AOAI.Chat",
+                    },
+                },
+                "code": {},
+            },
+            {
+                "nodes": [
+                    {
+                        "name": "get_summarized_text_content",
+                        "type": "csharp",
+                        "source": {
+                            "type": "package",
+                            "tool": "(Promptflow.Tools)Promptflow.Tools.BuiltInTools.AOAI.Chat",
+                        },
+                        "inputs": {
+                            "connection": input_value,
+                        },
+                    },
+                ]
+            },
+        )
+        assert connection_names == expected_connection_names


### PR DESCRIPTION
# Description

This pull request includes several changes to improve code readability, maintainability, and functionality. The most important changes include refactoring code in the `_flow_operations.py` file to improve readability and maintainability, various changes in the `utils.py` file to improve code clarity and future modifications, and the addition of a new class method in the `_base_executor_proxy.py` file for generating tool metadata.

Code readability and maintainability improvements:

* <a href="diffhunk://#diff-afdd40a5d0519512dcf9be48bd46c4caaa2291b808687de77896989af63f47e4L372-R391">`src/promptflow/promptflow/_sdk/operations/_flow_operations.py`</a>: Refactored code to improve readability and maintainability by using the `load_flow` function instead of directly instantiating classes. <a href="diffhunk://#diff-afdd40a5d0519512dcf9be48bd46c4caaa2291b808687de77896989af63f47e4L372-R391">[1]</a> <a href="diffhunk://#diff-afdd40a5d0519512dcf9be48bd46c4caaa2291b808687de77896989af63f47e4L558-R557">[2]</a>
* <a href="diffhunk://#diff-38c78274ff4a19381a2129bfd86174d225e0d8537b48c80aa8f6feaca25083abR8-R19">`src/promptflow/promptflow/_sdk/_submitter/utils.py`</a>: Various changes to improve code clarity and future code modifications. <a href="diffhunk://#diff-38c78274ff4a19381a2129bfd86174d225e0d8537b48c80aa8f6feaca25083abR8-R19">[1]</a> <a href="diffhunk://#diff-38c78274ff4a19381a2129bfd86174d225e0d8537b48c80aa8f6feaca25083abL174-R178">[2]</a> <a href="diffhunk://#diff-38c78274ff4a19381a2129bfd86174d225e0d8537b48c80aa8f6feaca25083abR193">[3]</a> <a href="diffhunk://#diff-38c78274ff4a19381a2129bfd86174d225e0d8537b48c80aa8f6feaca25083abL35-R39">[4]</a> <a href="diffhunk://#diff-38c78274ff4a19381a2129bfd86174d225e0d8537b48c80aa8f6feaca25083abL201-L215">[5]</a>
* <a href="diffhunk://#diff-44ac8eeb30a630bd24987e92f8bd5a180d57a3ad067db5d937561f21771e14c5R25-R33">`src/promptflow/promptflow/batch/_base_executor_proxy.py`</a>: Added a new class method `_get_tool_metadata` to generate the tool metadata file for a flow.

Other important changes:

* <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138R486-R487">`src/promptflow/promptflow/_sdk/_submitter/test_submitter.py`</a>: Changes to improve code readability and maintainability. <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138R486-R487">[1]</a> <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138L35-R35">[2]</a> <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138L16-R16">[3]</a> <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138L400-R400">[4]</a> <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138L416-L420">[5]</a> <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138L471-L476">[6]</a>
* <a href="diffhunk://#diff-339752a6e9c04159a62708efed6b385bd91b016a0f0d2edeb32024fd19886a2bR232-R235">`src/promptflow/promptflow/_sdk/entities/_flow.py`</a>: Added a new property `language` to the `Flow` class.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
