### PR TITLE
[SDK] Fix extra warning for batch run

### DIFF
--- a/src/promptflow/promptflow/_sdk/_submitter/run_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/run_submitter.py
@@ -111,7 +111,8 @@ class RunSubmitter:
                 error_logs.append(
                     f" Please check out {run.properties[FlowRunProperties.OUTPUT_PATH]} for more details."
                 )
-            logger.warning("\n".join(error_logs))
+            if error_logs:
+                logger.warning("\n".join(error_logs))
             # The bulk run is completed if the batch_engine.run successfully completed.
             status = Status.Completed.value
         except Exception as e:


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
This pull request includes a single change to the file `src/promptflow/promptflow/_sdk/_submitter/run_submitter.py`. The change adds a new condition to log a warning message if the `error_logs` variable is not empty in the `_submit_bulk_run` method. This change provides more information to the user.
![image](https://github.com/microsoft/promptflow/assets/7776147/306b619f-534e-48aa-b899-1647a077c8ca)

Main change:

* <a href="diffhunk://#diff-e3499cf713c66612d91723759de1c5076c22689b2ce2c89678f82de624b57c2cR114">`src/promptflow/promptflow/_sdk/_submitter/run_submitter.py`</a>: Added a new condition to log a warning message if `error_logs` is not empty in the `_submit_bulk_run` method.
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
