### PR TITLE
[Executor] Add root level api_calls

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Please set before importing `promptflow`, otherwise it won't take effect.
 - [Executor] Handle KeyboardInterrupt in flow test so that the final state is Canceled.
 - [Executor] Calculate system_metrics recursively in api_calls.
+- [Executor] Add root level api_calls.
 
 ### Bugs Fixed
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -187,7 +187,9 @@ class RunTracker(ThreadLocalSingleton):
             "start_time": start_timestamp,
             "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
-            "system_metrics": run_info.system_metrics
+            "system_metrics": run_info.system_metrics,
+            "inputs": run_info.inputs,
+            "output": run_info.output,
             }]
 
     def _node_run_postprocess(self, run_info: RunInfo, output, ex: Optional[Exception]):

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -5,7 +5,7 @@
 import asyncio
 import json
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import datetime, timezone
 from types import GeneratorType
 from typing import Any, Dict, List, Mapping, Optional, Union
 
@@ -177,10 +177,15 @@ class RunTracker(ThreadLocalSingleton):
         # TODO: Refactor Tracer to support flow level tracing,
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
+        start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
+            if run_info.start_time else None
+        end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \
+            if run_info.end_time else None
         run_info.api_calls = [{
-            "name": "root",
-            "start_time": run_info.start_time,
-            "end_time": run_info.end_time,
+            "name": "flow_root",
+            "node_name": "flow_root",
+            "start_time": start_timestamp,
+            "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
             "system_metrics": run_info.system_metrics
             }]

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -177,6 +177,8 @@ class RunTracker(ThreadLocalSingleton):
         # TODO: Refactor Tracer to support flow level tracing,
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
+        # TODO: Add input, output, error to top level. Adding them would cause early
+        # serialization of Image objects and making flow output uncorrect.
         start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
             if run_info.start_time else None
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \
@@ -189,9 +191,6 @@ class RunTracker(ThreadLocalSingleton):
             "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
             "system_metrics": run_info.system_metrics,
-            "inputs": run_info.inputs,
-            "output": run_info.output,
-            "error": run_info.error
             }]
 
     def _node_run_postprocess(self, run_info: RunInfo, output, ex: Optional[Exception]):

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -178,7 +178,7 @@ class RunTracker(ThreadLocalSingleton):
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
         # TODO: Add input, output, error to top level. Adding them would cause early
-        # serialization of Image objects and making flow output uncorrect.
+        # serialization of Image objects and making flow output incorrect.
         start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
             if run_info.start_time else None
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -169,7 +169,7 @@ class RunTracker(ThreadLocalSingleton):
                 output, ex = None, e
         self._common_postprocess(run_info, output, ex)
 
-    def _update_flow_run_info_with_node_runs(self, run_info):
+    def _update_flow_run_info_with_node_runs(self, run_info: FlowRunInfo):
         run_id = run_info.run_id
         child_run_infos = self.collect_child_node_runs(run_id)
         run_info.system_metrics = run_info.system_metrics or {}
@@ -182,14 +182,16 @@ class RunTracker(ThreadLocalSingleton):
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \
             if run_info.end_time else None
         run_info.api_calls = [{
-            "name": "flow_root",
-            "node_name": "flow_root",
+            "name": "flow",
+            "node_name": "flow",
+            "type": "Flow",
             "start_time": start_timestamp,
             "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
             "system_metrics": run_info.system_metrics,
             "inputs": run_info.inputs,
             "output": run_info.output,
+            "error": run_info.error
             }]
 
     def _node_run_postprocess(self, run_info: RunInfo, output, ex: Optional[Exception]):

--- a/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
@@ -88,8 +88,9 @@ class TestRunTracker:
 
         assert len(run_info_flow.api_calls) == 1, "There should be only one top level api call for flow run."
         assert run_info_flow.system_metrics["total_tokens"] == 60
-        assert run_info_flow.api_calls[0]["name"] == "flow_root"
-        assert run_info_flow.api_calls[0]["node_name"] == "flow_root"
+        assert run_info_flow.api_calls[0]["name"] == "flow"
+        assert run_info_flow.api_calls[0]["node_name"] == "flow"
+        assert run_info_flow.api_calls[0]["type"] == "Flow"
         assert run_info_flow.api_calls[0]["system_metrics"]["total_tokens"] == 60
         assert isinstance(run_info_flow.api_calls[0]["start_time"], float)
         assert isinstance(run_info_flow.api_calls[0]["end_time"], float)

--- a/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
@@ -23,6 +23,8 @@ class TestRunTracker:
         run_tracker.start_flow_run("test_flow_id", "test_root_run_id", "test_flow_run_id")
         assert len(run_tracker._flow_runs) == 1
         assert run_tracker._current_run_id == "test_flow_run_id"
+        flow_input = {"flow_input": "input_0"}
+        run_tracker.set_inputs("test_flow_run_id", flow_input)
 
         # Start node runs
         run_info = run_tracker.start_node_run("node_0", "test_root_run_id", "test_flow_run_id", "run_id_0", index=0)
@@ -83,8 +85,17 @@ class TestRunTracker:
         run_info_aggr.api_calls, run_info_aggr.system_metrics = [
             {"name": "caht"}, {"name": "completion"}], {"total_tokens": 30}
         run_tracker._update_flow_run_info_with_node_runs(run_info_flow)
-        assert len(run_info_flow.api_calls) == 4
+
+        assert len(run_info_flow.api_calls) == 1, "There should be only one top level api call for flow run."
         assert run_info_flow.system_metrics["total_tokens"] == 60
+        assert run_info_flow.api_calls[0]["name"] == "flow_root"
+        assert run_info_flow.api_calls[0]["node_name"] == "flow_root"
+        assert run_info_flow.api_calls[0]["system_metrics"]["total_tokens"] == 60
+        assert isinstance(run_info_flow.api_calls[0]["start_time"], float)
+        assert isinstance(run_info_flow.api_calls[0]["end_time"], float)
+        assert len(run_info_flow.api_calls[0]["children"]) == 4, "There should be 4 children under root."
+        assert run_info_flow.api_calls[0]["inputs"] == flow_input
+        assert run_info_flow.api_calls[0]["output"] is None
 
         # Test get_status_summary
         status_summary = run_tracker.get_status_summary("test_root_run_id")


### PR DESCRIPTION
# Description

Add top-level api_calls in flow trace to aggregate flow level information.
The current implementation uses hard-coded top level fields instead of using flow-level Trace object, that's due to the implementation of current Tracer does not support multiple level activation due to the difficulty of supporting concurrency.

Example effect on web_classification flow:
Before:
![image](https://github.com/microsoft/promptflow/assets/10575286/67cf2040-a9af-44ee-83d1-2b11095299a0)

After:
![image](https://github.com/microsoft/promptflow/assets/10575286/96873df8-a054-495a-91a9-f23a7d6158da)
# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
