### PR TITLE
Refactor Tracer and add more unit tests

### DIFF
--- a/src/promptflow/promptflow/contracts/trace.py
+++ b/src/promptflow/promptflow/contracts/trace.py
@@ -12,6 +12,7 @@ class TraceType(str, Enum):
 
     LLM = "LLM"
     TOOL = "Tool"
+    FUNCTION = "Function"
     LANGCHAIN = "LangChain"
 
 

--- a/src/promptflow/tests/executor/unittests/_core/test_tracer.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tracer.py
@@ -1,7 +1,7 @@
 import pytest
 
 from promptflow._core.generator_proxy import GeneratorProxy
-from promptflow._core.tracer import Tracer
+from promptflow._core.tracer import Tracer, _create_trace_from_function_call
 from promptflow.connections import AzureOpenAIConnection
 from promptflow.contracts.trace import Trace, TraceType
 
@@ -134,3 +134,89 @@ class TestTracer:
     @pytest.mark.parametrize("obj", [({"name": "Alice", "age": 25}), ([1, 2, 3]), (GeneratorProxy(generator())), (42)])
     def test_to_serializable(self, obj):
         assert Tracer.to_serializable(obj) == obj
+
+
+def func_with_no_parameters():
+    pass
+
+
+def func_with_args_and_kwargs(arg1, arg2=None, *, kwarg1=None, kwarg2=None):
+    _ = (arg1, arg2, kwarg1, kwarg2)
+
+
+def func_with_connection_parameter(a: int, conn: AzureOpenAIConnection):
+    _, _ = a, conn
+
+
+class MyClass:
+    def my_method(self, a: int):
+        _ = a
+
+
+@pytest.mark.unittest
+class TestCreateTraceFromFunctionCall:
+    def test_basic_fields_are_filled_and_others_are_not(self):
+        trace = _create_trace_from_function_call(func_with_no_parameters)
+
+        # These fields should be filled in this method call.
+        assert trace.name == "func_with_no_parameters"
+        assert trace.type == TraceType.FUNCTION
+        assert trace.inputs == {}
+        # start_time should be a timestamp, which is a float value currently.
+        assert isinstance(trace.start_time, float)
+
+        # These should be left empty in this method call.
+        # They will be filled by the tracer later.
+        assert trace.output is None
+        assert trace.end_time is None
+        assert trace.children is None
+        assert trace.error is None
+
+    def test_trace_name_should_contain_class_name_for_class_methods(self):
+        obj = MyClass()
+        trace = _create_trace_from_function_call(obj.my_method, args=[obj, 1])
+        assert trace.name == "MyClass.my_method"
+
+    def test_trace_type_can_be_set_correctly(self):
+        trace = _create_trace_from_function_call(func_with_no_parameters, trace_type=TraceType.TOOL)
+        assert trace.type == TraceType.TOOL
+
+    def test_args_and_kwargs_are_filled_correctly(self):
+        trace = _create_trace_from_function_call(
+            func_with_args_and_kwargs, args=[1, 2], kwargs={"kwarg1": 3, "kwarg2": 4}
+        )
+        assert trace.inputs == {"arg1": 1, "arg2": 2, "kwarg1": 3, "kwarg2": 4}
+
+    def test_args_called_with_name_should_be_filled_correctly(self):
+        trace = _create_trace_from_function_call(func_with_args_and_kwargs, args=[1], kwargs={"arg2": 2, "kwarg2": 4})
+        assert trace.inputs == {"arg1": 1, "arg2": 2, "kwarg2": 4}
+
+    def test_kwargs_called_without_name_should_be_filled_correctly(self):
+        trace = _create_trace_from_function_call(func_with_args_and_kwargs, args=[1, 2, 3], kwargs={"kwarg2": 4})
+        assert trace.inputs == {"arg1": 1, "arg2": 2, "kwarg1": 3, "kwarg2": 4}
+
+    def test_empty_args_should_be_excluded_from_inputs(self):
+        trace = _create_trace_from_function_call(func_with_args_and_kwargs, args=[1])
+        assert trace.inputs == {"arg1": 1}
+
+    def test_empty_kwargs_should_be_excluded_from_inputs(self):
+        trace = _create_trace_from_function_call(func_with_args_and_kwargs, kwargs={"kwarg1": 1})
+        assert trace.inputs == {"kwarg1": 1}
+        trace = _create_trace_from_function_call(func_with_args_and_kwargs, kwargs={"kwarg2": 2})
+        assert trace.inputs == {"kwarg2": 2}
+
+    def test_args_and_kwargs_should_be_filled_in_called_order(self):
+        trace = _create_trace_from_function_call(
+            func_with_args_and_kwargs, args=[1, 2], kwargs={"kwarg2": 4, "kwarg1": 3}
+        )
+        assert list(trace.inputs.keys()) == ["arg1", "arg2", "kwarg2", "kwarg1"]
+
+    def test_connections_should_be_serialized(self):
+        conn = AzureOpenAIConnection("test_name", "test_secret")
+        trace = _create_trace_from_function_call(func_with_connection_parameter, args=[1, conn])
+        assert trace.inputs == {"a": 1, "conn": "AzureOpenAIConnection"}
+
+    def test_self_arg_should_be_excluded_from_inputs(self):
+        obj = MyClass()
+        trace = _create_trace_from_function_call(obj.my_method, args=[1])
+        assert trace.inputs == {"a": 1}

