### PR TITLE
[promptflow][fundamental] Make Azure test fixtures package scope when live mode

### DIFF
--- a/src/promptflow/tests/conftest.py
+++ b/src/promptflow/tests/conftest.py
@@ -172,7 +172,7 @@ def mock_module_with_list_func(mock_list_func):
 
 
 # below fixtures are used for pfazure and global config tests
-@pytest.fixture
+@pytest.fixture(scope="session")
 def subscription_id() -> str:
     if is_replay():
         return SanitizedValues.SUBSCRIPTION_ID
@@ -180,7 +180,7 @@ def subscription_id() -> str:
         return os.getenv("PROMPT_FLOW_SUBSCRIPTION_ID", DEFAULT_SUBSCRIPTION_ID)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def resource_group_name() -> str:
     if is_replay():
         return SanitizedValues.RESOURCE_GROUP_NAME
@@ -188,7 +188,7 @@ def resource_group_name() -> str:
         return os.getenv("PROMPT_FLOW_RESOURCE_GROUP_NAME", DEFAULT_RESOURCE_GROUP_NAME)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def workspace_name() -> str:
     if is_replay():
         return SanitizedValues.WORKSPACE_NAME
@@ -196,11 +196,11 @@ def workspace_name() -> str:
         return os.getenv("PROMPT_FLOW_WORKSPACE_NAME", DEFAULT_WORKSPACE_NAME)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def runtime_name() -> str:
     return os.getenv("PROMPT_FLOW_RUNTIME_NAME", DEFAULT_RUNTIME_NAME)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def registry_name() -> str:
     return os.getenv("PROMPT_FLOW_REGISTRY_NAME", DEFAULT_REGISTRY_NAME)

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -37,7 +37,7 @@ AZUREML_RESOURCE_PROVIDER = "Microsoft.MachineLearningServices"
 RESOURCE_ID_FORMAT = "/subscriptions/{}/resourceGroups/{}/providers/{}/workspaces/{}"
 
 
-def determine_scope() -> str:
+def package_scope_in_live_mode() -> str:
     """Determine the scope of the pytest fixtures.
 
     We have many tests against flows and runs, and it's very time consuming to create a new flow/run
@@ -52,7 +52,7 @@ def determine_scope() -> str:
     return "package" if is_live() else "function"
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def user_object_id() -> str:
     if is_replay():
         return SanitizedValues.USER_OBJECT_ID
@@ -62,7 +62,7 @@ def user_object_id() -> str:
     return decoded_token["oid"]
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def tenant_id() -> str:
     if is_replay():
         return SanitizedValues.TENANT_ID
@@ -72,7 +72,7 @@ def tenant_id() -> str:
     return decoded_token["tid"]
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def ml_client(
     subscription_id: str,
     resource_group_name: str,
@@ -90,7 +90,7 @@ def ml_client(
     )
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def remote_client(subscription_id: str, resource_group_name: str, workspace_name: str):
     from promptflow.azure import PFClient
 
@@ -115,7 +115,7 @@ def remote_workspace_resource_id(subscription_id: str, resource_group_name: str,
     )
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def pf(remote_client):
     # do not add annotation here, because PFClient will trigger promptflow.azure imports and break the isolation
     # between azure and non-azure tests
@@ -163,12 +163,12 @@ def flow_serving_client_remote_connection(mocker: MockerFixture, remote_workspac
     return app.test_client()
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def variable_recorder() -> VariableRecorder:
     yield VariableRecorder()
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def randstr(variable_recorder: VariableRecorder) -> Callable[[str], str]:
     """Return a "random" UUID."""
 
@@ -184,7 +184,7 @@ def randstr(variable_recorder: VariableRecorder) -> Callable[[str], str]:
     return generate_random_string
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def vcr_recording(
     request: pytest.FixtureRequest, user_object_id: str, tenant_id: str, variable_recorder: VariableRecorder
 ) -> Optional[PFAzureIntegrationTestRecording]:
@@ -280,7 +280,7 @@ def mock_get_user_identity_info(mocker: MockerFixture) -> None:
     yield
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def created_flow(pf: PFClient, randstr: Callable[[str], str]) -> Flow:
     """Create a flow for test."""
     flow_display_name = randstr("flow_display_name")
@@ -302,7 +302,7 @@ def created_flow(pf: PFClient, randstr: Callable[[str], str]) -> Flow:
     yield result
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def created_batch_run_without_llm(pf: PFClient, randstr: Callable[[str], str], runtime: str) -> Run:
     """Create a batch run that does not require LLM."""
     name = randstr("batch_run_name")
@@ -322,7 +322,7 @@ def created_batch_run_without_llm(pf: PFClient, randstr: Callable[[str], str], r
     yield run
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def created_eval_run_without_llm(
     pf: PFClient, randstr: Callable[[str], str], runtime: str, created_batch_run_without_llm: Run
 ) -> Run:
@@ -342,7 +342,7 @@ def created_eval_run_without_llm(
     yield run
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture(scope=package_scope_in_live_mode())
 def created_failed_run(pf: PFClient, randstr: Callable[[str], str], runtime: str) -> Run:
     """Create a failed run."""
     name = randstr("failed_run_name")

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -41,14 +41,15 @@ def determine_scope() -> str:
     """Determine the scope of the pytest fixtures.
 
     We have many tests against flows and runs, and it's very time consuming to create a new flow/run
