### PR TITLE
[promptflow][feature] Support to configure PF home directory

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features Added
 - [SDK/CLI] Support `pfazure run cancel` to cancel a run on Azure AI.
+- Add support to configure prompt flow home directory via environment variable `PF_HOME_DIRECTORY`.
+  - Please set before importing `promptflow`, otherwise it won't take effect.
 
 ### Bugs Fixed
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -2,10 +2,47 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+import os
 from enum import Enum
 from pathlib import Path
 
+from promptflow._utils.logger_utils import LoggerFactory
+
 LOGGER_NAME = "promptflow"
+_logger = LoggerFactory.get_logger(LOGGER_NAME)
+
+PROMPT_FLOW_DIR_NAME = ".promptflow"
+
+# prepare prompt flow home directory
+# user can configure by setting the environment variable: `PF_HOME_DIRECTORY`
+PROMPT_FLOW_HOME_DIR_ENV_VAR = "PF_HOME_DIRECTORY"
+HOME_PROMPT_FLOW_DIR = None
+if PROMPT_FLOW_HOME_DIR_ENV_VAR in os.environ:
+    try:
+        _pf_home_dir = Path(os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR)).resolve()
+        _pf_home_dir.mkdir(exist_ok=True)
+        HOME_PROMPT_FLOW_DIR = _pf_home_dir
+    except Exception as e:  # pylint: disable=broad-except
+        _warning_message = (
+            "Invalid configuration for prompt flow home directory: "
+            f"{os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR)!r}: {str(e)!r}.\n"
+            'Fall back to use default value: "~/.promptflow/".'
+        )
+        _logger.warning(_warning_message)
+# if configured value is not valid/not set, use default value: "~/.promptflow/"
+if HOME_PROMPT_FLOW_DIR is None:
+    try:
+        HOME_PROMPT_FLOW_DIR = (Path.home() / PROMPT_FLOW_DIR_NAME).resolve()
+        HOME_PROMPT_FLOW_DIR.mkdir(exist_ok=True)
+    except Exception as e:  # pylint: disable=broad-except
+        _error_message = (
+            f"Cannot create prompt flow home directory: {str(e)!r}.\n"
+            "Please check if you have proper permission to operate the directory "
+            f"{HOME_PROMPT_FLOW_DIR.as_posix()!r}; or configure it via "
+            f"environment variable {PROMPT_FLOW_HOME_DIR_ENV_VAR!r}.\n"
+        )
+        _logger.error(_error_message)
+        raise Exception(_error_message)
 
 DAG_FILE_NAME = "flow.dag.yaml"
 NODE_VARIANTS = "node_variants"
@@ -17,15 +54,10 @@ USE_VARIANTS = "use_variants"
 DEFAULT_VAR_ID = "default_variant_id"
 FLOW_TOOLS_JSON = "flow.tools.json"
 FLOW_TOOLS_JSON_GEN_TIMEOUT = 60
-PROMPT_FLOW_DIR_NAME = ".promptflow"
 PROMPT_FLOW_RUNS_DIR_NAME = ".runs"
-HOME_PROMPT_FLOW_DIR = (Path.home() / PROMPT_FLOW_DIR_NAME).resolve()
 SERVICE_CONFIG_FILE = "pf.yaml"
 PF_SERVICE_PORT_FILE = "pfs.port"
 PF_SERVICE_LOG_FILE = "pfs.log"
-
-if not HOME_PROMPT_FLOW_DIR.is_dir():
-    HOME_PROMPT_FLOW_DIR.mkdir(exist_ok=True)
 
 LOCAL_MGMT_DB_PATH = (HOME_PROMPT_FLOW_DIR / "pf.sqlite").resolve()
 LOCAL_MGMT_DB_SESSION_ACQUIRE_LOCK_PATH = (HOME_PROMPT_FLOW_DIR / "pf.sqlite.lock").resolve()

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -28,7 +28,7 @@ def _prepare_home_dir() -> Path:
         )
         try:
             pf_home_dir = Path(os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR)).resolve()
