### PR TITLE
[CLI] Show help instead of failing when calling 'pf run".

### DIFF
--- a/src/promptflow/promptflow/_cli/_pf/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf/entry.py
@@ -128,7 +128,9 @@ def main():
         show_welcome_message()
         command_args.append("-h")
     elif len(command_args) == 1:
-        command_args.append("-h")
+        # pf only has "pf --version" with 1 layer
+        if command_args[0] not in ["--version", "-v"]:
+            command_args.append("-h")
     setup_user_agent_to_operation_context(USER_AGENT)
     entry(command_args)
 

--- a/src/promptflow/promptflow/_cli/_pf/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf/entry.py
@@ -127,6 +127,8 @@ def main():
         show_privacy_statement()
         show_welcome_message()
         command_args.append("-h")
+    elif len(command_args) == 1:
+        command_args.append("-h")
     setup_user_agent_to_operation_context(USER_AGENT)
     entry(command_args)
 

--- a/src/promptflow/promptflow/_cli/_pf_azure/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/entry.py
@@ -134,8 +134,10 @@ def main():
         show_privacy_statement()
         show_welcome_message()
         command_args.append("-h")
-    if len(command_args) == 1:
-        command_args.append("-h")
+    elif len(command_args) == 1:
+        # pfazure only has "pf --version" with 1 layer
+        if command_args[0] not in ["--version", "-v"]:
+            command_args.append("-h")
     setup_user_agent_to_operation_context(USER_AGENT)
     entry(command_args)
 

--- a/src/promptflow/promptflow/_cli/_pf_azure/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/entry.py
@@ -5,6 +5,7 @@
 import json
 import time
 
+from promptflow._cli._pf.help import show_privacy_statement, show_welcome_message
 from promptflow._cli._user_agent import USER_AGENT
 from promptflow._cli._utils import _get_cli_activity_name, get_client_info_for_cli
 from promptflow._sdk._telemetry import ActivityType, get_telemetry_logger, log_activity
@@ -129,6 +130,11 @@ def main():
         version_dict = {"promptflow": get_promptflow_sdk_version()}
         return json.dumps(version_dict, ensure_ascii=False, indent=2, sort_keys=True, separators=(",", ": ")) + "\n"
     if len(command_args) == 0:
+        # print privacy statement & welcome message like azure-cli
+        show_privacy_statement()
+        show_welcome_message()
+        command_args.append("-h")
+    if len(command_args) == 1:
         command_args.append("-h")
     setup_user_agent_to_operation_context(USER_AGENT)
     entry(command_args)

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1637,3 +1637,35 @@ class TestCli:
                     "--inputs",
                     "key=API_BASE",
                 )
+
+    def test_cli_command_no_sub_command(self, capfd):
+        try:
+            run_pf_command(
+                "run",
+            )
+            # argparse will return SystemExit after running --help
+        except SystemExit:
+            pass
+        # will run pf run -h
+        out, _ = capfd.readouterr()
+        assert "A CLI tool to manage runs for prompt flow." in out
+
+        try:
+            run_pf_command("run", "-h")
+            # argparse will return SystemExit after running --help
+        except SystemExit:
+            pass
+        # will run pf run -h
+        out, _ = capfd.readouterr()
+        assert "A CLI tool to manage runs for prompt flow." in out
+
+    def test_unknown_command(self, capfd):
+        try:
+            run_pf_command(
+                "unknown",
+            )
+            # argparse will return SystemExit after running --help
+        except SystemExit:
+            pass
+        _, err = capfd.readouterr()
+        assert "invalid choice" in err


### PR DESCRIPTION
This pull request includes changes to improve the behavior and user experience of the CLI tool. The most important changes include adding function calls to display a privacy statement and a welcome message, appending `"-h"` to the `command_args` list when only one command argument is provided, and adding new test methods to verify the behavior of the CLI tool.

Before:
![image](https://github.com/microsoft/promptflow/assets/7776147/7f526ada-a57d-46ab-9913-4b34a15631a6)

After:
![image](https://github.com/microsoft/promptflow/assets/7776147/cbfec46e-0815-4a22-8e2d-01db2285a8f3)


Main functionality changes:

* <a href="diffhunk://#diff-3f1dd7459115086f5d3af3d298744079416aebf0a0a99d19883591e7e053cf19R133-R137">`src/promptflow/promptflow/_cli/_pf_azure/entry.py`</a>: Added function calls to display a privacy statement and a welcome message before showing the help message when no command arguments are provided.
* <a href="diffhunk://#diff-b8db1e22a2a3f1affd6de96bc94ffee0363fb5a80a1b3452e5fd6926ce7a914cR130-R131">`src/promptflow/promptflow/_cli/_pf/entry.py`</a>: Added an `elif` condition in `def main():` to append `"-h"` to the `command_args` list when its length is equal to 1, ensuring that the help message is shown when only one command argument is provided.

Testing improvements:

* <a href="diffhunk://#diff-7d74ecb42a689e4b7dea2171b91f90db56f79b6efcd70629df1548a1b091f229R1640-R1671">`src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py`</a>: Added two new test methods to verify the behavior of the CLI tool when no sub-command is provided and when an unknown command is provided.# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
