### PR TITLE
[Do Not Merge] Only load tool once

### DIFF
--- a/src/promptflow/promptflow/contracts/_errors.py
+++ b/src/promptflow/promptflow/contracts/_errors.py
@@ -7,3 +7,7 @@ class FailedToImportModule(UserErrorException):
 
 class InvalidImageInput(ValidationException):
     pass
+
+
+class DuplicateNodeName(ValidationException):
+    pass

--- a/src/promptflow/promptflow/executor/_tool_loader.py
+++ b/src/promptflow/promptflow/executor/_tool_loader.py
@@ -1,0 +1,98 @@
+import logging
+import types
+from typing import List, Dict, Optional, Tuple
+
+from promptflow._core._errors import PackageToolNotFoundError
+from promptflow._core.tool_meta_generator import (
+    _parse_tool_from_function,
+    collect_tool_function_in_module,
+    load_python_module_from_file,
+)
+from promptflow._core.tools_manager import collect_package_tools, BuiltinsManager
+from promptflow._utils.tool_utils import _find_deprecated_tools
+from promptflow.contracts.flow import Node, Tool, ToolType, ToolSourceType
+from promptflow.executor._errors import UserErrorException, SystemErrorException
+from promptflow.exceptions import ErrorTarget
+
+module_logger = logging.getLogger(__name__)
+
+
+class ToolLoader:
+    def __init__(self, working_dir: str, package_tool_keys: Optional[List[str]] = None) -> None:
+        self._working_dir = working_dir
+        self._package_tools = collect_package_tools(package_tool_keys) if package_tool_keys else {}
+        # Used to handle backward compatibility of tool ID changes.
+        self._deprecated_tools = _find_deprecated_tools(self._package_tools)
+        self._loaded_tools = {}
+
+    @property
+    def loaded_tools(self) -> Dict[str, Tool]:
+        return self._loaded_tools
+
+    # TODO: Replace NotImplementedError with NotSupported in the future.
+    def load_tool_for_node(self, node: Node) -> Tool:
+        if node.source is None:
+            raise UserErrorException(f"Node {node.name} does not have source defined.")
+        if node.type == ToolType.PYTHON:
+            if node.source.type == ToolSourceType.Package:
+                return self.load_tool_for_package_node(node)
+            elif node.source.type == ToolSourceType.Code:
+                _, tool = self.load_tool_for_script_node(node)
+                return tool
+            raise NotImplementedError(f"Tool source type {node.source.type} for python tool is not supported yet.")
+        elif node.type == ToolType.CUSTOM_LLM:
+            if node.source.type == ToolSourceType.PackageWithPrompt:
+                return self.load_tool_for_package_node(node)
+            raise NotImplementedError(f"Tool source type {node.source.type} for custom_llm tool is not supported yet.")
+        else:
+            raise NotImplementedError(f"Tool type {node.type} is not supported yet.")
+
+    def load_tool_for_package_node(self, node: Node) -> Tool:
+        if node.name in self._loaded_tools:
+            return self._loaded_tools[node.name]
+
+        if node.source.tool in self._package_tools:
+            return Tool.deserialize(self._package_tools[node.source.tool])
+
+        # If node source tool is not in package tools, try to find the tool ID in deprecated tools.
+        # If found, load the tool with the new tool ID for backward compatibility.
+        if node.source.tool in self._deprecated_tools:
+            new_tool_id = self._deprecated_tools[node.source.tool]
+            # Used to collect deprecated tool usage and warn user to replace the deprecated tool with the new one.
+            module_logger.warning(f"Tool ID '{node.source.tool}' is deprecated. Please use '{new_tool_id}' instead.")
+            tool = Tool.deserialize(self._package_tools[new_tool_id])
+            self._loaded_tools[node.name] = tool
+
+        raise PackageToolNotFoundError(
+            f"Package tool '{node.source.tool}' is not found in the current environment. "
+            f"All available package tools are: {list(self._package_tools.keys())}.",
+            target=ErrorTarget.EXECUTOR,
+        )
+
+    def load_tool_for_script_node(self, node: Node) -> Tuple[types.ModuleType, Tool]:
+        if node.name in self._loaded_tools:
+            return self._loaded_tools[node.name]
+
+        if node.source.path is None:
+            raise UserErrorException(f"Node {node.name} does not have source path defined.")
+        path = node.source.path
+        m = load_python_module_from_file(self._working_dir / path)
+        if m is None:
+            raise CustomToolSourceLoadError(f"Cannot load module from {path}.")
+        f, init_inputs = collect_tool_function_in_module(m)
+        tool = _parse_tool_from_function(f, init_inputs, gen_custom_type_conn=True)
+        self._loaded_tools[node.name] = (m, tool)
+        return m, tool
+
+    def load_tool_for_llm_node(self, node: Node) -> Tool:
+        if node.name in self._loaded_tools:
+            return self._loaded_tools[node.name]
+
+        api_name = f"{node.provider}.{node.api}"
+        tool = BuiltinsManager._load_llm_api(api_name)
+        self._loaded_tools[node.name] = tool
+        return tool
+
+
+class CustomToolSourceLoadError(SystemErrorException):
+    pass

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -12,7 +12,7 @@ from typing import Callable, List, Optional
 
 from promptflow._core.connection_manager import ConnectionManager
 from promptflow._core.tool import STREAMING_OPTION_PARAMETER_ATTR
