### PR TITLE
[promptflow][bugfix] Adjust fixture order to fix breaking flow serve test

### DIFF
--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -5,11 +5,12 @@ import re
 import pytest
 
 from promptflow._core.operation_context import OperationContext
+from promptflow._sdk._serving.app import PromptflowServingApp
 
 
 @pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
-def test_swagger(flow_serving_client):
+def test_swagger(flow_serving_client: PromptflowServingApp):
     swagger_dict = json.loads(flow_serving_client.get("/swagger.json").data.decode())
     assert swagger_dict == {
         "components": {"securitySchemes": {"bearerAuth": {"scheme": "bearer", "type": "http"}}},
@@ -58,7 +59,7 @@ def test_swagger(flow_serving_client):
 
 @pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
-def test_chat_swagger(serving_client_llm_chat):
+def test_chat_swagger(serving_client_llm_chat: PromptflowServingApp):
     swagger_dict = json.loads(serving_client_llm_chat.get("/swagger.json").data.decode())
     assert swagger_dict == {
         "components": {"securitySchemes": {"bearerAuth": {"scheme": "bearer", "type": "http"}}},
@@ -117,7 +118,7 @@ def test_chat_swagger(serving_client_llm_chat):
 
 @pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
-def test_user_agent(flow_serving_client):
+def test_user_agent(flow_serving_client: PromptflowServingApp):
     operation_context = OperationContext.get_instance()
     assert "test-user-agent" in operation_context.get_user_agent()
     assert "promptflow-local-serving" in operation_context.get_user_agent()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -7,7 +7,7 @@ import pytest
 from promptflow._core.operation_context import OperationContext
 
 
-@pytest.mark.usefixtures("flow_serving_client", "recording_injection", "setup_local_connection")
+@pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
 def test_swagger(flow_serving_client):
     swagger_dict = json.loads(flow_serving_client.get("/swagger.json").data.decode())
@@ -56,7 +56,7 @@ def test_swagger(flow_serving_client):
     }
 
 
-@pytest.mark.usefixtures("serving_client_llm_chat", "recording_injection", "setup_local_connection")
+@pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
 def test_chat_swagger(serving_client_llm_chat):
     swagger_dict = json.loads(serving_client_llm_chat.get("/swagger.json").data.decode())
@@ -115,7 +115,7 @@ def test_chat_swagger(serving_client_llm_chat):
     }
 
 
-@pytest.mark.usefixtures("flow_serving_client", "recording_injection", "setup_local_connection")
+@pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
 def test_user_agent(flow_serving_client):
     operation_context = OperationContext.get_instance()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -5,12 +5,11 @@ import re
 import pytest
 
 from promptflow._core.operation_context import OperationContext
-from promptflow._sdk._serving.app import PromptflowServingApp
 
 
 @pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
-def test_swagger(flow_serving_client: PromptflowServingApp):
+def test_swagger(flow_serving_client):
     swagger_dict = json.loads(flow_serving_client.get("/swagger.json").data.decode())
     assert swagger_dict == {
         "components": {"securitySchemes": {"bearerAuth": {"scheme": "bearer", "type": "http"}}},
@@ -59,7 +58,7 @@ def test_swagger(flow_serving_client: PromptflowServingApp):
 
 @pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
-def test_chat_swagger(serving_client_llm_chat: PromptflowServingApp):
+def test_chat_swagger(serving_client_llm_chat):
     swagger_dict = json.loads(serving_client_llm_chat.get("/swagger.json").data.decode())
     assert swagger_dict == {
         "components": {"securitySchemes": {"bearerAuth": {"scheme": "bearer", "type": "http"}}},
@@ -118,7 +117,7 @@ def test_chat_swagger(serving_client_llm_chat: PromptflowServingApp):
 
 @pytest.mark.usefixtures("recording_injection", "setup_local_connection")
 @pytest.mark.e2etest
-def test_user_agent(flow_serving_client: PromptflowServingApp):
+def test_user_agent(flow_serving_client):
     operation_context = OperationContext.get_instance()
     assert "test-user-agent" in operation_context.get_user_agent()
     assert "promptflow-local-serving" in operation_context.get_user_agent()


### PR DESCRIPTION
# Description

In flow serving tests, remove `flow_serving_client` fixture requst in `@pytest.mark.usefixtures` as it will be requests in the test function parameters. Otherwise, we might run into local connection not found error, which shall result from `setup_local_connection` has not been requested.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
