### PR TITLE
Improving error handling for invalid image inputs

### DIFF
--- a/src/promptflow/promptflow/_utils/_errors.py
+++ b/src/promptflow/promptflow/_utils/_errors.py
@@ -1,0 +1,9 @@
+from promptflow.exceptions import UserErrorException, ValidationException
+
+
+class InvalidImageInput(ValidationException):
+    pass
+
+
+class LoadMultimediaDataError(UserErrorException):
+    pass

--- a/src/promptflow/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow/promptflow/_utils/multimedia_utils.py
@@ -10,10 +10,11 @@ from urllib.parse import urlparse
 import filetype
 import requests
 
+from promptflow._utils._errors import InvalidImageInput, LoadMultimediaDataError
 from promptflow.contracts.flow import FlowInputDefinition
 from promptflow.contracts.multimedia import Image, PFBytes
 from promptflow.contracts.tool import ValueType
-from promptflow.exceptions import ErrorTarget, UserErrorException, ValidationException
+from promptflow.exceptions import ErrorTarget
 
 MIME_PATTERN = re.compile(r"^data:image/(.*);(path|base64|url)$")
 
@@ -237,8 +238,7 @@ def load_multimedia_data(inputs: Dict[str, FlowInputDefinition], line_inputs: di
             error_type_and_message = f"({ex.__class__.__name__}) {ex}"
             raise LoadMultimediaDataError(
                 message_format="Failed to load image for input '{key}': {error_type_and_message}",
-                key=key,
-                error_type_and_message=error_type_and_message,
+                key=key, error_type_and_message=error_type_and_message,
                 target=ex.target
             ) from ex
     return updated_inputs
@@ -275,11 +275,3 @@ def resolve_image_path(input_dir: Path, image_dict: dict):
             if resource == "path":
                 image_dict[key] = str(input_dir / image_dict[key])
     return image_dict
-
-
-class InvalidImageInput(ValidationException):
-    pass
-
-
-class LoadMultimediaDataError(UserErrorException):
-    pass

--- a/src/promptflow/promptflow/contracts/_errors.py
+++ b/src/promptflow/promptflow/contracts/_errors.py
@@ -1,9 +1,5 @@
-from promptflow.exceptions import UserErrorException, ValidationException
+from promptflow.exceptions import UserErrorException
 
 
 class FailedToImportModule(UserErrorException):
-    pass
-
-
-class InvalidImageInput(ValidationException):
     pass

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -13,9 +13,8 @@ from typing import Callable, List, Optional
 from promptflow._core.connection_manager import ConnectionManager
 from promptflow._core.tool import STREAMING_OPTION_PARAMETER_ATTR
 from promptflow._core.tools_manager import BuiltinsManager, ToolLoader, connection_type_to_api_mapping
-from promptflow._utils.multimedia_utils import create_image, load_multimedia_data_recursively
+from promptflow._utils.multimedia_utils import create_image, load_multimedia_data_recursively, InvalidImageInput
 from promptflow._utils.tool_utils import get_inputs_for_prompt_template, get_prompt_param_name_from_func
-from promptflow.contracts._errors import InvalidImageInput
 from promptflow.contracts.flow import InputAssignment, InputValueType, Node, ToolSourceType
 from promptflow.contracts.tool import ConnectionType, Tool, ToolType, ValueType
 from promptflow.contracts.types import PromptTemplate

--- a/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 import pytest
 
+from promptflow._utils._errors import InvalidImageInput, LoadMultimediaDataError
 from promptflow._utils.multimedia_utils import (
     _create_image_from_base64,
     _create_image_from_file,
@@ -15,8 +16,6 @@ from promptflow._utils.multimedia_utils import (
     load_multimedia_data,
     persist_multimedia_data,
     resolve_multimedia_data_recursively,
-    InvalidImageInput,
-    LoadMultimediaDataError,
 )
 from promptflow.contracts.flow import FlowInputDefinition
 from promptflow.contracts.multimedia import Image

--- a/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
@@ -102,7 +102,7 @@ class TestMultimediaUtils:
         mocker.patch("promptflow._utils.multimedia_utils._is_url", return_value=True)
         mocker.patch("promptflow._utils.multimedia_utils._is_base64", return_value=False)
         mocker.patch("requests.get", return_value=mocker.Mock(content=image_from_path, status_code=200))
-        image_from_url = create_image("")
+        image_from_url = create_image("Test")
         assert str(image_from_path) == str(image_from_url)
         assert image_from_url._mime_type in ["image/jpg", "image/jpeg"]
 
@@ -121,6 +121,15 @@ class TestMultimediaUtils:
             invalid_image_dict = {"invalid_image": "invalid_image"}
             create_image(invalid_image_dict)
         assert "Invalid image input format" in ex.value.message_format
+
+        # Test none or empty input value
+        with pytest.raises(InvalidImageInput) as ex:
+            create_image(None)
+        assert "Unsupported image input type" in ex.value.message_format
+
+        with pytest.raises(InvalidImageInput) as ex:
+            create_image("")
+        assert "The image input should not be empty." in ex.value.message_format
 
     def test_persist_multimedia_date(self, mocker):
         image = _create_image_from_file(TEST_IMAGE_PATH)
@@ -183,6 +192,12 @@ class TestMultimediaUtils:
             "images": [[image, image], [image]],
             "object": [{"image": image, "other_data": "other_data"}, {"other_data": "other_data"}],
         }
+
+        # Case 3: Test invalid input type
+        with pytest.raises(InvalidImageInput) as ex:
+            line_inputs = {"image": 0}
+            load_multimedia_data(inputs, line_inputs)
+        assert "Failed to load image for input 'image': Unsupported image input type" in ex.value.message_format
 
     def test_resolve_multimedia_data_recursively(self):
         image_dict = {"data:image/jpg;path": "logo.jpg"}

--- a/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
@@ -15,8 +15,9 @@ from promptflow._utils.multimedia_utils import (
     load_multimedia_data,
     persist_multimedia_data,
     resolve_multimedia_data_recursively,
+    InvalidImageInput,
+    LoadMultimediaDataError,
 )
-from promptflow.contracts._errors import InvalidImageInput
 from promptflow.contracts.flow import FlowInputDefinition
 from promptflow.contracts.multimedia import Image
 from promptflow.contracts.tool import ValueType
@@ -194,10 +195,12 @@ class TestMultimediaUtils:
         }
 
         # Case 3: Test invalid input type
