### PR TITLE
[fundamental][bugfix] Remove useless steps in perf monitor CI

### DIFF
--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -54,16 +54,6 @@ jobs:
           setupType: ${{ env.packageSetupType }}
           scriptPath: ${{ env.testWorkingDirectory }}
 
-      - name: Azure login
-        uses: azure/login@v1
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: generate live test resources (non pull_request workflow)
-        uses: "./.github/actions/step_generate_configs"
-        with:
-          targetFolder: ${{ env.testWorkingDirectory }}
-
       - name: Run Test
         shell: pwsh
         working-directory: ${{ env.testWorkingDirectory }}

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -54,6 +54,11 @@ jobs:
           setupType: ${{ env.packageSetupType }}
           scriptPath: ${{ env.testWorkingDirectory }}
 
+      - name: Generate (mock) connections.json
+        shell: pwsh
+        working-directory: ${{ env.testWorkingDirectory }}
+        run: cp ${{ github.workspace }}/src/promptflow/dev-connections.json.example ${{ github.workspace }}/src/promptflow/connections.json
+
       - name: Run Test
         shell: pwsh
         working-directory: ${{ env.testWorkingDirectory }}

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -1,5 +1,4 @@
 # execute tests in src/promptflow/tests/sdk_cli_azure_test, src/promptflow/tests/sdk_cli_test with mark perf_monitor_test
-# when pull_request triggers, use live mode
 
 name: sdk-cli-perf-monitor-test
 

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - src/promptflow/**
       - scripts/building/**
+      - .github/workflows/sdk-cli-perf-monitor-test.yml
 
   schedule:
     - cron: "0 */6 * * *"  # Run every 6 hours


### PR DESCRIPTION
# Description

[SDK perf monitor CI](https://github.com/microsoft/promptflow/actions/workflows/sdk-cli-perf-monitor-test.yml) always uses replay mode, so it should be safe to remove steps that related to sensitive data: Azure CLI login and prepare live resources (replace with copy connection json example as a mock); otherwise, these steps will fail in a PR from fork as it does not have enough permission to do so.

Also make workflow listen to change to itself.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
