### PR TITLE
[Executor] Fix bug when sync node is called in async mode

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -102,23 +102,12 @@ class AsyncNodesScheduler:
         return asyncio.create_task(task)
 
     @staticmethod
-    def _invoke_sync_tool(context, node, f, kwargs):
-        try:
-            context.start()
-            context.current_node = node
-            result = f(**kwargs)
-            context.current_node = None
-            return result
-        finally:
-            context.end()
-
-    @staticmethod
     async def _sync_function_to_async_task(
         executor: ThreadPoolExecutor,
-        context, node,
+        context: FlowExecutionContext, node,
         f,
         kwargs,
     ):
         return await asyncio.get_running_loop().run_in_executor(
-            executor, AsyncNodesScheduler._invoke_sync_tool, context, node, f, kwargs
+            executor, context.invoke_tool, node, f, kwargs
         )


### PR DESCRIPTION
# Description

In current implementation, there is a bug that uses legacy code reference of flow execution context which introduce a bug when running sync function in async mode.
This pull request to `src/promptflow/promptflow/executor/_async_nodes_scheduler.py` simplifies the code by removing the `_invoke_sync_tool` method from the `AsyncNodesScheduler` class and delegating the responsibility of invoking the tool to the `context` object.

* <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fL104-R112">`src/promptflow/promptflow/executor/_async_nodes_scheduler.py`</a>: Removed the `_invoke_sync_tool` method from the `AsyncNodesScheduler` class and replaced it with a call to the `invoke_tool` method of the `context` object.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
