### PR TITLE
[SDK] Support "pf config set user_agent="smile-llm/0.0.1""

### DIFF
--- a/src/promptflow/promptflow/_sdk/_configuration.py
+++ b/src/promptflow/promptflow/_sdk/_configuration.py
@@ -217,7 +217,7 @@ class Configuration(object):
         return
 
     def get_user_agent(self) -> Optional[str]:
-        """Get 1p customer set user agent. Only 1p customer will set this. If set, will add prefix `PFCustomer_`"""
+        """Get customer set user agent. If set, will add prefix `PFCustomer_`"""
         user_agent = self.get_config(key=self.USER_AGENT)
         if user_agent:
             return f"PFCustomer_{user_agent}"

--- a/src/promptflow/promptflow/_sdk/_configuration.py
+++ b/src/promptflow/promptflow/_sdk/_configuration.py
@@ -45,6 +45,7 @@ class Configuration(object):
     INSTALLATION_ID = "cli.installation_id"
     CONNECTION_PROVIDER = "connection.provider"
     RUN_OUTPUT_PATH = "run.output_path"
+    USER_AGENT = "user_agent"
     _instance = None
 
     def __init__(self, overrides=None):
@@ -214,3 +215,10 @@ class Configuration(object):
                     "please use its child folder, e.g. '${flow_directory}/.runs'."
                 )
         return
+
+    def get_user_agent(self) -> Optional[str]:
+        """Get 1p customer set user agent. Only 1p customer will set this. If set, will add prefix `PFCustomer_`"""
+        user_agent = self.get_config(key=self.USER_AGENT)
+        if user_agent:
+            return f"PFCustomer_{user_agent}"
+        return user_agent

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -884,16 +884,28 @@ class ClientUserAgentUtil:
             if env_name in os.environ:
                 cls.append_user_agent(os.environ[env_name])
 
+    @classmethod
+    def update_user_agent_from_config(cls):
+        """Update user agent from config. 1p customer will set it. We'll add PFCustomer_ as prefix."""
+        from promptflow._sdk._configuration import Configuration
+
+        config = Configuration.get_instance()
+        user_agent = config.get_user_agent()
+        if user_agent:
+            cls.append_user_agent(user_agent)
+
 
 def setup_user_agent_to_operation_context(user_agent):
     """Setup user agent to OperationContext.
     For calls from extension, ua will be like: prompt-flow-extension/ promptflow-cli/ promptflow-sdk/
     For calls from CLI, ua will be like: promptflow-cli/ promptflow-sdk/
     For calls from SDK, ua will be like: promptflow-sdk/
+    For 1p customer call which set user agent in config, ua will be like: PFCustomer_XXX/
     """
     # add user added UA after SDK/CLI
     ClientUserAgentUtil.append_user_agent(user_agent)
     ClientUserAgentUtil.update_user_agent_from_env_var()
+    ClientUserAgentUtil.update_user_agent_from_config()
     return ClientUserAgentUtil.get_user_agent()
 
 

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1719,3 +1719,5 @@ class TestCli:
             "set",
             "user_agent=",
         )
+        context = OperationContext().get_instance()
+        context.user_agent = ""

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -22,7 +22,7 @@ from promptflow._constants import PF_USER_AGENT
 from promptflow._core.operation_context import OperationContext
 from promptflow._sdk._constants import LOGGER_NAME, SCRUBBED_VALUE
 from promptflow._sdk._errors import RunNotFoundError
-from promptflow._sdk._utils import ClientUserAgentUtil
+from promptflow._sdk._utils import ClientUserAgentUtil, setup_user_agent_to_operation_context
 from promptflow._sdk.operations._local_storage_operations import LocalStorageOperations
 from promptflow._sdk.operations._run_operations import RunOperations
 from promptflow._utils.context_utils import _change_working_dir
@@ -1702,3 +1702,20 @@ class TestCli:
             pass
         _, err = capfd.readouterr()
         assert "invalid choice" in err
+
+    def test_config_set_user_agent(self) -> None:
+        run_pf_command(
+            "config",
+            "set",
+            "user_agent=test/1.0.0",
+        )
+        user_agent = setup_user_agent_to_operation_context(None)
+        ua_dict = parse_ua_to_dict(user_agent)
+        assert ua_dict.keys() == {"promptflow-sdk", "promptflow-cli", "PFCustomer_test"}
+
+        # clear user agent
+        run_pf_command(
+            "config",
+            "set",
+            "user_agent=",
+        )

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_config.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_config.py
@@ -8,7 +8,6 @@ import pytest
 from promptflow._sdk._configuration import Configuration, InvalidConfigValue
 from promptflow._sdk._constants import FLOW_DIRECTORY_MACRO_IN_CONFIG
 from promptflow._sdk._utils import ClientUserAgentUtil
