### PR TITLE
[example][bugfix] Set environ to make CIs run against production region in PR

### DIFF
--- a/.github/workflows/samples_connections.yml
+++ b/.github/workflows/samples_connections.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/connections
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/connections
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_connections.yml
+++ b/.github/workflows/samples_connections.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/connections
         run: |

--- a/.github/workflows/samples_connections.yml
+++ b/.github/workflows/samples_connections.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/connections
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/connections
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_connections.yml
+++ b/.github/workflows/samples_connections.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/connections
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/connections
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_basic_chat.yml
+++ b/.github/workflows/samples_flows_chat_basic_chat.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/chat/basic-chat
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/chat/basic-chat
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_basic_chat.yml
+++ b/.github/workflows/samples_flows_chat_basic_chat.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/chat/basic-chat
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/chat/basic-chat
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_chat_basic_chat.yml
+++ b/.github/workflows/samples_flows_chat_basic_chat.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/chat/basic-chat
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/chat/basic-chat
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_basic_chat.yml
+++ b/.github/workflows/samples_flows_chat_basic_chat.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/chat/basic-chat
         run: |

--- a/.github/workflows/samples_flows_chat_chat_math_variant.yml
+++ b/.github/workflows/samples_flows_chat_chat_math_variant.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/chat/chat-math-variant
         run: |

--- a/.github/workflows/samples_flows_chat_chat_math_variant.yml
+++ b/.github/workflows/samples_flows_chat_chat_math_variant.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/chat/chat-math-variant
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/chat/chat-math-variant
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_chat_math_variant.yml
+++ b/.github/workflows/samples_flows_chat_chat_math_variant.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/chat/chat-math-variant
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/chat/chat-math-variant
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_chat_math_variant.yml
+++ b/.github/workflows/samples_flows_chat_chat_math_variant.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/chat/chat-math-variant
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/chat/chat-math-variant
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_chat_chat_with_pdf.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_pdf.yml
@@ -82,23 +82,23 @@ jobs:
         working-directory: examples/flows/chat/chat-with-pdf
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/chat/chat-with-pdf
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_chat_with_pdf.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_pdf.yml
@@ -82,14 +82,23 @@ jobs:
         working-directory: examples/flows/chat/chat-with-pdf
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/chat/chat-with-pdf
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_chat_with_pdf.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_pdf.yml
@@ -84,6 +84,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/chat/chat-with-pdf
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -93,6 +94,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/chat/chat-with-pdf
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_chat_chat_with_pdf.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_pdf.yml
@@ -92,7 +92,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/chat/chat-with-pdf
         run: |

--- a/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/chat/chat-with-wikipedia
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/chat/chat-with-wikipedia
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/chat/chat-with-wikipedia
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/chat/chat-with-wikipedia
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/chat/chat-with-wikipedia
         run: |

--- a/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/chat/chat-with-wikipedia
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/chat/chat-with-wikipedia
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_basic.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_basic.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/evaluation/eval-basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/evaluation/eval-basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_evaluation_eval_basic.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_basic.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/evaluation/eval-basic
         run: |

--- a/.github/workflows/samples_flows_evaluation_eval_basic.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_basic.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-basic
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/evaluation/eval-basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_basic.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_basic.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-basic
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/evaluation/eval-basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-chat-math
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/evaluation/eval-chat-math
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/evaluation/eval-chat-math
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/evaluation/eval-chat-math
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-chat-math
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/evaluation/eval-chat-math
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/evaluation/eval-chat-math
         run: |

--- a/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/evaluation/eval-classification-accuracy
         run: |

--- a/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |

--- a/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/evaluation/eval-entity-match-rate
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/evaluation/eval-groundedness
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/evaluation/eval-groundedness
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-groundedness
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/evaluation/eval-groundedness
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-groundedness
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/evaluation/eval-groundedness
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/evaluation/eval-groundedness
         run: |

--- a/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/evaluation/eval-perceived-intelligence
         run: |

--- a/.github/workflows/samples_flows_standard_autonomous_agent.yml
+++ b/.github/workflows/samples_flows_standard_autonomous_agent.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/autonomous-agent
         run: |