-        with pytest.raises(InvalidImageInput) as ex:
+        with pytest.raises(LoadMultimediaDataError) as ex:
             line_inputs = {"image": 0}
             load_multimedia_data(inputs, line_inputs)
-        assert "Failed to load image for input 'image': Unsupported image input type" in ex.value.message_format
+        assert (
+            "Failed to load image for input 'image': "
+            "(InvalidImageInput) Unsupported image input type") in ex.value.message
 
     def test_resolve_multimedia_data_recursively(self):
         image_dict = {"data:image/jpg;path": "logo.jpg"}

--- a/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
@@ -210,7 +210,7 @@ class TestToolResolver:
         with pytest.raises(NodeInputValidationError) as e:
             tool_resolver = ToolResolver(working_dir=None, connections=connections)
             tool_resolver._convert_node_literal_input_types(node, tool)
-        message = "value invalid is not type int"
+        message = "value 'invalid' is not type int"
         assert message in str(e.value), "Expected: {}, Actual: {}".format(message, str(e.value))
 
         # Case 4: Unresolved value, like newly added type not in old version ValueType enum


### PR DESCRIPTION
This pull request includes changes to improve test coverage and handle empty image inputs in the `multimedia_utils` module. The most important changes include adding test cases for the `load_multimedia_data` and `create_image` functions, and modifying the exception handling for empty image inputs.

Summary of changes:

* <a href="diffhunk://#diff-032d36cff1825e9647e49a6c988fc63557a7a02df06ba02ff5b850f0d5a6d4ceR196-R201">`src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py`</a>: Added test cases to improve test coverage for `load_multimedia_data` and `create_image` functions. <a href="diffhunk://#diff-032d36cff1825e9647e49a6c988fc63557a7a02df06ba02ff5b850f0d5a6d4ceR196-R201">[1]</a> <a href="diffhunk://#diff-032d36cff1825e9647e49a6c988fc63557a7a02df06ba02ff5b850f0d5a6d4ceL105-R105">[2]</a> <a href="diffhunk://#diff-032d36cff1825e9647e49a6c988fc63557a7a02df06ba02ff5b850f0d5a6d4ceR125-R133">[3]</a>
* <a href="diffhunk://#diff-46760b7ed265c4b29c9cc4111fb19da9b815717e4d7180f61e0d0da023d2a8f9R145-R148">`src/promptflow/promptflow/_utils/multimedia_utils.py`</a>: Updated exception handling for empty image inputs, including raising an `InvalidImageInput` exception with a specific error message, catching and re-raising the exception with a modified error message, and modifying the exception to include the input key in the error message. <a href="diffhunk://#diff-46760b7ed265c4b29c9cc4111fb19da9b815717e4d7180f61e0d0da023d2a8f9R145-R148">[1]</a> <a href="diffhunk://#diff-46760b7ed265c4b29c9cc4111fb19da9b815717e4d7180f61e0d0da023d2a8f9R228">[2]</a> <a href="diffhunk://#diff-46760b7ed265c4b29c9cc4111fb19da9b815717e4d7180f61e0d0da023d2a8f9R237-R240">[3]</a>

Improving error handling for invalid image inputs.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
