### PR TITLE
[fundamental] Enable close stale items

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -17,13 +17,13 @@ jobs:
           exempt-issue-labels: 'long-term'  # syntax: <label1>,<label2>
           exempt-pr-labels: 'long-term'
           # stale issue/pull request
-          stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 30 days. We need more information about this issue to help address it. Please be sure to give us your input."
+          stale-issue-message: "Hi, we're sending this friendly reminder because we haven't heard back from you in 30 days. We need more information about this issue to help address it. Please be sure to give us your input. If we don't hear back from you within 7 days of this comment, the issue will be automatically closed. Thank you!"
           stale-issue-label: 'no-recent-activity'
           stale-pr-message: "Hi, thank you for your interest in helping to improve the prompt flow experience and for your contribution. We've noticed that there hasn't been recent engagement on this pull request. If this is still an active work stream, please let us know by pushing some changes or leaving a comment."
           stale-pr-label: 'no-recent-activity'
           days-before-issue-stale: 30
           days-before-pr-stale: 14
           # close issue/pull request
-          # days-before-issue-close: 7
+          days-before-issue-close: 7
           days-before-pr-close: 7
           close-pr-message: "Hi, thank you for your contribution. Since there has not been recent engagement, we are going to close this out. Feel free to reopen if you'd like to continue working on these changes. Please be sure to remove the `no-recent-activity` label; otherwise, this is likely to be closed again with the next cleanup pass."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,7 +23,7 @@ jobs:
           stale-pr-label: 'no-recent-activity'
           days-before-issue-stale: 30
           days-before-pr-stale: 14
-          # # close issue/pull request
-          # close-pr-message: 'Hi, thank you for your contribution. Since there hasn't been recent engagement, we're going to close this out.'
+          # close issue/pull request
           # days-before-issue-close: 7
-          # days-before-pr-close: 7
+          days-before-pr-close: 7
+          close-pr-message: "Hi, thank you for your contribution. Since there has not been recent engagement, we are going to close this out. Feel free to reopen if you'd like to continue working on these changes. Please be sure to remove the `no-recent-activity` label; otherwise, this is likely to be closed again with the next cleanup pass."


### PR DESCRIPTION
# Description

This PR updates stale items cleanup workflow to enable close. Issues and PRs will be closed after 7 days after tagged `no-recent-activity` label, and bot will comment a message in PR.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