--- a/.github/workflows/samples_flows_standard_autonomous_agent.yml
+++ b/.github/workflows/samples_flows_standard_autonomous_agent.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/autonomous-agent
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/autonomous-agent
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_autonomous_agent.yml
+++ b/.github/workflows/samples_flows_standard_autonomous_agent.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/autonomous-agent
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/autonomous-agent
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_autonomous_agent.yml
+++ b/.github/workflows/samples_flows_standard_autonomous_agent.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/autonomous-agent
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/autonomous-agent
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/basic
         run: |

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/basic
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -25,6 +25,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
+      - name: Generate config.json for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
+      - name: Generate config.json for production workspace
+        if: github.event_name != 'schedule'
+        run: echo '${{ secrets.EXAMPLE_WORKSPACE_CONFIG_JSON_PROD }}' > ${{ github.workspace }}/examples/config.json
       - name: Prepare requirements
         working-directory: examples
         run: |

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/basic
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/basic
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -25,12 +25,6 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
-      - name: Generate config.json for canary workspace (scheduled runs only)
-        if: github.event_name == 'schedule'
-        run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
-      - name: Generate config.json for production workspace
-        if: github.event_name != 'schedule'
-        run: echo '${{ secrets.EXAMPLE_WORKSPACE_CONFIG_JSON_PROD }}' > ${{ github.workspace }}/examples/config.json
       - name: Prepare requirements
         working-directory: examples
         run: |

--- a/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
@@ -79,6 +79,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -88,6 +89,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
@@ -77,14 +77,23 @@ jobs:
         working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
@@ -87,7 +87,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |

--- a/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
@@ -77,23 +77,23 @@ jobs:
         working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/basic-with-builtin-llm
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_basic_with_connection.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_connection.yml
@@ -87,7 +87,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/basic-with-connection
         run: |

--- a/.github/workflows/samples_flows_standard_basic_with_connection.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_connection.yml
@@ -79,6 +79,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/basic-with-connection
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -88,6 +89,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/basic-with-connection
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_basic_with_connection.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_connection.yml
@@ -77,23 +77,23 @@ jobs:
         working-directory: examples/flows/standard/basic-with-connection
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/basic-with-connection
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_basic_with_connection.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_connection.yml
@@ -77,14 +77,23 @@ jobs:
         working-directory: examples/flows/standard/basic-with-connection
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/basic-with-connection
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/conditional-flow-for-if-else
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/conditional-flow-for-switch
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
+++ b/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/customer-intent-extraction
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/customer-intent-extraction
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
+++ b/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/customer-intent-extraction
         run: |

--- a/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
+++ b/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/customer-intent-extraction
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/customer-intent-extraction
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
+++ b/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/customer-intent-extraction
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/customer-intent-extraction
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
@@ -79,6 +79,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/flow-with-additional-includes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -88,6 +89,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/flow-with-additional-includes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
@@ -77,14 +77,23 @@ jobs:
         working-directory: examples/flows/standard/flow-with-additional-includes
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/flow-with-additional-includes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
@@ -77,23 +77,23 @@ jobs:
         working-directory: examples/flows/standard/flow-with-additional-includes
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/flow-with-additional-includes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
@@ -87,7 +87,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/flow-with-additional-includes
         run: |

--- a/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
@@ -77,23 +77,23 @@ jobs:
         working-directory: examples/flows/standard/flow-with-symlinks
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/flow-with-symlinks
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
@@ -87,7 +87,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/flow-with-symlinks
         run: |

--- a/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
@@ -77,14 +77,23 @@ jobs:
         working-directory: examples/flows/standard/flow-with-symlinks
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/flow-with-symlinks
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
@@ -79,6 +79,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/flow-with-symlinks
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -88,6 +89,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/flow-with-symlinks
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_gen_docstring.yml
+++ b/.github/workflows/samples_flows_standard_gen_docstring.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/gen-docstring
         run: |

--- a/.github/workflows/samples_flows_standard_gen_docstring.yml
+++ b/.github/workflows/samples_flows_standard_gen_docstring.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/gen-docstring
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/gen-docstring
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_gen_docstring.yml
+++ b/.github/workflows/samples_flows_standard_gen_docstring.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/gen-docstring
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/gen-docstring
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_gen_docstring.yml
+++ b/.github/workflows/samples_flows_standard_gen_docstring.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/gen-docstring
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/gen-docstring
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_maths_to_code.yml
+++ b/.github/workflows/samples_flows_standard_maths_to_code.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/maths-to-code
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/maths-to-code
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_maths_to_code.yml
+++ b/.github/workflows/samples_flows_standard_maths_to_code.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/maths-to-code
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/maths-to-code
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_maths_to_code.yml
+++ b/.github/workflows/samples_flows_standard_maths_to_code.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/maths-to-code
         run: |

--- a/.github/workflows/samples_flows_standard_maths_to_code.yml
+++ b/.github/workflows/samples_flows_standard_maths_to_code.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/maths-to-code
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/maths-to-code
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_named_entity_recognition.yml
+++ b/.github/workflows/samples_flows_standard_named_entity_recognition.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/named-entity-recognition
         run: |

