### PR TITLE
update cli perf time limit

### DIFF
--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -36,6 +36,12 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
+      - name: Set PR Number to an Environment Variable
+        run: echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
+
+      - name: Print PR Number
+        run: echo "PR Number is $PR_NUMBER"
+
       - name: Display and Set Environment Variables
         run: |
           export pyVersion="3.9";

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -36,11 +36,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Set PR Number to an Environment Variable
-        run: echo "PR_NUMBER=${{ github.event.number }}" >> $GITHUB_ENV
+      - name: Set Flow Run Id to an Environment Variable
+        run: echo "FLOW_RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
 
-      - name: Print PR Number
-        run: echo "PR Number is $PR_NUMBER"
+      - name: Print Flow Run Id
+        run: echo "Flow Run Id is $FLOW_RUN_ID"
 
       - name: Display and Set Environment Variables
         run: |

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -33,6 +33,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: set test mode
+        run: echo "PROMPT_FLOW_TEST_MODE=replay" >> $GITHUB_ENV
+
+      - name: check test mode from env
+        run: echo $PROMPT_FLOW_TEST_MODE
+
       - name: checkout
         uses: actions/checkout@v4
 

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -36,11 +36,11 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - name: Set Flow Run Id to an Environment Variable
-        run: echo "FLOW_RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
+      - name: Set Github Run Id to an Environment Variable
+        run: echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
 
-      - name: Print Flow Run Id
-        run: echo "Flow Run Id is $FLOW_RUN_ID"
+      - name: Print Github Run Id
+        run: echo "Github Run Id is GITHUB_RUN_ID"
 
       - name: Display and Set Environment Variables
         run: |

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -33,12 +33,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: set test mode
-        run: echo "PROMPT_FLOW_TEST_MODE=replay" >> $GITHUB_ENV
-
-      - name: check test mode from env
-        run: echo $PROMPT_FLOW_TEST_MODE
-
       - name: checkout
         uses: actions/checkout@v4
 

--- a/src/promptflow/promptflow/_cli/_pf/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf/entry.py
@@ -101,12 +101,6 @@ def get_parser_args(argv):
     return parser.prog, parser.parse_args(argv)
 
 
-def _get_custom_dimensions():
-    """Currently, it returns empty directly here, but externally it will mock the _get_custom_dimensions"""
-
-    return {}
-
-
 def entry(argv):
     """
     Control plane CLI tools for promptflow.
@@ -117,12 +111,10 @@ def entry(argv):
     logger = get_telemetry_logger()
     activity_name = _get_cli_activity_name(cli=prog, args=args)
     activity_name = update_activity_name(activity_name, args=args)
-    custom_dimensions = _get_custom_dimensions()
     with log_activity(
             logger,
             activity_name,
             activity_type=ActivityType.PUBLICAPI,
-            custom_dimensions=custom_dimensions,
     ):
         run_command(args)
 

--- a/src/promptflow/promptflow/_cli/_pf/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf/entry.py
@@ -101,6 +101,12 @@ def get_parser_args(argv):
     return parser.prog, parser.parse_args(argv)
 
 
+def _get_custom_dimensions():
+    """Currently, it returns empty directly here, but externally it will mock the _get_custom_dimensions"""
+
+    return {}
+
+
 def entry(argv):
     """
     Control plane CLI tools for promptflow.
@@ -111,7 +117,13 @@ def entry(argv):
     logger = get_telemetry_logger()
     activity_name = _get_cli_activity_name(cli=prog, args=args)
     activity_name = update_activity_name(activity_name, args=args)
-    with log_activity(logger, activity_name, activity_type=ActivityType.PUBLICAPI):
+    custom_dimensions = _get_custom_dimensions()
+    with log_activity(
+            logger,
+            activity_name,
+            activity_type=ActivityType.PUBLICAPI,
+            custom_dimensions=custom_dimensions,
+    ):
         run_command(args)
 
 

--- a/src/promptflow/promptflow/_cli/_pf_azure/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/entry.py
@@ -104,6 +104,10 @@ def _get_workspace_info(args):
         return {}
 
 