--- a/src/promptflow/tests/executor/unittests/_core/test_tracer.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tracer.py
@@ -145,7 +145,7 @@ def func_with_args_and_kwargs(arg1, arg2=None, *, kwarg1=None, kwarg2=None):
 
 
 def func_with_connection_parameter(a: int, conn: AzureOpenAIConnection):
-    _, _ = a, conn
+    _ = (a, conn)
 
 
 class MyClass:


### PR DESCRIPTION
# Description

* Refactored the `Tracer` class by extracting a new `_create_trace_from_function_call` method.
* Added test cases for the newly created method.
The test cases are named according to the policies described in [this post](https://enterprisecraftsmanship.com/posts/you-naming-tests-wrong/).

TLDR:
> Name the test as if you were describing the scenario to a non-programmer who is familiar with the problem domain.

Below are the test case names:
![image](https://github.com/microsoft/promptflow/assets/113209/92182338-9065-40cd-a589-64a217e58ec7)


# Copilot-generated description

This pull request includes changes to improve the behavior and readability of the codebase. The most important changes include adding new functions and a test class for testing the behavior of a specific function in the `test_tracer.py` file, modifying the `push_tool` method in the `Tracer` class to improve code readability and reusability, and adding a new value to an enum in the `trace.py` file.

Main changes:

* <a href="diffhunk://#diff-d572bf03138454bb6cf9229e9ea52580360c274c94e329d60e7fd485e6c41578R137-R222">`src/promptflow/tests/executor/unittests/_core/test_tracer.py`</a>: Added new functions and a test class to `test_tracer.py` for testing the behavior of `_create_trace_from_function_call` function. <a href="diffhunk://#diff-d572bf03138454bb6cf9229e9ea52580360c274c94e329d60e7fd485e6c41578R137-R222">[1]</a> <a href="diffhunk://#diff-d572bf03138454bb6cf9229e9ea52580360c274c94e329d60e7fd485e6c41578L4-R4">[2]</a>
* <a href="diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L68-R68">`src/promptflow/promptflow/_core/tracer.py`</a>: Modified the `push_tool` method in the `Tracer` class to improve code readability and reusability by replacing the code that creates a `Trace` object with a new helper function `_create_trace_from_function_call`.
* <a href="diffhunk://#diff-025f6ace207470504d15aeceb310625c6178fca578f856e0f6e36dd1a7f7b48eR15">`src/promptflow/promptflow/contracts/trace.py`</a>: Added a new value `FUNCTION` to the `TraceType` enum in `trace.py`, representing the type of a function trace.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