-from promptflow._core.tools_manager import BuiltinsManager, ToolLoader, connection_type_to_api_mapping
+from promptflow._core.tools_manager import BuiltinsManager, connection_type_to_api_mapping
 from promptflow._utils.multimedia_utils import create_image, load_multimedia_data_recursively
 from promptflow._utils.tool_utils import get_inputs_for_prompt_template, get_prompt_param_name_from_func
 from promptflow.contracts._errors import InvalidImageInput
@@ -30,6 +30,7 @@ from promptflow.executor._errors import (
     ResolveToolError,
     ValueTypeUnresolved,
 )
+from promptflow.executor._tool_loader import ToolLoader
 
 
 @dataclass
@@ -42,14 +43,18 @@ class ResolvedTool:
 
 class ToolResolver:
     def __init__(
-        self, working_dir: Path, connections: Optional[dict] = None, package_tool_keys: Optional[List[str]] = None
+        self,
+        working_dir: Path,
+        connections: Optional[dict] = None,
+        package_tool_keys: Optional[List[str]] = None,
+        tool_loader: Optional[ToolLoader] = None
     ):
         try:
             # Import openai and aoai for llm tool
             from promptflow.tools import aoai, openai  # noqa: F401
         except ImportError:
             pass
-        self._tool_loader = ToolLoader(working_dir, package_tool_keys=package_tool_keys)
+        self._tool_loader = tool_loader or ToolLoader(working_dir, package_tool_keys=package_tool_keys)
         self._working_dir = working_dir
         self._connection_manager = ConnectionManager(connections)
 

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -215,7 +215,7 @@ class FlowExecutor:
             flow = flow._apply_node_overrides(node_override)
         flow = flow._apply_default_node_variants()
         package_tool_keys = [node.source.tool for node in flow.nodes if node.source and node.source.tool]
