### PR TITLE
[Fundamental] Promptflow-tool is blocked by promptflow enforcer matcher

### DIFF
--- a/scripts/building/check_enforcer.ps1
+++ b/scripts/building/check_enforcer.ps1
@@ -136,7 +136,7 @@ function run_checks() {
         if ($snippet_debug -eq 1) {
             Write-Output "git diff --name-only HEAD main $_"
         }
-        if ($_.Contains("src/promptflow")) {
+        if ($_.Contains("src/promptflow/")) {
             $need_to_check.Add("sdk_cli")
         }
     }


### PR DESCRIPTION
# Description

Promptflow-tool is blocked by promptflow enforcer matcher

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
