### PR TITLE
[Executor] Update executor finalization in async scheduler

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -35,10 +35,16 @@ class AsyncNodesScheduler:
         context: FlowExecutionContext,
     ) -> Tuple[dict, dict]:
         parent_context = contextvars.copy_context()
-        with ThreadPoolExecutor(
+        executor = ThreadPoolExecutor(
             max_workers=self._node_concurrency, initializer=set_context, initargs=(parent_context,)
-        ) as executor:
-            return await self._execute_with_thread_pool(executor, nodes, inputs, context)
+        )
+        # Note that we must not use `with` statement to manage the executor.
+        # This is because it will always call `executor.shutdown()` when exiting the `with` block.
+        # Then the event loop will wait for all tasks to be completed before raising the cancellation error.
+        # See reference: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
+        outputs = await self._execute_with_thread_pool(executor, nodes, inputs, context)
+        executor.shutdown()
+        return outputs
 
     async def _execute_with_thread_pool(
         self,


### PR DESCRIPTION
# Description

Update ThreadPoolExecutor finalization logic in async scheduler to ensure cancel works if it is running.
This pull request to `src/promptflow/promptflow/executor/_async_nodes_scheduler.py` improves the handling of `ThreadPoolExecutor` by manually shutting it down after tasks are completed, ensuring that the cancellation error is raised immediately.

* <a href="diffhunk://#diff-aea06244ab378a5cbd47d27ba6d92c433df3089d077871b1e6aaa1b47cd3c73fL38-R47">`src/promptflow/promptflow/executor/_async_nodes_scheduler.py`</a>: Removed the `with` statement and assigned the `ThreadPoolExecutor` to a variable to manually shutdown the executor after tasks are completed, ensuring immediate raising of the cancellation error.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