--- a/.github/workflows/samples_flows_standard_named_entity_recognition.yml
+++ b/.github/workflows/samples_flows_standard_named_entity_recognition.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/named-entity-recognition
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/named-entity-recognition
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_named_entity_recognition.yml
+++ b/.github/workflows/samples_flows_standard_named_entity_recognition.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/named-entity-recognition
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/named-entity-recognition
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_named_entity_recognition.yml
+++ b/.github/workflows/samples_flows_standard_named_entity_recognition.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/named-entity-recognition
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/named-entity-recognition
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_web_classification.yml
+++ b/.github/workflows/samples_flows_standard_web_classification.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/flows/standard/web-classification
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/flows/standard/web-classification
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_web_classification.yml
+++ b/.github/workflows/samples_flows_standard_web_classification.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/flows/standard/web-classification
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/flows/standard/web-classification
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_flows_standard_web_classification.yml
+++ b/.github/workflows/samples_flows_standard_web_classification.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/flows/standard/web-classification
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/flows/standard/web-classification
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_flows_standard_web_classification.yml
+++ b/.github/workflows/samples_flows_standard_web_classification.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/flows/standard/web-classification
         run: |

--- a/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |

--- a/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tools/use-cases/cascading-inputs-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tools/use-cases/custom_llm_tool_showcase
         run: |

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |

--- a/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tools/use-cases/dynamic-list-input-tool-showcase
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -84,6 +84,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/e2e-development
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -93,6 +94,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/e2e-development
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -82,14 +82,23 @@ jobs:
         working-directory: examples/tutorials/e2e-development
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/e2e-development
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -92,7 +92,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/e2e-development
         run: |

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -82,23 +82,23 @@ jobs:
         working-directory: examples/tutorials/e2e-development
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/e2e-development
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/flow-deploy/azure-app-service
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |

--- a/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/flow-deploy/create-service-with-flow
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/flow-deploy/distribute-flow-as-executable-app
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/flow-deploy/docker
         run: |

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/docker
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/flow-deploy/docker
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/docker
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/flow-deploy/docker
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/flow-deploy/docker
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/flow-deploy/docker
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/flow-deploy/kubernetes
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -74,14 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |
           cat bash_script.sh
+      - name: Set environ for canary workspace (scheduled runs only)
+        if: github.event_name == 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+      - name: Set environ for production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
       - name: Run scripts
         working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -76,6 +76,7 @@ jobs:
           cat bash_script.sh
       - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
+        working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
@@ -85,6 +86,7 @@ jobs:
           bash bash_script.sh
       - name: Run scripts against production workspace (scheduled runs only)
         if: github.event_name != 'schedule'
+        working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -74,23 +74,23 @@ jobs:
         working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |
           cat bash_script.sh
-      - name: Set environ for canary workspace (scheduled runs only)
+      - name: Run scripts against canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
-      - name: Set environ for production workspace (scheduled runs only)
-        if: github.event_name != 'schedule'
-        run: |
-          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
-          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
-          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
-      - name: Run scripts
-        working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |
           export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
           export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
+          bash bash_script.sh
+      - name: Run scripts against production workspace (scheduled runs only)
+        if: github.event_name != 'schedule'
+        run: |
+          export aoai_api_key=${{secrets.AOAI_API_KEY_TEST }}
+          export aoai_api_endpoint=${{ secrets.AOAI_API_ENDPOINT_TEST }}
+          export test_workspace_sub_id=${{ secrets.TEST_WORKSPACE_SUB_ID }}
+          export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
+          export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_PROD }}
           bash bash_script.sh
       - name: Pip List for Debug
         if : ${{ always() }}

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -84,7 +84,7 @@ jobs:
           export test_workspace_rg=${{ secrets.TEST_WORKSPACE_RG }}
           export test_workspace_name=${{ secrets.TEST_WORKSPACE_NAME_CANARY }}
           bash bash_script.sh
-      - name: Run scripts against production workspace (scheduled runs only)
+      - name: Run scripts against production workspace
         if: github.event_name != 'schedule'
         working-directory: examples/tutorials/flow-fine-tuning-evaluation
         run: |

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
@@ -16,7 +16,7 @@
     export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
     export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
     bash bash_script.sh
-- name: Run scripts against production workspace (scheduled runs only)
+- name: Run scripts against production workspace
   if: github.event_name != 'schedule'
   working-directory: {{ working_dir }}
   run: |

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
@@ -6,14 +6,23 @@
   working-directory: {{ working_dir }}
   run: |
     cat bash_script.sh
