### PR TITLE
Change node test's interface. Add storage to persist image.

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -9,7 +9,6 @@
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node
 
 ### Improvements
-- Change node test's interface, use storage instread of relative path.
 - Change `ruamel.yaml` lower bound to 0.17.10.
 - [SDK/CLI] Improve `pfazure run download` to handle large run data files.
 

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node
 
 ### Improvements
+- Change node test's interface, use storage instread of relative path.
 - Change `ruamel.yaml` lower bound to 0.17.10.
 - [SDK/CLI] Improve `pfazure run download` to handle large run data files.
 

--- a/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/test_submitter.py
@@ -236,6 +236,7 @@ class TestSubmitter:
             stream=stream,
             credential_list=credential_list,
         ):
+            storage = DefaultRunStorage(base_dir=self.flow.code, sub_dir=Path(".promptflow/intermediate"))
             result = FlowExecutor.load_and_exec_node(
                 self.flow.path,
                 node_name,
@@ -243,7 +244,7 @@ class TestSubmitter:
                 dependency_nodes_outputs=dependency_nodes_outputs,
                 connections=connections,
                 working_dir=self.flow.code,
-                output_sub_dir=".promptflow/intermediate",
+                storage=storage,
             )
             return result
 

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -254,7 +254,7 @@ class FlowExecutor:
         flow_file: Path,
         node_name: str,
         *,
-        output_sub_dir: Optional[str] = None,
+        storage: AbstractRunStorage = None,
         flow_inputs: Optional[Mapping[str, Any]] = None,
         dependency_nodes_outputs: Optional[Mapping[str, Any]] = None,
         connections: Optional[dict] = None,
@@ -341,9 +341,8 @@ class FlowExecutor:
         # so we need to remove them from the inputs before invoking.
         resolved_inputs = {k: v for k, v in resolved_inputs.items() if k not in resolved_node.init_args}
 
-        # TODO: Simplify the logic here
-        sub_dir = "." if output_sub_dir is None else output_sub_dir
-        storage = DefaultRunStorage(base_dir=working_dir, sub_dir=Path(sub_dir))
+        if storage is None:
+            storage = DefaultRunStorage(base_dir=working_dir, sub_dir=Path("."))
         run_tracker = RunTracker(storage)
         with run_tracker.node_log_manager:
             # Will generate node run in context

--- a/src/promptflow/tests/executor/e2etests/test_image.py
+++ b/src/promptflow/tests/executor/e2etests/test_image.py
@@ -73,40 +73,35 @@ def get_test_cases_for_node_run():
     composite_image_input = {"image_list": image_list, "image_dcit": image_dict}
 
     return [
-        (SIMPLE_IMAGE_FLOW, "python_node", simple_image_input, None, True),
-        (SIMPLE_IMAGE_FLOW, "python_node", simple_image_input, None, False),  # Add case for no storage.
-        (SIMPLE_IMAGE_FLOW, "python_node_2", simple_image_input, {"python_node": image}, True),
-        (COMPOSITE_IMAGE_FLOW, "python_node", composite_image_input, None, True),
-        (COMPOSITE_IMAGE_FLOW, "python_node_2", composite_image_input, None, True),
+        (SIMPLE_IMAGE_FLOW, "python_node", simple_image_input, None),
+        (SIMPLE_IMAGE_FLOW, "python_node_2", simple_image_input, {"python_node": image}),
+        (COMPOSITE_IMAGE_FLOW, "python_node", composite_image_input, None),
+        (COMPOSITE_IMAGE_FLOW, "python_node_2", composite_image_input, None),
         (
             COMPOSITE_IMAGE_FLOW,
             "python_node_3",
             composite_image_input,
             {"python_node": image_list, "python_node_2": image_dict},
-            True,
         ),
     ]
 
 
-def contain_image_reference(value, under_temp_dir=True):
+def contain_image_reference(value, parent_path="temp"):
     if isinstance(value, (FlowRunInfo, RunInfo)):