+def _get_custom_dimensions(args):
+    return _get_workspace_info(args)
+
+
 def entry(argv):
     """
     Control plane CLI tools for promptflow cloud version.
@@ -112,7 +116,7 @@ def entry(argv):
     if hasattr(args, "user_agent"):
         setup_user_agent_to_operation_context(args.user_agent)
     logger = get_telemetry_logger()
-    custom_dimensions = _get_workspace_info(args)
+    custom_dimensions = _get_custom_dimensions(args)
     with log_activity(
         logger,
         _get_cli_activity_name(cli=prog, args=args),

--- a/src/promptflow/promptflow/_cli/_pf_azure/entry.py
+++ b/src/promptflow/promptflow/_cli/_pf_azure/entry.py
@@ -104,10 +104,6 @@ def _get_workspace_info(args):
         return {}
 
 
-def _get_custom_dimensions(args):
-    return _get_workspace_info(args)
-
-
 def entry(argv):
     """
     Control plane CLI tools for promptflow cloud version.
@@ -116,7 +112,7 @@ def entry(argv):
     if hasattr(args, "user_agent"):
         setup_user_agent_to_operation_context(args.user_agent)
     logger = get_telemetry_logger()
-    custom_dimensions = _get_custom_dimensions(args)
+    custom_dimensions = _get_workspace_info(args)
     with log_activity(
         logger,
         _get_cli_activity_name(cli=prog, args=args),

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -7,6 +7,7 @@ import pytest
 
 from promptflow._cli._user_agent import USER_AGENT as CLI_USER_AGENT  # noqa: E402
 from promptflow._sdk._utils import ClientUserAgentUtil
+from sdk_cli_azure_test.recording_utilities import is_replay
 
 FLOWS_DIR = "./tests/test_configs/flows"
 DATAS_DIR = "./tests/test_configs/datas"
@@ -26,7 +27,8 @@ def run_cli_command(cmd, time_limit=3600):
     ed = timeit.default_timer()
 
     print(f"{cmd}, \nTotal time: {ed - st}s")
-    assert ed - st < time_limit, f"The time limit is {time_limit}s, but it took {ed - st}s."
+    if is_replay():
+        assert ed - st < time_limit, f"The time limit is {time_limit}s, but it took {ed - st}s."
 
 
 @pytest.fixture

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -16,8 +16,8 @@ DATAS_DIR = "./tests/test_configs/datas"
 
 
 def mock_log_activity(*args, **kwargs):
-    custom_message = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
-        os.environ.get("FLOW_RUN_ID")
+    custom_message = "github run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
+        os.environ.get("GITHUB_RUN_ID")
     )
     if len(args) == 4:
         if args[3] is not None:

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -33,7 +33,7 @@ def run_cli_command(cmd, time_limit=3600):
     sys.argv = list(cmd)
     st = timeit.default_timer()
     with (mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._sdk._telemetry.log_activity", side_effect=mock_log_activity)):
+          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity)):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -17,7 +17,7 @@ DATAS_DIR = "./tests/test_configs/datas"
 
 def get_custom_dimensions(*args, **kwargs):
     custom_dimensions = _get_custom_dimensions(*args, **kwargs)
-    custom_dimensions["flow run: "] = "https://github.com/microsoft/promptflow/actions/runs/{0}".format(
+    custom_dimensions["custom_message"] = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
         os.environ.get("FLOW_RUN_ID")
     )
 

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -49,7 +49,7 @@ def operation_scope_args(subscription_id: str, resource_group_name: str, workspa
     "vcr_recording",
 )
 class TestAzureCliPerf:
-    def test_pfazure_run_create(self, operation_scope_args, runtime: str, randstr: Callable[[str], str], time_limit=30):
+    def test_pfazure_run_create(self, operation_scope_args, runtime: str, randstr: Callable[[str], str], time_limit=15):
         name = randstr("name")
         run_cli_command(
             cmd=(
@@ -69,7 +69,7 @@ class TestAzureCliPerf:
             time_limit=time_limit,
         )
 
-    def test_pfazure_run_update(self, operation_scope_args, time_limit=30):
+    def test_pfazure_run_update(self, operation_scope_args, time_limit=15):
         run_cli_command(
             cmd=(
                 "pfazure",
@@ -86,7 +86,7 @@ class TestAzureCliPerf:
             time_limit=time_limit,
         )
 
-    def test_run_restore(self, operation_scope_args, time_limit=30):
+    def test_run_restore(self, operation_scope_args, time_limit=15):
         run_cli_command(
             cmd=(
                 "pfazure",

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -38,10 +38,9 @@ def run_cli_command(cmd, time_limit=3600):
 
     sys.argv = list(cmd)
     st = timeit.default_timer()
-    with (mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity),
-          mock.patch("promptflow._cli._pf_azure.entry.log_activity", side_effect=mock_log_activity),
-          ):
+    with mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun, mock.patch(
+        "promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity
+    ), mock.patch("promptflow._cli._pf_azure.entry.log_activity", side_effect=mock_log_activity):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -19,7 +19,13 @@ def mock_log_activity(*args, **kwargs):
     custom_message = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
         os.environ.get("FLOW_RUN_ID")
     )
-    if "custom_dimensions" in kwargs and kwargs["custom_dimensions"] is not None:
+    if len(args) == 4:
+        if args[3] is not None:
+            args[3]["custom_message"] = custom_message
+        else:
+            args = list(args)
+            args[3] = {"custom_message": custom_message}
+    elif "custom_dimensions" in kwargs and kwargs["custom_dimensions"] is not None:
         kwargs["custom_dimensions"]["custom_message"] = custom_message
     else:
         kwargs["custom_dimensions"] = {"custom_message": custom_message}
@@ -33,7 +39,9 @@ def run_cli_command(cmd, time_limit=3600):
     sys.argv = list(cmd)
     st = timeit.default_timer()
     with (mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity)):
+          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity),
+          mock.patch("promptflow._cli._pf_azure.entry.log_activity", side_effect=mock_log_activity),
+          ):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -17,7 +17,7 @@ DATAS_DIR = "./tests/test_configs/datas"
 
 def get_custom_dimensions(*args, **kwargs):
     custom_dimensions = _get_custom_dimensions(*args, **kwargs)
-    custom_dimensions["pr_number"] = os.environ.get("PR_NUMBER")
+    custom_dimensions["flow_run_id"] = os.environ.get("FLOW_RUN_ID")
 
     return custom_dimensions
 

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_azure_cli_perf.py
@@ -17,7 +17,9 @@ DATAS_DIR = "./tests/test_configs/datas"
 
 def get_custom_dimensions(*args, **kwargs):
     custom_dimensions = _get_custom_dimensions(*args, **kwargs)
-    custom_dimensions["flow_run_id"] = os.environ.get("FLOW_RUN_ID")
+    custom_dimensions["flow run: "] = "https://github.com/microsoft/promptflow/actions/runs/{0}".format(
+        os.environ.get("FLOW_RUN_ID")
+    )
 
     return custom_dimensions
 

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -21,8 +21,8 @@ DATAS_DIR = "./tests/test_configs/datas"
 
 
 def mock_log_activity(*args, **kwargs):
-    custom_message = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
-        os.environ.get("FLOW_RUN_ID")
+    custom_message = "github run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
+        os.environ.get("GITHUB_RUN_ID")
     )
     if len(args) == 4:
         if args[3] is not None:

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -57,7 +57,7 @@ def subprocess_run_cli_command(cmd, time_limit=3600):
 @pytest.mark.usefixtures("use_secrets_config_file", "setup_local_connection")
 @pytest.mark.perf_monitor_test
 class TestCliPerf:
-    def test_pf_run_create(self, time_limit=35) -> None:
+    def test_pf_run_create(self, time_limit=20) -> None:
         res = subprocess_run_cli_command(
             cmd=(
                 "pf",
@@ -112,7 +112,7 @@ class TestCliPerf:
         output_path = Path(FLOWS_DIR) / "print_input_flow" / ".promptflow" / "flow.output.json"
         assert output_path.exists()
 
-    def test_pf_flow_build(self, time_limit=35):
+    def test_pf_flow_build(self, time_limit=20):
         with tempfile.TemporaryDirectory() as temp_dir:
             subprocess_run_cli_command(
                 cmd=(

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -24,7 +24,13 @@ def mock_log_activity(*args, **kwargs):
     custom_message = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
         os.environ.get("FLOW_RUN_ID")
     )
-    if "custom_dimensions" in kwargs and kwargs["custom_dimensions"] is not None:
+    if len(args) == 4:
+        if args[3] is not None:
+            args[3]["custom_message"] = custom_message
+        else:
+            args = list(args)
+            args[3] = {"custom_message": custom_message}
+    elif "custom_dimensions" in kwargs and kwargs["custom_dimensions"] is not None:
         kwargs["custom_dimensions"]["custom_message"] = custom_message
     else:
         kwargs["custom_dimensions"] = {"custom_message": custom_message}
@@ -41,7 +47,9 @@ def run_cli_command(cmd, time_limit=3600, result_queue=None):
     st = timeit.default_timer()
     with (contextlib.redirect_stdout(output),
           mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity)):
+          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity),
+          mock.patch("promptflow._cli._pf.entry.log_activity", side_effect=mock_log_activity),
+          ):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -45,11 +45,13 @@ def run_cli_command(cmd, time_limit=3600, result_queue=None):
     output = io.StringIO()
 
     st = timeit.default_timer()
