### PR TITLE
[example][bugfix] Make configuration example exception in workflow generation

### DIFF
--- a/.github/workflows/samples_configuration.yml
+++ b/.github/workflows/samples_configuration.yml
@@ -9,7 +9,7 @@ on:
     - cron: "40 22 * * *" # Every day starting at 6:40 BJT
   pull_request:
     branches: [ main ]
-    paths: [ examples/**, examples/*requirements.txt, .github/workflows/samples_configuration.yml, '!examples/flows/integrations/**' ]
+    paths: [ examples/configuration.ipynb, .github/workflows/samples_configuration.yml ]
   workflow_dispatch:
 
 env:

--- a/scripts/readme/workflow_generator.py
+++ b/scripts/readme/workflow_generator.py
@@ -61,6 +61,11 @@ def write_notebook_workflow(notebook, name, output_telemetry=Telemetry()):
     if "tutorials" in gh_working_dir:
         notebook_path = Path(ReadmeStepsManage.git_base_dir()) / str(notebook)
         path_filter = resolve_tutorial_resource(workflow_name, notebook_path.resolve())
+    elif "samples_configuration" in workflow_name:
+        # exception, samples configuration is very simple and not related to other prompt flow examples
+        path_filter = (
+            "[ examples/configuration.ipynb, .github/workflows/samples_configuration.yml ]"
+        )
     else:
         path_filter = (
             f"[ {gh_working_dir}/**, examples/*requirements.txt, .github/workflows/{workflow_name}.yml, "


### PR DESCRIPTION
# Description

Example `configuration.ipynb` is very unique among examples in this repo, it targets to demonstrate how to setup an Azure ML workspace, and not related to prompt flow at all; and it locates in `examples/`. Update the workflow generation logic to make an exception for it: just listen to its notebook and workflow, that's all.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