-        assert contain_image_reference(value.api_calls, under_temp_dir)
-        assert contain_image_reference(value.inputs, under_temp_dir)
-        assert contain_image_reference(value.output, under_temp_dir)
+        assert contain_image_reference(value.api_calls, parent_path)
+        assert contain_image_reference(value.inputs, parent_path)
+        assert contain_image_reference(value.output, parent_path)
         return True
     assert not isinstance(value, Image)
     if isinstance(value, list):
-        return any(contain_image_reference(item, under_temp_dir) for item in value)
+        return any(contain_image_reference(item, parent_path) for item in value)
     if isinstance(value, dict):
         if is_multimedia_dict(value):
             v = list(value.values())[0]
             assert isinstance(v, str)
-            if under_temp_dir:
-                assert v.startswith(str(Path("./temp")))
-            else:
-                assert not v.startswith(str(Path("./temp")))  # When did not assign storage, save image in working dir.
+            assert str(Path(v).parent) == parent_path
             return True
-        return any(contain_image_reference(v, under_temp_dir) for v in value.values())
+        return any(contain_image_reference(v, parent_path) for v in value.values())
     return False
 
 
@@ -146,14 +141,14 @@ class TestExecutorWithImage:
             assert contain_image_reference(node_run_info)
 
     @pytest.mark.parametrize(
-        "flow_folder, node_name, flow_inputs, dependency_nodes_outputs, assign_storage", get_test_cases_for_node_run()
+        "flow_folder, node_name, flow_inputs, dependency_nodes_outputs", get_test_cases_for_node_run()
     )
     def test_executor_exec_node_with_image(
-        self, flow_folder, node_name, flow_inputs, dependency_nodes_outputs, assign_storage, dev_connections
+        self, flow_folder, node_name, flow_inputs, dependency_nodes_outputs, dev_connections
     ):
         working_dir = get_flow_folder(flow_folder)
         os.chdir(working_dir)
-        storage = DefaultRunStorage(base_dir=working_dir, sub_dir=Path("./temp")) if assign_storage else None
+        storage = DefaultRunStorage(base_dir=working_dir, sub_dir=Path("./temp"))
         run_info = FlowExecutor.load_and_exec_node(
             get_yaml_file(flow_folder),
             node_name,
@@ -164,7 +159,38 @@ class TestExecutorWithImage:
             raise_ex=True,
         )
         assert run_info.status == Status.Completed
-        assert contain_image_reference(run_info, under_temp_dir=assign_storage)
+        assert contain_image_reference(run_info)
+
+    # Assert image could be persisted to the specified path.
+    @pytest.mark.parametrize(
+        "output_sub_dir, assign_storage, expected_path",
+        [
+            ("test_path", True, "test_storage"),
+            ("test_path", False, "test_path"),
+            (None, True, "test_storage"),
+            (None, False, "."),
+        ],
+    )
+    def test_executor_exec_node_with_image_storage_and_path(self, output_sub_dir, assign_storage, expected_path):
+        flow_folder = SIMPLE_IMAGE_FLOW
+        node_name = "python_node"
+        image = {"data:image/jpg;path": str(get_flow_folder(SIMPLE_IMAGE_FLOW) / "logo.jpg")}
+        flow_inputs = {"image": image}
+        working_dir = get_flow_folder(flow_folder)
+        os.chdir(working_dir)
+        storage = DefaultRunStorage(base_dir=working_dir, sub_dir=Path("./test_storage"))
+        run_info = FlowExecutor.load_and_exec_node(
+            get_yaml_file(flow_folder),
+            node_name,
+            flow_inputs=flow_inputs,
+            dependency_nodes_outputs=None,
+            connections=None,
+            storage=storage if assign_storage else None,
+            output_sub_dir=output_sub_dir,
+            raise_ex=True,
+        )
+        assert run_info.status == Status.Completed
+        assert contain_image_reference(run_info, parent_path=expected_path)
 
     @pytest.mark.parametrize(
         "flow_folder, node_name, flow_inputs, dependency_nodes_outputs",


### PR DESCRIPTION
# Description

Change node test's interface. Add storage to persist image.
Storage is a more flexible way to persist run info.
Using storage, we could apply same logic to implement async flow test and node test.

Didn't delete `output_sub_dir` because we may need to keep backward combability for a few versions.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
