### PR TITLE
Remove legacy field result in promptflow run info contract

### DIFF
--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -152,7 +152,6 @@ class RunTracker(ThreadLocalSingleton):
             error=None,
             start_time=datetime.utcnow(),
             end_time=datetime.utcnow(),
-            result=None,
             index=index,
             variant_id=variant_id,
             api_calls=[],
@@ -192,7 +191,6 @@ class RunTracker(ThreadLocalSingleton):
     def _common_postprocess(self, run_info, output, ex):
         if output is not None:
             #  Duplicated fields for backward compatibility.
-            run_info.result = output
             run_info.output = output
         if ex is not None:
             self._enrich_run_info_with_exception(run_info=run_info, ex=ex)

--- a/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
@@ -320,7 +320,6 @@ class TestSubmitter:
                 if isinstance(node.output, GeneratorType):
                     node_output = "".join(get_result_output(node.output))
                     node.output = node_output
-                    node.result = node_output
 
             return flow_result
 

--- a/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
@@ -312,7 +312,6 @@ class TestSubmitter:
                 if isinstance(v, GeneratorType):
                     flow_output = "".join(get_result_output(v))
                     flow_result.run_info.output[k] = flow_output
-                    flow_result.run_info.result[k] = flow_output
                     flow_result.output[k] = flow_output
 
             # resolve generator in node outputs

--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -403,7 +403,6 @@ class LocalStorageOperations(AbstractRunStorage):
             run_info.inputs = self._serialize_multimedia(run_info.inputs, folder_path)
         if run_info.output:
             run_info.output = self._serialize_multimedia(run_info.output, folder_path)
-            run_info.result = None
         if run_info.api_calls:
             run_info.api_calls = self._serialize_multimedia(run_info.api_calls, folder_path)
 

--- a/src/promptflow/promptflow/contracts/run_info.py
+++ b/src/promptflow/promptflow/contracts/run_info.py
@@ -98,7 +98,7 @@ class RunInfo:
     cached_flow_run_id: str = None
     logs: Optional[Dict[str, str]] = None
     system_metrics: Dict[str, Any] = None
-    result: object = None
+    result: object = None # Legacy field, will be removed in the future
 
     @staticmethod
     def deserialize(data: dict) -> "RunInfo":
@@ -122,7 +122,6 @@ class RunInfo:
             cached_flow_run_id=data.get("cached_flow_run_id", None),
             logs=data.get("logs", None),
             system_metrics=data.get("system_metrics", None),
-            result=data.get("result", None),
         )
         return run_info
 
@@ -197,7 +196,7 @@ class FlowRunInfo:
     description: str = ""
     tags: Optional[Mapping[str, str]] = None
     system_metrics: Dict[str, Any] = None
-    result: object = None
+    result: object = None  # Legacy field, will be removed in the future
     upload_metrics: bool = False  # only set as true for root runs in bulk test mode and evaluation mode
 
     @staticmethod

--- a/src/promptflow/promptflow/contracts/run_info.py
+++ b/src/promptflow/promptflow/contracts/run_info.py
@@ -98,7 +98,7 @@ class RunInfo:
     cached_flow_run_id: str = None
     logs: Optional[Dict[str, str]] = None
     system_metrics: Dict[str, Any] = None
-    result: object = None # Legacy field, will be removed in the future
+    result: object = None  # Legacy field, will be removed in the future
 
     @staticmethod
     def deserialize(data: dict) -> "RunInfo":

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -289,7 +289,6 @@ class LineExecutionProcessPool:
         if run_info.output:
             serialized_output = self._persist_and_convert_images_to_path_dicts(run_info.output)
             run_info.output = serialized_output
-            run_info.result = None
 
         # Persist and convert images in api_calls to path dictionaries.
         # The `inplace=True` parameter is used here to ensure that the original list structure holding generator outputs

--- a/src/promptflow/promptflow/storage/_run_storage.py
+++ b/src/promptflow/promptflow/storage/_run_storage.py
@@ -76,7 +76,6 @@ class DefaultRunStorage(AbstractRunStorage):
         if run_info.output:
             serialized_output = self._persist_and_convert_images_to_path_dicts(run_info.output)
             run_info.output = serialized_output
-            run_info.result = serialized_output
 
         # Persist and convert images in api_calls to path dictionaries.
         # The `inplace=True` parameter is used here to ensure that the original list structure holding generator outputs


### PR DESCRIPTION
# Description

`run_info.result` is a legacy field, it is the same as `.output`, however, since we dump this twice, so it introduces problem when the output is very big. So we need to remove it.

This pull request includes various changes to remove unnecessary assignments and comments in multiple files. The most important changes include removing a legacy field and related comments in the `RunInfo` and `FlowRunInfo` classes, and removing assignments of `None` and unused variables in the `run_tracker` module.

Main changes:

* <a href="diffhunk://#diff-821f81db124579c44354435c93db2ff74c6e3a69e69ca463b95671bc8716cb45L200-R199">`src/promptflow/promptflow/contracts/run_info.py`</a>: Removed a legacy field and related comments in the `RunInfo` and `FlowRunInfo` classes. <a href="diffhunk://#diff-821f81db124579c44354435c93db2ff74c6e3a69e69ca463b95671bc8716cb45L200-R199">[1]</a> <a href="diffhunk://#diff-821f81db124579c44354435c93db2ff74c6e3a69e69ca463b95671bc8716cb45L125">[2]</a> <a href="diffhunk://#diff-821f81db124579c44354435c93db2ff74c6e3a69e69ca463b95671bc8716cb45L101-R101">[3]</a>
* <a href="diffhunk://#diff-3ea41c85102f8318e1dc8568de0fb0de76ce92172e506df95e6f419808eabaf8L155">`src/promptflow/promptflow/_core/run_tracker.py`</a>: Removed assignments of `None` and unused variables in the `run_tracker` module. <a href="diffhunk://#diff-3ea41c85102f8318e1dc8568de0fb0de76ce92172e506df95e6f419808eabaf8L155">[1]</a> <a href="diffhunk://#diff-3ea41c85102f8318e1dc8568de0fb0de76ce92172e506df95e6f419808eabaf8L195">[2]</a>

Additional changes:

* <a href="diffhunk://#diff-74f2c4b846365aeb3253e5f35d09ba7b53c9c0eccedefa280d1d21519799dbb7L79">`src/promptflow/promptflow/storage/_run_storage.py`</a>: Removed an unnecessary assignment in the `persist_run_info` method of the `_run_storage` class.
* <a href="diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138L323">`src/promptflow/promptflow/_sdk/_submitter/test_submitter.py`</a>: Removed an unnecessary assignment in the `resolve_generator` method of `test_submitter.py`.
* <a href="diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L406">`src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py`</a>: Removed an unnecessary assignment in the `_persist_run_multimedia` method of `_local_storage_operations.py`.
* <a href="diffhunk://#diff-c14422c33faa9e44145738152120929455da4e4f05d4fc7b59158423fa609bc1L292">`src/promptflow/promptflow/executor/_line_execution_process_pool.py`</a>: Removed an unnecessary assignment in the `_process_multimedia_in_run_info` method of the `_line_execution_process_pool` module.


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
