### PR TITLE
[Draft][Do not merge] Add draft version of execute a script as a flow

### DIFF
--- a/src/promptflow/tests/test_configs/flows/flow_no_yaml/flow_entry.py
+++ b/src/promptflow/tests/test_configs/flows/flow_no_yaml/flow_entry.py
@@ -1,0 +1,10 @@
+from promptflow import tool
+
+from passthrough import passthrough_str_and_wait_sync
+
+
+@tool
+def flow_entry(input1: str, wait_seconds=3):
+    val1 = passthrough_str_and_wait_sync(input1, wait_seconds)
+    val2 = passthrough_str_and_wait_sync(input1, wait_seconds + 2)
+    return {"val1": val1, "val2": val2}

--- a/src/promptflow/tests/test_configs/flows/flow_no_yaml/passthrough.py
+++ b/src/promptflow/tests/test_configs/flows/flow_no_yaml/passthrough.py
@@ -1,0 +1,12 @@
+from promptflow import tool
+import time
+
+
+@tool
+def passthrough_str_and_wait_sync(input1: str, wait_seconds=3) -> str:
+    assert isinstance(input1, str), f"input1 should be a string, got {input1}"
+    print("Wait for", wait_seconds, "seconds in sync function")
+    for i in range(wait_seconds):
+        print(i)
+        time.sleep(1)
+    return input1


### PR DESCRIPTION
# Description

Support directly run an executor with a tool script.

This pull request introduces new functionality to the `promptflow` library, allowing users to create flows using Python scripts instead of YAML files. It includes the addition of new Python scripts for creating flows and a test method to verify the successful execution of a flow using the `FlowExecutor`.

Main changes:

* <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69R204-R265">`src/promptflow/promptflow/executor/flow_executor.py`</a>: Added support for creating a `FlowExecutor` instance from a Python script instead of a YAML file. <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69R204-R265">[1]</a> <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69R187-R191">[2]</a>
* <a href="diffhunk://#diff-8c2b0cb721010f54be1e92a33339241745d9a9872160e7451fbab0e34543293fR1-R12">`src/promptflow/tests/test_configs/flows/flow_no_yaml/passthrough.py`</a>: Added a new Python script `passthrough_str_and_wait_sync` to the `flow_no_yaml` directory in the test suite. It is a tool that takes a string input and waits for a specified number of seconds before returning the input string.
* <a href="diffhunk://#diff-5fb22771467155f5edb3c2d407c61f0cc5c897a789af4b9d2f1ad0935d5a689eR1-R10">`src/promptflow/tests/test_configs/flows/flow_no_yaml/flow_entry.py`</a>: Added a new Python script `flow_entry` to the `flow_no_yaml` directory in the test suite. It is a tool that takes a string input and calls the `passthrough_str_and_wait_sync` tool twice with different wait times, returning a dictionary with the output values from the two calls.
* <a href="diffhunk://#diff-44d4009e9df8029bb88432b7a843d3a887764cd6a67070afc49557334af3cbaaR244-R257">`src/promptflow/tests/executor/e2etests/test_executor_happypath.py`</a>: Added a new test method `test_executor_flow_entry` to the `test_executor_happypath.py` file in the test suite. It tests the successful execution of a flow using `FlowExecutor` and verifies the output values and API calls made during the execution.
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
