### PR TITLE
[Executor] Add root level api_calls

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -8,7 +8,7 @@
   - Please set before importing `promptflow`, otherwise it won't take effect.
 - [Executor] Handle KeyboardInterrupt in flow test so that the final state is Canceled.
 - [Executor] Calculate system_metrics recursively in api_calls.
-- [Executor] Add root level api_calls.
+- [Executor] Add flow root level api_calls, so that user can overview the aggregated metrics of a flow.
 
 ### Bugs Fixed
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -8,6 +8,7 @@
   - Please set before importing `promptflow`, otherwise it won't take effect.
 - [Executor] Handle KeyboardInterrupt in flow test so that the final state is Canceled.
 - [Executor] Calculate system_metrics recursively in api_calls.
+- [Executor] Add root level api_calls.
 
 ### Bugs Fixed
 - [SDK/CLI] Fix single node run doesn't work when consuming sub item of upstream node

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -187,7 +187,9 @@ class RunTracker(ThreadLocalSingleton):
             "start_time": start_timestamp,
             "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
-            "system_metrics": run_info.system_metrics
+            "system_metrics": run_info.system_metrics,
+            "inputs": run_info.inputs,
+            "output": run_info.output,
             }]
 
     def _node_run_postprocess(self, run_info: RunInfo, output, ex: Optional[Exception]):

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -5,7 +5,7 @@
 import asyncio
 import json
 from contextvars import ContextVar
-from datetime import datetime
+from datetime import datetime, timezone
 from types import GeneratorType
 from typing import Any, Dict, List, Mapping, Optional, Union
 
@@ -177,10 +177,15 @@ class RunTracker(ThreadLocalSingleton):
         # TODO: Refactor Tracer to support flow level tracing,
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
+        start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
+            if run_info.start_time else None
+        end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \
+            if run_info.end_time else None
         run_info.api_calls = [{
-            "name": "root",
-            "start_time": run_info.start_time,
-            "end_time": run_info.end_time,
+            "name": "flow_root",
+            "node_name": "flow_root",
+            "start_time": start_timestamp,
+            "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
             "system_metrics": run_info.system_metrics
             }]

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -177,8 +177,9 @@ class RunTracker(ThreadLocalSingleton):
         # TODO: Refactor Tracer to support flow level tracing,
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
-        # TODO: Add input, output, error to top level. Adding them would cause early
-        # serialization of Image objects and making flow output incorrect.
+        # TODO: Add input, output, error to top level. Adding them would require
+        # the same technique of handingling image and generator in Tracer,
+        # which introduces duplicated logic. We should do it in the refactoring.
         start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
             if run_info.start_time else None
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -177,6 +177,8 @@ class RunTracker(ThreadLocalSingleton):
         # TODO: Refactor Tracer to support flow level tracing,
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
+        # TODO: Add input, output, error to top level. Adding them would cause early
+        # serialization of Image objects and making flow output uncorrect.
         start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
             if run_info.start_time else None
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \
@@ -189,9 +191,6 @@ class RunTracker(ThreadLocalSingleton):
             "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
             "system_metrics": run_info.system_metrics,
-            "inputs": run_info.inputs,
-            "output": run_info.output,
-            "error": run_info.error
             }]
 
     def _node_run_postprocess(self, run_info: RunInfo, output, ex: Optional[Exception]):

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -178,7 +178,7 @@ class RunTracker(ThreadLocalSingleton):
         # then we can remove the hard-coded root level api_calls here.
         # It has to be a list for UI backward compatibility.
         # TODO: Add input, output, error to top level. Adding them would cause early
-        # serialization of Image objects and making flow output uncorrect.
+        # serialization of Image objects and making flow output incorrect.
         start_timestamp = run_info.start_time.astimezone(timezone.utc).timestamp() \
             if run_info.start_time else None
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \

--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -169,7 +169,7 @@ class RunTracker(ThreadLocalSingleton):
                 output, ex = None, e
         self._common_postprocess(run_info, output, ex)
 
-    def _update_flow_run_info_with_node_runs(self, run_info):
+    def _update_flow_run_info_with_node_runs(self, run_info: FlowRunInfo):
         run_id = run_info.run_id
         child_run_infos = self.collect_child_node_runs(run_id)
         run_info.system_metrics = run_info.system_metrics or {}
@@ -182,14 +182,16 @@ class RunTracker(ThreadLocalSingleton):
         end_timestamp = run_info.end_time.astimezone(timezone.utc).timestamp() \
             if run_info.end_time else None
         run_info.api_calls = [{
-            "name": "flow_root",
-            "node_name": "flow_root",
+            "name": "flow",
+            "node_name": "flow",
+            "type": "Flow",
             "start_time": start_timestamp,
             "end_time": end_timestamp,
             "children": self._collect_traces_from_nodes(run_id),
             "system_metrics": run_info.system_metrics,
             "inputs": run_info.inputs,
             "output": run_info.output,
+            "error": run_info.error
             }]
 
     def _node_run_postprocess(self, run_info: RunInfo, output, ex: Optional[Exception]):

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -71,7 +71,7 @@ class TestExecutor:
         node_count = len(executor._flow.nodes)
         assert isinstance(flow_result.run_info.api_calls, list) and len(flow_result.run_info.api_calls) == 1
         assert isinstance(flow_result.run_info.api_calls[0]["children"], list) and \
-            len(flow_result.run_info.api_calls) == node_count
+            len(flow_result.run_info.api_calls[0]["children"]) == node_count
         assert len(flow_result.node_run_infos) == node_count
         for node, node_run_info in flow_result.node_run_infos.items():
             assert node_run_info.status == Status.Completed

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -69,7 +69,9 @@ class TestExecutor:
         assert isinstance(flow_result.output, dict)
         assert flow_result.run_info.status == Status.Completed
         node_count = len(executor._flow.nodes)
