### PR TITLE
Handle cancellation of async flow test and node test

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [SDK/CLI] Support `pfazure run cancel` to cancel a run on Azure AI.
 - Add support to configure prompt flow home directory via environment variable `PF_HOME_DIRECTORY`.
   - Please set before importing `promptflow`, otherwise it won't take effect.
+- [Executor] Handle KeyboardInterrupt in flow test so that the final state is Canceled.
 
 ### Bugs Fixed
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node

--- a/src/promptflow/promptflow/_core/flow_execution_context.py
+++ b/src/promptflow/promptflow/_core/flow_execution_context.py
@@ -146,7 +146,7 @@ class FlowExecutionContext(ThreadLocalSingleton):
         # so that the error can propagate to the scheduler for handling.
         # Otherwise, the node would end with Completed status.
         except asyncio.CancelledError as e:
-            logger.exception(f"Node {node.name} in line {self._line_number} is cancelled.")
+            logger.info(f"Node {node.name} in line {self._line_number} is cancelled.")
             traces = Tracer.end_tracing(node_run_id)
             self._run_tracker.end_run(node_run_id, ex=e, traces=traces)
             raise

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -281,7 +281,8 @@ class RunTracker(ThreadLocalSingleton):
     def _enrich_run_info_with_exception(self, run_info: Union[RunInfo, FlowRunInfo], ex: Exception):
         """Update exception details into run info."""
         run_info.error = ExceptionPresenter.create(ex).to_dict(include_debug_info=self._debug)
-        run_info.status = Status.Failed
+        # Update status to Cancelled the run terminates because of KeyboardInterruption.
+        run_info.status = Status.Canceled if isinstance(ex, KeyboardInterrupt) else Status.Failed
 
     def collect_all_run_infos_as_dicts(self) -> Mapping[str, List[Mapping[str, Any]]]:
         flow_runs = self.flow_run_list

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -281,11 +281,11 @@ class RunTracker(ThreadLocalSingleton):
 
     def _enrich_run_info_with_exception(self, run_info: Union[RunInfo, FlowRunInfo], ex: Exception):
         """Update exception details into run info."""
-        run_info.error = ExceptionPresenter.create(ex).to_dict(include_debug_info=self._debug)
         # Update status to Cancelled the run terminates because of KeyboardInterruption or CancelledError.
         if isinstance(ex, KeyboardInterrupt) or isinstance(ex, asyncio.CancelledError):
             run_info.status = Status.Canceled
         else:
+            run_info.error = ExceptionPresenter.create(ex).to_dict(include_debug_info=self._debug)
             run_info.status = Status.Failed
 
     def collect_all_run_infos_as_dicts(self) -> Mapping[str, List[Mapping[str, Any]]]:

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -814,6 +814,7 @@ class FlowExecutor:
             # Run will be cancelled when the process receives a SIGINT signal.
             # KeyboardInterrupt will be raised after asyncio finishes its signal handling
             # End run with the KeyboardInterrupt exception, so that its status will be Canceled
+            flow_logger.info("Received KeyboardInterrupt, cancel the run.")
             run_tracker.end_run(line_run_id, ex=ex)
             raise
         except Exception as e:

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -814,8 +814,7 @@ class FlowExecutor:
             # Run will be cancelled when the process receives a SIGINT signal.
             # KeyboardInterrupt will be raised after asyncio finishes its signal handling
             # End run with the KeyboardInterrupt exception, so that its status will be Canceled
-            if self._should_use_async():
-                run_tracker.end_run(line_run_id, ex=ex)
+            run_tracker.end_run(line_run_id, ex=ex)
             raise
         except Exception as e:
             run_tracker.end_run(line_run_id, ex=e)

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -816,7 +816,7 @@ class FlowExecutor:
             # End run with the KeyboardInterrupt exception, so that its status will be Canceled
             if self._should_use_async():
                 run_tracker.end_run(line_run_id, ex=ex)