-from promptflow._utils.utils import parse_ua_to_dict
 
 CONFIG_DATA_ROOT = Path(__file__).parent.parent.parent / "test_configs" / "configs"
 
@@ -64,5 +63,5 @@ class TestConfig:
         # empty ua won't add to context
         ClientUserAgentUtil.update_user_agent_from_config()
         user_agent = ClientUserAgentUtil.get_user_agent()
-        ua_dict = parse_ua_to_dict(user_agent)
-        assert dict(ua_dict.keys()) == {}
+        # in test environment, user agent may contain promptflow-local-serving/0.0.1 test-user-agent
+        assert "test/1.0.0" not in user_agent

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_config.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_config.py
@@ -7,6 +7,8 @@ import pytest
 
 from promptflow._sdk._configuration import Configuration, InvalidConfigValue
 from promptflow._sdk._constants import FLOW_DIRECTORY_MACRO_IN_CONFIG
+from promptflow._sdk._utils import ClientUserAgentUtil
+from promptflow._utils.utils import parse_ua_to_dict
 
 CONFIG_DATA_ROOT = Path(__file__).parent.parent.parent / "test_configs" / "configs"
 
@@ -50,3 +52,17 @@ class TestConfig:
         with pytest.raises(InvalidConfigValue) as e:
             Configuration(overrides={Configuration.RUN_OUTPUT_PATH: FLOW_DIRECTORY_MACRO_IN_CONFIG})
         assert expected_error_message in str(e)
+
+    def test_ua_set_load(self, config: Configuration) -> None:
+        config.set_config(key=Configuration.USER_AGENT, value="test/1.0.0")
+        user_agent = config.get_user_agent()
+        assert user_agent == "PFCustomer_test/1.0.0"
+        # load empty ua won't break
+        config.set_config(key=Configuration.USER_AGENT, value="")
+        user_agent = config.get_user_agent()
+        assert user_agent == ""
+        # empty ua won't add to context
+        ClientUserAgentUtil.update_user_agent_from_config()
+        user_agent = ClientUserAgentUtil.get_user_agent()
+        ua_dict = parse_ua_to_dict(user_agent)
+        assert dict(ua_dict.keys()) == {}


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
This PR supports config user agent for 1p customer to help us distinguish usage in telemetry.

This pull request includes changes to the codebase that improve the user agent functionality and add new tests for the user agent configuration.

Main user agent changes:

* <a href="diffhunk://#diff-47208ac35b30920275fcd5e55d662647ef360129359bdc77fddd2a2157b6f47eR887-R908">`src/promptflow/promptflow/_sdk/_utils.py`</a>: Added a new class method `update_user_agent_from_config` to the `ClientUserAgentUtil` class that retrieves the user agent from the configuration and appends it to the existing user agent.
* <a href="diffhunk://#diff-ff53f9e2ad1838023fb07cafd5526a639fe9589e470f9983a7461d5d8a89f9a5R48">`src/promptflow/promptflow/_sdk/_configuration.py`</a>: Added a new constant `USER_AGENT` and a new method `get_user_agent` to the `Configuration` class for retrieving and modifying the user agent configuration value. <a href="diffhunk://#diff-ff53f9e2ad1838023fb07cafd5526a639fe9589e470f9983a7461d5d8a89f9a5R48">[1]</a> <a href="diffhunk://#diff-ff53f9e2ad1838023fb07cafd5526a639fe9589e470f9983a7461d5d8a89f9a5R218-R224">[2]</a>

Testing improvements:

* <a href="diffhunk://#diff-1a31bc7b67fad77e9c55749fba2e3305222bba2dc5d8f46766001e2e2754caaaR55-R68">`src/promptflow/tests/sdk_cli_test/unittests/test_config.py`</a>: Added a new test method to `test_config.py` for testing the behavior of setting and loading the user agent from the configuration. <a href="diffhunk://#diff-1a31bc7b67fad77e9c55749fba2e3305222bba2dc5d8f46766001e2e2754caaaR55-R68">[1]</a> <a href="diffhunk://#diff-1a31bc7b67fad77e9c55749fba2e3305222bba2dc5d8f46766001e2e2754caaaR10-R11">[2]</a>
* <a href="diffhunk://#diff-7d74ecb42a689e4b7dea2171b91f90db56f79b6efcd70629df1548a1b091f229L25-R25">`src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py`</a>: Added a new test method to `test_cli.py` for testing the behavior of setting and clearing the user agent configuration value. <a href="diffhunk://#diff-7d74ecb42a689e4b7dea2171b91f90db56f79b6efcd70629df1548a1b091f229L25-R25">[1]</a> <a href="diffhunk://#diff-7d74ecb42a689e4b7dea2171b91f90db56f79b6efcd70629df1548a1b091f229R1705-R1723">[2]</a>

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