-        assert isinstance(flow_result.run_info.api_calls, list) and len(flow_result.run_info.api_calls) == node_count
+        assert isinstance(flow_result.run_info.api_calls, list) and len(flow_result.run_info.api_calls) == 1
+        assert isinstance(flow_result.run_info.api_calls[0]["children"], list) and \
+            len(flow_result.run_info.api_calls) == node_count
         assert len(flow_result.node_run_infos) == node_count
         for node, node_run_info in flow_result.node_run_infos.items():
             assert node_run_info.status == Status.Completed

--- a/src/promptflow/tests/executor/e2etests/test_traces.py
+++ b/src/promptflow/tests/executor/e2etests/test_traces.py
@@ -93,7 +93,7 @@ class TestExecutorTraces:
         assert flow_result.run_info.status == Status.Completed
         assert flow_result.run_info.api_calls is not None
 
-        tool_trace = flow_result.run_info.api_calls[0]
+        tool_trace = flow_result.run_info.api_calls[0]["children"][0]
         generator_trace = tool_trace.get("children")[0]
         assert generator_trace is not None
 

--- a/src/promptflow/tests/executor/e2etests/test_traces.py
+++ b/src/promptflow/tests/executor/e2etests/test_traces.py
@@ -125,7 +125,7 @@ class TestExecutorTraces:
         assert flow_result.run_info.api_calls is not None
 
         # Extract the trace for the generator node
-        tool_trace = flow_result.run_info.api_calls[0]
+        tool_trace = flow_result.run_info.api_calls[0]["children"][0]
         generator_output_trace = tool_trace.get("output")
 
         # Verify that the trace output is a list

--- a/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
@@ -88,8 +88,9 @@ class TestRunTracker:
 
         assert len(run_info_flow.api_calls) == 1, "There should be only one top level api call for flow run."
         assert run_info_flow.system_metrics["total_tokens"] == 60
-        assert run_info_flow.api_calls[0]["name"] == "flow_root"
-        assert run_info_flow.api_calls[0]["node_name"] == "flow_root"
+        assert run_info_flow.api_calls[0]["name"] == "flow"
+        assert run_info_flow.api_calls[0]["node_name"] == "flow"
+        assert run_info_flow.api_calls[0]["type"] == "Flow"
         assert run_info_flow.api_calls[0]["system_metrics"]["total_tokens"] == 60
         assert isinstance(run_info_flow.api_calls[0]["start_time"], float)
         assert isinstance(run_info_flow.api_calls[0]["end_time"], float)

--- a/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
@@ -23,6 +23,8 @@ class TestRunTracker:
         run_tracker.start_flow_run("test_flow_id", "test_root_run_id", "test_flow_run_id")
         assert len(run_tracker._flow_runs) == 1
         assert run_tracker._current_run_id == "test_flow_run_id"
+        flow_input = {"flow_input": "input_0"}
+        run_tracker.set_inputs("test_flow_run_id", flow_input)
 
         # Start node runs
         run_info = run_tracker.start_node_run("node_0", "test_root_run_id", "test_flow_run_id", "run_id_0", index=0)
@@ -83,8 +85,17 @@ class TestRunTracker:
         run_info_aggr.api_calls, run_info_aggr.system_metrics = [
             {"name": "caht"}, {"name": "completion"}], {"total_tokens": 30}
         run_tracker._update_flow_run_info_with_node_runs(run_info_flow)
-        assert len(run_info_flow.api_calls) == 4
+
+        assert len(run_info_flow.api_calls) == 1, "There should be only one top level api call for flow run."
         assert run_info_flow.system_metrics["total_tokens"] == 60
+        assert run_info_flow.api_calls[0]["name"] == "flow_root"
+        assert run_info_flow.api_calls[0]["node_name"] == "flow_root"
+        assert run_info_flow.api_calls[0]["system_metrics"]["total_tokens"] == 60
+        assert isinstance(run_info_flow.api_calls[0]["start_time"], float)
+        assert isinstance(run_info_flow.api_calls[0]["end_time"], float)
+        assert len(run_info_flow.api_calls[0]["children"]) == 4, "There should be 4 children under root."
+        assert run_info_flow.api_calls[0]["inputs"] == flow_input
+        assert run_info_flow.api_calls[0]["output"] is None
 
         # Test get_status_summary
         status_summary = run_tracker.get_status_summary("test_root_run_id")

--- a/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_run_tracker.py
@@ -95,8 +95,6 @@ class TestRunTracker:
         assert isinstance(run_info_flow.api_calls[0]["start_time"], float)
         assert isinstance(run_info_flow.api_calls[0]["end_time"], float)
         assert len(run_info_flow.api_calls[0]["children"]) == 4, "There should be 4 children under root."
-        assert run_info_flow.api_calls[0]["inputs"] == flow_input
-        assert run_info_flow.api_calls[0]["output"] is None
 
         # Test get_status_summary
         status_summary = run_tracker.get_status_summary("test_root_run_id")


### PR DESCRIPTION
# Description

Add top-level api_calls in flow trace to aggregate flow level information.
The current implementation uses hard-coded top-level fields instead of using flow-level Trace object, that's due to the implementation of current Tracer does not support multiple level activation due to the difficulty of supporting concurrency.

Example effect on web_classification flow:
Before:
![image](https://github.com/microsoft/promptflow/assets/10575286/dce14c15-0610-45e1-b23a-44a0fdaf753f)
After:
![image](https://github.com/microsoft/promptflow/assets/10575286/9ebd6e65-ca4f-4655-abd2-0b757a10ec10)



# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