-                raise
+            raise
         except Exception as e:
             run_tracker.end_run(line_run_id, ex=e)
             if self._raise_ex:

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -810,6 +810,13 @@ class FlowExecutor:
             run_tracker.allow_generator_types = allow_generator_output
             run_tracker.end_run(line_run_id, result=output)
             aggregation_inputs = self._extract_aggregation_inputs(nodes_outputs)
+        except KeyboardInterrupt as ex:
+            # Run will be cancelled when the process receives a SIGINT signal.
+            # KeyboardInterrupt will be raised after asyncio finishes its signal handling
+            # End run with the KeyboardInterrupt exception, so that its status will be Canceled
+            if self._should_use_async():
+                run_tracker.end_run(line_run_id, ex=ex)
+                raise
         except Exception as e:
             run_tracker.end_run(line_run_id, ex=e)
             if self._raise_ex:
@@ -875,15 +882,16 @@ class FlowExecutor:
             )
         return outputs
 
+    def _should_use_async(self):
+        return all(
+            inspect.iscoroutinefunction(f) for f in self._tools_manager._tools.values()
+        ) or os.environ.get("PF_USE_ASYNC", "false").lower() == "true"
+
     def _traverse_nodes(self, inputs, context: FlowExecutionContext) -> Tuple[dict, dict]:
         batch_nodes = [node for node in self._flow.nodes if not node.aggregation]
         outputs = {}
         #  TODO: Use a mixed scheduler to support both async and thread pool mode.
-        should_use_async = (
-            all(inspect.iscoroutinefunction(f) for f in self._tools_manager._tools.values())
-            or os.environ.get("PF_USE_ASYNC", "false").lower() == "true"
-        )
-        if should_use_async:
+        if self._should_use_async():
             flow_logger.info("Start executing nodes in async mode.")
             scheduler = AsyncNodesScheduler(self._tools_manager, self._node_concurrency)
             nodes_outputs, bypassed_nodes = asyncio.run(scheduler.execute(batch_nodes, inputs, context))

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/async_passthrough.py
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/async_passthrough.py
@@ -5,8 +5,17 @@ import asyncio
 @tool
 async def passthrough_str_and_wait(input1: str, wait_seconds=3) -> str:
     assert isinstance(input1, str), f"input1 should be a string, got {input1}"
-    print(f"Wait for {wait_seconds} seconds in async function")
-    for i in range(wait_seconds):
-        print(i)
-        await asyncio.sleep(1)
+    try:
+        print(f"Wait for {wait_seconds} seconds in async function")
+        for i in range(wait_seconds):
+            print(i)
+            await asyncio.sleep(1)
+    except asyncio.CancelledError:
+        print("Async function is cancelled, start time consuming cancellation process")
+        import time
+        for i in range(3):
+            print(i)
+            time.sleep(1)
+        print(f"End time consuming cancellation process")
+        raise
     return input1

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
@@ -25,7 +25,7 @@ nodes:
     path: async_passthrough.py
   inputs:
     input1: ${async_passthrough.output}
-    wait_seconds: 3
+    wait_seconds: 5
 - name: sync_passthrough1
   type: python
   source:
@@ -33,4 +33,4 @@ nodes:
     path: sync_passthrough.py
   inputs:
     input1: ${async_passthrough.output}
-    wait_seconds: 3
+    wait_seconds: 5

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
@@ -25,7 +25,7 @@ nodes:
     path: async_passthrough.py
   inputs:
     input1: ${async_passthrough.output}
-    wait_seconds: 5
+    wait_seconds: 8
 - name: sync_passthrough1
   type: python
   source:
@@ -33,4 +33,4 @@ nodes:
     path: sync_passthrough.py
   inputs:
     input1: ${async_passthrough.output}
-    wait_seconds: 5
+    wait_seconds: 10


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
When received SIGINT in a running flow with both sync(wrapped as coroutine) and async nodes:
1. Cancel async node, enter node asyncio.Canceled error handling logic.
2. Cancel flow run.
3. Persist status of async node and flow to Canceled. There's bug that the async node's status is still Running, working on fix.
4. Wait for sync node to finish. Here we rely on external timer and kill mechanism to avoid long-running useless job.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