-    for each test. So we expect to leverage pytest fixture concept to share flows/runs across tests -
-    session scope is what we expect. However, we also have replay tests, which require function scope
-    fixture as it will locate the recording YAML based on the test function info.
+    for each test. So we expect to leverage pytest fixture concept to share flows/runs across tests.
+    However, we also have replay tests, which require function scope fixture as it will locate the
+    recording YAML based on the test function info.
 
     Use this function to determine the scope of the fixtures dynamically. For those fixtures that
     will request dynamic scope fixture(s), they also need to be dynamic scope.
     """
-    return "session" if is_live() else "function"
+    # package-scope should be enough for Azure tests
+    return "package" if is_live() else "function"
 
 
 @pytest.fixture(scope=determine_scope())
@@ -107,7 +108,7 @@ def remote_client(subscription_id: str, resource_group_name: str, workspace_name
     yield client
 
 
-@pytest.fixture(scope=determine_scope())
+@pytest.fixture
 def remote_workspace_resource_id(subscription_id: str, resource_group_name: str, workspace_name: str) -> str:
     return "azureml:" + RESOURCE_ID_FORMAT.format(
         subscription_id, resource_group_name, AZUREML_RESOURCE_PROVIDER, workspace_name

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -40,9 +40,13 @@ RESOURCE_ID_FORMAT = "/subscriptions/{}/resourceGroups/{}/providers/{}/workspace
 def determine_scope() -> str:
     """Determine the scope of the pytest fixtures.
 
-    Replay tests require function scope fixture as it will locate the recording YAML based on
-    the test function; while we expect session level fixtures for shared flow/run during
-    live mode. So use this function to determine the scope of the fixtures dynamically.
+    We have many tests against flows and runs, and it's very time consuming to create a new flow/run
+    for each test. So we expect to leverage pytest fixture concept to share flows/runs across tests -
+    session scope is what we expect. However, we also have replay tests, which require function scope
+    fixture as it will locate the recording YAML based on the test function info.
+
+    Use this function to determine the scope of the fixtures dynamically. For those fixtures that
+    will request dynamic scope fixture(s), they also need to be dynamic scope.
     """
     return "session" if is_live() else "function"
 

--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -38,7 +38,7 @@ RESOURCE_ID_FORMAT = "/subscriptions/{}/resourceGroups/{}/providers/{}/workspace
 
 
 def package_scope_in_live_mode() -> str:
-    """Determine the scope of the pytest fixtures.
+    """Determine the scope of some expected sharing fixtures.
 
     We have many tests against flows and runs, and it's very time consuming to create a new flow/run
     for each test. So we expect to leverage pytest fixture concept to share flows/runs across tests.

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/__init__.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/__init__.py
@@ -5,10 +5,12 @@
 from .bases import PFAzureIntegrationTestRecording
 from .constants import SanitizedValues
 from .utils import get_pf_client_for_replay, is_live, is_record, is_replay
+from .variable_recorder import VariableRecorder
 
 __all__ = [
     "PFAzureIntegrationTestRecording",
     "SanitizedValues",
+    "VariableRecorder",
     "get_pf_client_for_replay",
     "is_live",
     "is_record",


### PR DESCRIPTION
# Description

In Azure tests, we have some fixtures that create flow/run for tests. **IDEALLY** we can make them package scope, so that all tests can share them - only create once and always reuse, time-saving, efficient; **however**, replay tests require function scope because replay tests need test function info to locate the recording YAML.

This PR leverages dynamic scope fixtures to resolve this: in live mode, make those fixtures package scope, so that tests can reuse; in record and replay mode, keep function scope as before. Then, we can still enjoy replay tests and benefit shared fixtures during live tests. Cheers!

**Experiment/Proof**

Manually triggered a live test: <https://github.com/microsoft/promptflow/actions/runs/7258746460>, and from corresponding workspace, there are only 4 failed run created recently (corresponds to matrix Python version, 3.8~3.11):

![image](https://github.com/microsoft/promptflow/assets/38847871/512d4775-a654-4986-96c3-151ef15dcf26)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