-    with (contextlib.redirect_stdout(output),
-          mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity),
-          mock.patch("promptflow._cli._pf.entry.log_activity", side_effect=mock_log_activity),
-          ):
+    with contextlib.redirect_stdout(output), mock.patch.object(
+        ClientUserAgentUtil, "get_user_agent"
+    ) as get_user_agent_fun, mock.patch(
+        "promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity
+    ), mock.patch(
+        "promptflow._cli._pf.entry.log_activity", side_effect=mock_log_activity
+    ):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -13,6 +13,7 @@ import pytest
 
 from promptflow._cli._pf.entry import _get_custom_dimensions
 from promptflow._cli._user_agent import USER_AGENT as CLI_USER_AGENT  # noqa: E402
+from promptflow._sdk._telemetry import log_activity
 from promptflow._sdk._utils import ClientUserAgentUtil
 
 FLOWS_DIR = "./tests/test_configs/flows"
@@ -22,7 +23,7 @@ DATAS_DIR = "./tests/test_configs/datas"
 
 def get_custom_dimensions():
     custom_dimensions = _get_custom_dimensions()
-    custom_dimensions["flow run: "] = "https://github.com/microsoft/promptflow/actions/runs/{0}".format(
+    custom_dimensions["custom_message"] = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
         os.environ.get("FLOW_RUN_ID")
     )
 

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -11,7 +11,6 @@ from unittest import mock
 
 import pytest
 
-from promptflow._cli._pf.entry import _get_custom_dimensions
 from promptflow._cli._user_agent import USER_AGENT as CLI_USER_AGENT  # noqa: E402
 from promptflow._sdk._telemetry import log_activity
 from promptflow._sdk._utils import ClientUserAgentUtil
@@ -21,13 +20,16 @@ CONNECTIONS_DIR = "./tests/test_configs/connections"
 DATAS_DIR = "./tests/test_configs/datas"
 
 
-def get_custom_dimensions():
-    custom_dimensions = _get_custom_dimensions()
-    custom_dimensions["custom_message"] = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
+def mock_log_activity(*args, **kwargs):
+    custom_message = "flow run: https://github.com/microsoft/promptflow/actions/runs/{0}".format(
         os.environ.get("FLOW_RUN_ID")
     )
+    if "custom_dimensions" in kwargs and kwargs["custom_dimensions"] is not None:
+        kwargs["custom_dimensions"]["custom_message"] = custom_message
+    else:
+        kwargs["custom_dimensions"] = {"custom_message": custom_message}
 
-    return custom_dimensions
+    return log_activity(*args, **kwargs)
 
 
 def run_cli_command(cmd, time_limit=3600, result_queue=None):
@@ -39,7 +41,7 @@ def run_cli_command(cmd, time_limit=3600, result_queue=None):
     st = timeit.default_timer()
     with (contextlib.redirect_stdout(output),
           mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._cli._pf.entry._get_custom_dimensions", side_effect=get_custom_dimensions)):
+          mock.patch("promptflow._sdk._telemetry.log_activity", side_effect=mock_log_activity)):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli_perf.py
@@ -41,7 +41,7 @@ def run_cli_command(cmd, time_limit=3600, result_queue=None):
     st = timeit.default_timer()
     with (contextlib.redirect_stdout(output),
           mock.patch.object(ClientUserAgentUtil, "get_user_agent") as get_user_agent_fun,
-          mock.patch("promptflow._sdk._telemetry.log_activity", side_effect=mock_log_activity)):
+          mock.patch("promptflow._sdk._telemetry.activity.log_activity", side_effect=mock_log_activity)):
         # Client side will modify user agent only through ClientUserAgentUtil to avoid impact executor/runtime.
         get_user_agent_fun.return_value = f"{CLI_USER_AGENT} perf_monitor/1.0"
         user_agent = ClientUserAgentUtil.get_user_agent()


### PR DESCRIPTION
# Description
After using replay mode

The time consumption of "**pf.azure.create**" related commands will be reduced, with an average time of 6 seconds, but the maximum time consumption is still 20 seconds+

The duration of other commands PC99 is less than 10 seconds, but the maximum duration is still 20 seconds+

This PR modifies the test mode to replay mode and reduces the time limit, and then continues to observe the average and maximum time consumption, PC99 time consumption.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.