### PR TITLE
[fundamental] Update PR labeler workflow to apply a label to PR from fork

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -10,3 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v4
+
+    - name: apply a label to PRs from forks
+      if: ${{ github.event.pull_request.head.repo.full_name != 'microsoft/promptflow' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['fork']
+          })

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -20,5 +20,5 @@ jobs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            labels: ['fork']
+            labels: ['external']
           })

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/labeler@v4
 
-    - name: apply a label to PRs from forks
+    - name: apply a label to pull request from fork
       if: ${{ github.event.pull_request.head.repo.full_name != 'microsoft/promptflow' }}
       uses: actions/github-script@v7
       with:


### PR DESCRIPTION
# Description

This PR adds one step in workflow [Pull Request Labeler](https://github.com/microsoft/promptflow/actions/workflows/labeler.yml) to apply a label (current value: `external`) to pull request from fork, then we can use this label to query PRs from fork easily.

Some experiments from private repo:

- fork PR: https://github.com/zhengfeiwang/gh-actions/pull/9
- internal PR: https://github.com/zhengfeiwang/gh-actions/pull/10

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