+- name: Set environ for canary workspace (scheduled runs only)
+  if: github.event_name == 'schedule'
+  run: |
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
+- name: Set environ for production workspace (scheduled runs only)
+  if: github.event_name != 'schedule'
+  run: |
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_PROD }}
 - name: Run scripts
   working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
-    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
-    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
-    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
     bash bash_script.sh
 - name: Pip List for Debug
   if : ${{ '{{' }} always() }}

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
@@ -8,6 +8,7 @@
     cat bash_script.sh
 - name: Run scripts against canary workspace (scheduled runs only)
   if: github.event_name == 'schedule'
+  working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
@@ -17,6 +18,7 @@
     bash bash_script.sh
 - name: Run scripts against production workspace (scheduled runs only)
   if: github.event_name != 'schedule'
+  working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run.yml.jinja2
@@ -6,23 +6,23 @@
   working-directory: {{ working_dir }}
   run: |
     cat bash_script.sh
-- name: Set environ for canary workspace (scheduled runs only)
+- name: Run scripts against canary workspace (scheduled runs only)
   if: github.event_name == 'schedule'
-  run: |
-    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
-    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
-    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
-- name: Set environ for production workspace (scheduled runs only)
-  if: github.event_name != 'schedule'
-  run: |
-    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
-    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
-    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_PROD }}
-- name: Run scripts
-  working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
+    bash bash_script.sh
+- name: Run scripts against production workspace (scheduled runs only)
+  if: github.event_name != 'schedule'
+  run: |
+    export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
+    export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_PROD }}
     bash bash_script.sh
 - name: Pip List for Debug
   if : ${{ '{{' }} always() }}

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
@@ -16,7 +16,7 @@
     export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
     export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
     bash bash_script.sh
-- name: Run scripts against production workspace (scheduled runs only)
+- name: Run scripts against production workspace
   if: github.event_name != 'schedule'
   working-directory: {{ working_dir }}
   run: |

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
@@ -6,14 +6,23 @@
   working-directory: {{ working_dir }}
   run: |
     cat bash_script.sh
+- name: Set environ for canary workspace (scheduled runs only)
+  if: github.event_name == 'schedule'
+  run: |
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
+- name: Set environ for production workspace (scheduled runs only)
+  if: github.event_name != 'schedule'
+  run: |
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_PROD }}
 - name: Run scripts
   working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
-    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
-    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
-    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
     bash bash_script.sh
 - name: Pip List for Debug
   if : ${{ '{{' }} always() }}

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
@@ -8,6 +8,7 @@
     cat bash_script.sh
 - name: Run scripts against canary workspace (scheduled runs only)
   if: github.event_name == 'schedule'
+  working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
@@ -17,6 +18,7 @@
     bash bash_script.sh
 - name: Run scripts against production workspace (scheduled runs only)
   if: github.event_name != 'schedule'
+  working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}

--- a/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_extract_steps_and_run_gpt4.yml.jinja2
@@ -6,23 +6,23 @@
   working-directory: {{ working_dir }}
   run: |
     cat bash_script.sh
-- name: Set environ for canary workspace (scheduled runs only)
+- name: Run scripts against canary workspace (scheduled runs only)
   if: github.event_name == 'schedule'
-  run: |
-    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
-    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
-    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
-- name: Set environ for production workspace (scheduled runs only)
-  if: github.event_name != 'schedule'
-  run: |
-    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
-    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
-    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_PROD }}
-- name: Run scripts
-  working-directory: {{ working_dir }}
   run: |
     export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
     export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_CANARY }}
+    bash bash_script.sh
+- name: Run scripts against production workspace (scheduled runs only)
+  if: github.event_name != 'schedule'
+  run: |
+    export aoai_api_key=${{ '{{' }}secrets.AOAI_API_KEY_TEST }}
+    export aoai_api_endpoint=${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}
+    export test_workspace_sub_id=${{ '{{' }} secrets.TEST_WORKSPACE_SUB_ID }}
+    export test_workspace_rg=${{ '{{' }} secrets.TEST_WORKSPACE_RG }}
+    export test_workspace_name=${{ '{{' }} secrets.TEST_WORKSPACE_NAME_PROD }}
     bash bash_script.sh
 - name: Pip List for Debug
   if : ${{ '{{' }} always() }}


### PR DESCRIPTION
# Description

We observed current examples run against canary region in PR triggered workflows, which results from the wrong environ set inside the workflow, and promptflow does not honor `config.json` (which works for Azure ML only). This PR targets to fix this by updating the template.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