-        tool_resolver = ToolResolver(working_dir, connections, package_tool_keys)
+        tool_resolver = ToolResolver(working_dir, connections, package_tool_keys, tool_loader=flow.tool_loader)
         with _change_working_dir(working_dir):
             resolved_tools = [tool_resolver.resolve_tool_by_node(node) for node in flow.nodes]
         flow = Flow(

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -10,11 +10,10 @@ from promptflow._core.tools_manager import APINotFound
 from promptflow._sdk._constants import DAG_FILE_NAME
 from promptflow._utils.utils import dump_list_to_jsonl
 from promptflow.batch import BatchEngine
-from promptflow.contracts._errors import FailedToImportModule
+from promptflow.contracts._errors import FailedToImportModule, DuplicateNodeName
 from promptflow.executor import FlowExecutor
 from promptflow.executor._errors import (
     ConnectionNotFound,
-    DuplicateNodeName,
     EmptyOutputReference,
     InputNotFound,
     InputReferenceNotFound,
@@ -43,10 +42,10 @@ class TestValidation:
                 DuplicateNodeName,
                 None,
                 (
-                    "Invalid node definitions found in the flow graph. Node with name 'stringify_num' appears more "
-                    "than once in the node definitions in your flow, which is not allowed. To "
-                    "address this issue, please review your flow and either rename or remove "
-                    "nodes with identical names."
+                    "Invalid node definitions found in the flow graph. Node with name '['stringify_num']' "
+                    "appears more than once in the node definitions in your flow, which is not allowed. To "
+                    "address this issue, please review your flow and either rename or remove nodes with "
+                    "identical names."
                 ),
             ),
             (

--- a/src/promptflow/tests/executor/e2etests/test_package_tool.py
+++ b/src/promptflow/tests/executor/e2etests/test_package_tool.py
@@ -13,7 +13,7 @@ from promptflow.executor._result import LineResult
 from ..utils import WRONG_FLOW_ROOT, get_flow_package_tool_definition, get_flow_sample_inputs, get_yaml_file
 
 PACKAGE_TOOL_BASE = Path(__file__).parent.parent / "package_tools"
-PACKAGE_TOOL_ENTRY = "promptflow._core.tools_manager.collect_package_tools"
+PACKAGE_TOOL_ENTRY = "promptflow.executor._tool_loader.collect_package_tools"
 
 sys.path.insert(0, str(PACKAGE_TOOL_BASE.resolve()))
 

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -1,134 +1,17 @@
 import textwrap
-from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from mock import MagicMock
 from ruamel.yaml import YAML
 
-from promptflow import tool
-from promptflow._core._errors import InputTypeMismatch, PackageToolNotFoundError
+from promptflow._core._errors import InputTypeMismatch
 from promptflow._core.tools_manager import (
     BuiltinsManager,
-    ToolLoader,
     collect_package_tools,
     collect_package_tools_and_connections,
 )
-from promptflow.contracts.flow import InputAssignment, InputValueType, Node, ToolSource, ToolSourceType
-from promptflow.contracts.tool import Tool, ToolType
-from promptflow.exceptions import UserErrorException
-
-
-@pytest.mark.unittest
-class TestToolLoader:
-    def test_load_tool_for_node_with_invalid_node(self):
-        tool_loader = ToolLoader(working_dir="test_working_dir")
-        node: Node = Node(name="test", tool="test_tool", inputs={}, type=ToolType.PYTHON)
-        with pytest.raises(UserErrorException, match="Node test does not have source defined."):
-            tool_loader.load_tool_for_node(node)
-
-        node: Node = Node(
-            name="test", tool="test_tool", inputs={}, type=ToolType.PYTHON, source=ToolSource(type="invalid_type")
-        )
-        with pytest.raises(
-            NotImplementedError, match="Tool source type invalid_type for python tool is not supported yet."
-        ):
-            tool_loader.load_tool_for_node(node)
-
-        node: Node = Node(
-            name="test", tool="test_tool", inputs={}, type=ToolType.CUSTOM_LLM, source=ToolSource(type="invalid_type")
-        )
-        with pytest.raises(
-            NotImplementedError, match="Tool source type invalid_type for custom_llm tool is not supported yet."
-        ):
-            tool_loader.load_tool_for_node(node)
-
-        node: Node = Node(
-            name="test", tool="test_tool", inputs={}, type="invalid_type", source=ToolSource(type=ToolSourceType.Code)
-        )
-        with pytest.raises(NotImplementedError, match="Tool type invalid_type is not supported yet."):
-            tool_loader.load_tool_for_node(node)
-
-    def test_load_tool_for_package_node(self, mocker):
-        package_tools = {"test_tool": Tool(name="test_tool", type=ToolType.PYTHON, inputs={}).serialize()}
-        mocker.patch("promptflow._core.tools_manager.collect_package_tools", return_value=package_tools)
-        tool_loader = ToolLoader(
-            working_dir="test_working_dir", package_tool_keys=["promptflow._core.tools_manager.collect_package_tools"]
-        )
-        node: Node = Node(
-            name="test",
-            tool="test_tool",
-            inputs={},
-            type=ToolType.PYTHON,
-            source=ToolSource(type=ToolSourceType.Package, tool="test_tool"),
-        )
-        tool = tool_loader.load_tool_for_node(node)
-        assert tool.name == "test_tool"
-
-        node: Node = Node(
-            name="test",
-            tool="test_tool",
-            inputs={},
-            type=ToolType.PYTHON,
-            source=ToolSource(type=ToolSourceType.Package, tool="invalid_tool"),
-        )
-        msg = (
-            "Package tool 'invalid_tool' is not found in the current environment. "
-            "All available package tools are: ['test_tool']."
-        )
-        with pytest.raises(PackageToolNotFoundError) as ex:
-            tool_loader.load_tool_for_node(node)
-            assert str(ex.value) == msg
-
-    def test_load_tool_for_package_node_with_legacy_tool_id(self, mocker):
-        package_tools = {
-            "new_tool_1": Tool(
-                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_1"]
-            ).serialize(),
-            "new_tool_2": Tool(
-                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_2"]
-            ).serialize(),
-            "old_tool_2": Tool(name="old tool 2", type=ToolType.PYTHON, inputs={}).serialize(),
-        }
-        mocker.patch("promptflow._core.tools_manager.collect_package_tools", return_value=package_tools)
-        tool_loader = ToolLoader(working_dir="test_working_dir", package_tool_keys=list(package_tools.keys()))
-        node_with_legacy_tool: Node = Node(
-            name="test_legacy_tool",
-            tool="old_tool_1",
-            inputs={},
-            type=ToolType.PYTHON,
-            source=ToolSource(type=ToolSourceType.Package, tool="old_tool_1"),
-        )
-        assert tool_loader.load_tool_for_node(node_with_legacy_tool).name == "new tool 1"
-
-        node_with_legacy_tool_but_in_package_tools: Node = Node(
-            name="test_legacy_tool_but_in_package_tools",
-            tool="old_tool_2",
-            inputs={},
-            type=ToolType.PYTHON,
-            source=ToolSource(type=ToolSourceType.Package, tool="old_tool_2"),
-        )
-        assert tool_loader.load_tool_for_node(node_with_legacy_tool_but_in_package_tools).name == "old tool 2"
-
-    def test_load_tool_for_script_node(self):
-        working_dir = Path(__file__).parent
-        tool_loader = ToolLoader(working_dir=working_dir)
-        file = "test_tools_manager.py"
-        node: Node = Node(
-            name="test",
-            tool="sample_tool",
-            inputs={},
-            type=ToolType.PYTHON,
-            source=ToolSource(type=ToolSourceType.Code, path=file),
-        )
-        tool = tool_loader.load_tool_for_node(node)
-        assert tool.name == "sample_tool"
-
-
-# This tool is for testing tools_manager.ToolLoader.load_tool_for_script_node
-@tool
-def sample_tool(input: str):
-    return input
+from promptflow.contracts.flow import InputAssignment, InputValueType
 
 
 @pytest.mark.unittest

--- a/src/promptflow/tests/executor/unittests/contracts/test_flow.py
+++ b/src/promptflow/tests/executor/unittests/contracts/test_flow.py
@@ -50,7 +50,7 @@ class TestFlowContract:
         flow_folder = PACKAGE_TOOL_BASE / "custom_llm_tool"
         flow_file = flow_folder / "flow.dag.yaml"
         package_tool_definition = get_flow_package_tool_definition(flow_folder)
-        mocker.patch("promptflow._core.tools_manager.collect_package_tools", return_value=package_tool_definition)
+        mocker.patch("promptflow.executor._tool_loader.collect_package_tools", return_value=package_tool_definition)
         flow = Flow.from_yaml(flow_file)
         connection_names = flow.get_connection_names()
         assert connection_names == {"azure_open_ai_connection"}
@@ -59,7 +59,7 @@ class TestFlowContract:
         flow_folder = PACKAGE_TOOL_BASE / "custom_llm_tool"
         flow_file = flow_folder / "flow.dag.yaml"
         package_tool_definition = get_flow_package_tool_definition(flow_folder)
-        mocker.patch("promptflow._core.tools_manager.collect_package_tools", return_value=package_tool_definition)
+        mocker.patch("promptflow.executor._tool_loader.collect_package_tools", return_value=package_tool_definition)
         flow = Flow.from_yaml(flow_file)
         connection_names = flow.get_connection_input_names_for_node(flow.nodes[0].name)
         assert connection_names == ["connection", "connection_2"]
@@ -325,9 +325,10 @@ class TestFlow:
 
     def test_get_tool(self):
         tool = Tool(name="tool", type=ToolType.PYTHON, inputs={})
-        flow = Flow(id="id", name="name", nodes=[], inputs={}, outputs={}, tools=[tool])
-        assert flow.get_tool("tool") is tool
-        assert flow.get_tool("other_tool") is None
+        node = Node(name="node", tool="tool", inputs={})
+        flow = Flow(id="id", name="name", nodes=[node], inputs={}, outputs={}, tools=[tool])
+        assert flow.get_tool("node") is tool
+        assert flow.get_tool("other_node") is None
 
     def test_is_reduce_node(self):
         llm_node = Node(name="llm_node", tool=None, inputs={})

--- a/src/promptflow/tests/executor/unittests/executor/test_tool_loader.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_loader.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+import pytest
+
+from promptflow import tool
+from promptflow._core._errors import PackageToolNotFoundError
+from promptflow.contracts.flow import Node, ToolSource, ToolSourceType
+from promptflow.contracts.tool import Tool, ToolType
+from promptflow.exceptions import UserErrorException
+from promptflow.executor._tool_loader import ToolLoader
+
+
+@pytest.mark.unittest
+class TestToolLoader:
+    def test_load_tool_for_node_with_invalid_node(self):
+        tool_loader = ToolLoader(working_dir="test_working_dir")
+        node: Node = Node(name="test", tool="test_tool", inputs={}, type=ToolType.PYTHON)
+        with pytest.raises(UserErrorException, match="Node test does not have source defined."):
+            tool_loader.load_tool_for_node(node)
+
+        node: Node = Node(
+            name="test", tool="test_tool", inputs={}, type=ToolType.PYTHON, source=ToolSource(type="invalid_type")
+        )
+        with pytest.raises(
+            NotImplementedError, match="Tool source type invalid_type for python tool is not supported yet."
+        ):
+            tool_loader.load_tool_for_node(node)
+
+        node: Node = Node(
+            name="test", tool="test_tool", inputs={}, type=ToolType.CUSTOM_LLM, source=ToolSource(type="invalid_type")
+        )
+        with pytest.raises(
+            NotImplementedError, match="Tool source type invalid_type for custom_llm tool is not supported yet."
+        ):
+            tool_loader.load_tool_for_node(node)
+
+        node: Node = Node(
+            name="test", tool="test_tool", inputs={}, type="invalid_type", source=ToolSource(type=ToolSourceType.Code)
+        )
+        with pytest.raises(NotImplementedError, match="Tool type invalid_type is not supported yet."):
+            tool_loader.load_tool_for_node(node)
+
+    def test_load_tool_for_package_node(self, mocker):
+        package_tools = {"test_tool": Tool(name="test_tool", type=ToolType.PYTHON, inputs={}).serialize()}
+        mocker.patch("promptflow.executor._tool_loader.collect_package_tools", return_value=package_tools)
+        tool_loader = ToolLoader(
+            working_dir="test_working_dir", package_tool_keys=["promptflow._core.tools_manager.collect_package_tools"]
+        )
+        node: Node = Node(
+            name="test",
+            tool="test_tool",
+            inputs={},
+            type=ToolType.PYTHON,
+            source=ToolSource(type=ToolSourceType.Package, tool="test_tool"),
+        )
+        tool = tool_loader.load_tool_for_node(node)
+        assert tool.name == "test_tool"
+
+        node: Node = Node(
+            name="test",
+            tool="test_tool",
+            inputs={},
+            type=ToolType.PYTHON,
+            source=ToolSource(type=ToolSourceType.Package, tool="invalid_tool"),
+        )
+        msg = (
+            "Package tool 'invalid_tool' is not found in the current environment. "
+            "All available package tools are: ['test_tool']."
+        )
+        with pytest.raises(PackageToolNotFoundError) as ex:
+            tool_loader.load_tool_for_node(node)
+            assert str(ex.value) == msg
+
+    def test_load_tool_for_package_node_with_legacy_tool_id(self, mocker):
+        package_tools = {
+            "new_tool_1": Tool(
+                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_1"]
+            ).serialize(),
+            "new_tool_2": Tool(
+                name="new tool 1", type=ToolType.PYTHON, inputs={}, deprecated_tools=["old_tool_2"]
+            ).serialize(),
+            "old_tool_2": Tool(name="old tool 2", type=ToolType.PYTHON, inputs={}).serialize(),
+        }
+        mocker.patch("promptflow.executor._tool_loader.collect_package_tools", return_value=package_tools)
+        tool_loader = ToolLoader(working_dir="test_working_dir", package_tool_keys=list(package_tools.keys()))
+        node_with_legacy_tool: Node = Node(
+            name="test_legacy_tool",
+            tool="old_tool_1",
+            inputs={},
+            type=ToolType.PYTHON,
+            source=ToolSource(type=ToolSourceType.Package, tool="old_tool_1"),
+        )
+        assert tool_loader.load_tool_for_node(node_with_legacy_tool).name == "new tool 1"
+
+        node_with_legacy_tool_but_in_package_tools: Node = Node(
+            name="test_legacy_tool_but_in_package_tools",
+            tool="old_tool_2",
+            inputs={},
+            type=ToolType.PYTHON,
+            source=ToolSource(type=ToolSourceType.Package, tool="old_tool_2"),
+        )
+        assert tool_loader.load_tool_for_node(node_with_legacy_tool_but_in_package_tools).name == "old tool 2"
+
+    def test_load_tool_for_script_node(self):
+        working_dir = Path(__file__).parent
+        tool_loader = ToolLoader(working_dir=working_dir)
+        file = "test_tools_manager.py"
+        node: Node = Node(
+            name="test",
+            tool="sample_tool",
+            inputs={},
+            type=ToolType.PYTHON,
+            source=ToolSource(type=ToolSourceType.Code, path=file),
+        )
+        tool = tool_loader.load_tool_for_node(node)
+        assert tool.name == "sample_tool"
+
+
+# This tool is for testing ToolLoader.load_tool_for_script_node
+@tool
+def sample_tool(input: str):
+    return input


### PR DESCRIPTION
Previously, we always load tools twice, once when getting connections, once when resolving tools. In this pull request, we refactor the logic of tool loader to ensure tools are loaded only once. The most important changes include adding a new class `ToolLoader` responsible for loading tools for nodes in a flow, adding a method to check for duplicated node names in the `Flow` class, and modifying the `get_tool` method to return the tool associated with a node name.

Main changes:

* <a href="diffhunk://#diff-6840a6ba29f586b0b034238ebe73e4705e820b5229abf9e4a767d8f4dac3e3e4R1-R99">`src/promptflow/promptflow/executor/_tool_loader.py`</a>: Added imports and a new class `ToolLoader` responsible for loading tools for nodes in a flow.
* <a href="diffhunk://#diff-b353941bce91518c7f494112d2dd5088b73681eb66e6ff19294edb9c3ec05d0fL651-R671">`src/promptflow/promptflow/contracts/flow.py`</a>: Added a method to check for duplicated node names in the `Flow` class, modified the `get_tool` method to return the tool associated with a node name, and removed the `_set_tool_loader` method call and created the `tool_loader` directly in the `load_env_variables` method. <a href="diffhunk://#diff-b353941bce91518c7f494112d2dd5088b73681eb66e6ff19294edb9c3ec05d0fL651-R671">[1]</a> <a href="diffhunk://#diff-b353941bce91518c7f494112d2dd5088b73681eb66e6ff19294edb9c3ec05d0fL718-R738">[2]</a> <a href="diffhunk://#diff-b353941bce91518c7f494112d2dd5088b73681eb66e6ff19294edb9c3ec05d0fL676-L683">[3]</a>

Other changes:

* <a href="diffhunk://#diff-f518149ddd2c66f8e68b168e37ca8f63513b9326fdb6483b9570284f32fad005L20-R21">`src/promptflow/promptflow/_core/tools_manager.py`</a>: Removed unused imports, updated the import statement, and removed the `ToolLoader` class and its methods. <a href="diffhunk://#diff-f518149ddd2c66f8e68b168e37ca8f63513b9326fdb6483b9570284f32fad005L20-R21">[1]</a> <a href="diffhunk://#diff-f518149ddd2c66f8e68b168e37ca8f63513b9326fdb6483b9570284f32fad005L10">[2]</a> <a href="diffhunk://#diff-f518149ddd2c66f8e68b168e37ca8f63513b9326fdb6483b9570284f32fad005L36-R37">[3]</a>
* <a href="diffhunk://#diff-904f7ae7497cd5e7477e0de92541ac4ef8b1dbc70c1ec39c424602c4fd20e084L13-L17">`src/promptflow/tests/executor/e2etests/test_executor_validation.py`</a>: Updated the import statement to import the `DuplicateNodeName` exception from the correct location and modified a test case to include the node name in the error message. <a href="diffhunk://#diff-904f7ae7497cd5e7477e0de92541ac4ef8b1dbc70c1ec39c424602c4fd20e084L13-L17">[1]</a> <a href="diffhunk://#diff-904f7ae7497cd5e7477e0de92541ac4ef8b1dbc70c1ec39c424602c4fd20e084L46-R48">[2]</a>
* <a href="diffhunk://#diff-29ac2bd241c1fdeeb619291bb81701c9aedd64338b65a219e8373d03e4e3cd94L62-R62">`src/promptflow/tests/executor/unittests/contracts/test_flow.py`</a>: Updated import statements, applied a patch to mock a function, and modified a method to use a different argument. <a href="diffhunk://#diff-29ac2bd241c1fdeeb619291bb81701c9aedd64338b65a219e8373d03e4e3cd94L62-R62">[1]</a> <a href="diffhunk://#diff-29ac2bd241c1fdeeb619291bb81701c9aedd64338b65a219e8373d03e4e3cd94L53-R53">[2]</a> <a href="diffhunk://#diff-29ac2bd241c1fdeeb619291bb81701c9aedd64338b65a219e8373d03e4e3cd94L328-R331">[3]</a>
* <a href="diffhunk://#diff-d9c2c33c19aa44bfe939f9ee19a064e7538d5a156a91b46a6341ca6bcb139aa9L16-R16">`src/promptflow/tests/executor/e2etests/test_package_tool.py`</a>: Updated the import statement to import the `collect_package_tools` function from the correct location.
* <a href="diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65L15-R15">`src/promptflow/promptflow/executor/_tool_resolver.py`</a>: Modified the import statement and constructor to include the `ToolLoader` class and remove the unused import. <a href="diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65L15-R15">[1]</a> <a href="diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65R33">[2]</a> <a href="diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65L45-R57">[3]</a>
* <a href="diffhunk://#diff-98d7f289bc824f662294f763ec29c6b956d8d26d7568bd5ba5217ef97bbe220bR10-R13">`src/promptflow/promptflow/contracts/_errors.py`</a>: Added the `DuplicateNodeName` exception class.
* <a href="diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69L218-R218">`src/promptflow/promptflow/executor/flow_executor.py`</a>: Modified the `ToolResolver` constructor to accept a `tool_loader` argument.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