-            pf_home_dir.mkdir(exist_ok=True)
+            pf_home_dir.mkdir(parents=True, exist_ok=True)
             return pf_home_dir
         except Exception as e:  # pylint: disable=broad-except
             _warning_message = (
@@ -41,7 +41,7 @@ def _prepare_home_dir() -> Path:
     try:
         logger.debug("preparing home directory with default value.")
         pf_home_dir = (Path.home() / PROMPT_FLOW_DIR_NAME).resolve()
-        pf_home_dir.mkdir(exist_ok=True)
+        pf_home_dir.mkdir(parents=True, exist_ok=True)
         return pf_home_dir
     except Exception as e:  # pylint: disable=broad-except
         _error_message = (

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -6,10 +6,7 @@ import os
 from enum import Enum
 from pathlib import Path
 
-from promptflow._utils.logger_utils import LoggerFactory
-
 LOGGER_NAME = "promptflow"
-_logger = LoggerFactory.get_logger(LOGGER_NAME)
 
 PROMPT_FLOW_HOME_DIR_ENV_VAR = "PF_HOME_DIRECTORY"
 PROMPT_FLOW_DIR_NAME = ".promptflow"
@@ -21,6 +18,10 @@ def _prepare_home_dir() -> Path:
     User can configure it by setting environment variable: `PF_HOME_DIRECTORY`;
     if not configured, or configured value is not valid, use default value: "~/.promptflow/".
     """
+    from promptflow._utils.logger_utils import LoggerFactory
+
+    logger = LoggerFactory.get_logger(LOGGER_NAME)
+
     if PROMPT_FLOW_HOME_DIR_ENV_VAR in os.environ:
         try:
             pf_home_dir = Path(os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR)).resolve()
@@ -32,7 +33,7 @@ def _prepare_home_dir() -> Path:
                 f"{os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR)!r}: {str(e)!r}.\n"
                 'Fall back to use default value: "~/.promptflow/".'
             )
-            _logger.warning(_warning_message)
+            logger.warning(_warning_message)
 
     try:
         pf_home_dir = (Path.home() / PROMPT_FLOW_DIR_NAME).resolve()
@@ -45,7 +46,7 @@ def _prepare_home_dir() -> Path:
             f"{HOME_PROMPT_FLOW_DIR.as_posix()!r}; or configure it via "
             f"environment variable {PROMPT_FLOW_HOME_DIR_ENV_VAR!r}.\n"
         )
-        _logger.error(_error_message)
+        logger.error(_error_message)
         raise Exception(_error_message)
 
 

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -23,6 +23,9 @@ def _prepare_home_dir() -> Path:
     logger = LoggerFactory.get_logger(LOGGER_NAME)
 
     if PROMPT_FLOW_HOME_DIR_ENV_VAR in os.environ:
+        logger.debug(
+            f"environment variable {PROMPT_FLOW_HOME_DIR_ENV_VAR!r} is set, honor it preparing home directory."
+        )
         try:
             pf_home_dir = Path(os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR)).resolve()
             pf_home_dir.mkdir(exist_ok=True)
@@ -36,6 +39,7 @@ def _prepare_home_dir() -> Path:
             logger.warning(_warning_message)
 
     try:
+        logger.debug("preparing home directory with default value.")
         pf_home_dir = (Path.home() / PROMPT_FLOW_DIR_NAME).resolve()
         pf_home_dir.mkdir(exist_ok=True)
         return pf_home_dir

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -282,7 +282,7 @@ class TestUtils:
             assert _constants.HOME_PROMPT_FLOW_DIR.is_dir()
         importlib.reload(_constants)
 
-    def test_configure_pf_home_dir_with_invalid_path(self, capfd: pytest.CaptureFixture) -> None:
+    def test_configure_pf_home_dir_with_invalid_path(self) -> None:
         from promptflow._sdk import _constants
 
         invalid_path = "/invalid:path"
@@ -290,10 +290,6 @@ class TestUtils:
             assert os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR) == invalid_path
             importlib.reload(_constants)
             assert _constants.HOME_PROMPT_FLOW_DIR.as_posix() == (Path.home() / ".promptflow").resolve().as_posix()
-            # during reload, logger.propagate is set to False, which makes caplog not work
-            # so we use capfd here to assert the warning message
-            _, err = capfd.readouterr()
-            assert "Invalid configuration for prompt flow home directory" in err
         importlib.reload(_constants)
 
 

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------
 
 import argparse
+import importlib
 import os
 import shutil
 import sys
@@ -21,7 +22,7 @@ from promptflow._cli._utils import (
     _calculate_column_widths,
     list_of_dict_to_nested_dict,
 )
-from promptflow._sdk._constants import HOME_PROMPT_FLOW_DIR
+from promptflow._sdk._constants import HOME_PROMPT_FLOW_DIR, PROMPT_FLOW_HOME_DIR_ENV_VAR
 from promptflow._sdk._errors import GenerateFlowToolsJsonError
 from promptflow._sdk._telemetry.logging_handler import get_scrubbed_cloud_role
 from promptflow._sdk._utils import (
@@ -269,6 +270,31 @@ class TestUtils:
     def test_get_scrubbed_cloud_role(self, script_name, expected_result):
         with mock.patch("sys.argv", [script_name]):
             assert get_scrubbed_cloud_role() == expected_result
+
+    def test_configure_pf_home_dir(self, tmpdir) -> None:
+        from promptflow._sdk import _constants
+
+        custom_pf_home_dir_path = Path(tmpdir / ".promptflow").resolve()
+        assert not custom_pf_home_dir_path.exists()
+        with patch.dict(os.environ, {PROMPT_FLOW_HOME_DIR_ENV_VAR: custom_pf_home_dir_path.as_posix()}):
+            importlib.reload(_constants)
+            assert _constants.HOME_PROMPT_FLOW_DIR.as_posix() == custom_pf_home_dir_path.as_posix()
+            assert _constants.HOME_PROMPT_FLOW_DIR.is_dir()
+        importlib.reload(_constants)
+
+    def test_configure_pf_home_dir_with_invalid_path(self, capfd: pytest.CaptureFixture) -> None:
+        from promptflow._sdk import _constants
+
+        invalid_path = "/invalid:path"
+        with patch.dict(os.environ, {PROMPT_FLOW_HOME_DIR_ENV_VAR: invalid_path}):
+            assert os.getenv(PROMPT_FLOW_HOME_DIR_ENV_VAR) == invalid_path
+            importlib.reload(_constants)
+            assert _constants.HOME_PROMPT_FLOW_DIR.as_posix() == (Path.home() / ".promptflow").resolve().as_posix()
+            # during reload, logger.propagate is set to False, which makes caplog not work
+            # so we use capfd here to assert the warning message
+            _, err = capfd.readouterr()
+            assert "Invalid configuration for prompt flow home directory" in err
+        importlib.reload(_constants)
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
# Description

This PR targets to support the feature ask in #1501 , user can configure PF home directory via setting environment variable `PF_HOME_DIRECTORY` in case they don't have enough permission to operate the default value (`~/.promptflow/`).

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
