### PR TITLE
[Executor] Exit the process when all async tools are done or exceeded timeout after cancellation

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Improvements
 - Change `ruamel.yaml` lower bound to 0.17.10.
 - [SDK/CLI] Improve `pfazure run download` to handle large run data files.
+- [Executor] Exit the process when all async tools are done or exceeded timeout after cancellation.
 
 ## 1.2.0 (2023.12.14)
 

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -172,12 +172,13 @@ def monitor_coroutine_after_cancellation(loop: asyncio.AbstractEventLoop):
         exceeded_wait_seconds = time.time() - thread_start_time > max_wait_seconds
         time.sleep(1)
 
-    if exceeded_wait_seconds and not all_tasks_are_done:
-        flow_logger.info(f"Not all coroutines are done within {max_wait_seconds}s"
-                         " after cancellation. Exiting the process despite of them."
-                         " Please config the environment variable"
-                         " PF_WAIT_SECONDS_AFTER_CANCELLATION if your tool needs"
-                         " more time to clean up after cancellation.")
-        remaining_tasks = [task for task in asyncio.all_tasks(loop) if not task.done()]
-        flow_logger.info(f"Remaining tasks: {[task.get_name() for task in remaining_tasks]}")
+    if exceeded_wait_seconds:
+        if not all_tasks_are_done:
+            flow_logger.info(f"Not all coroutines are done within {max_wait_seconds}s"
+                             " after cancellation. Exiting the process despite of them."
+                             " Please config the environment variable"
+                             " PF_WAIT_SECONDS_AFTER_CANCELLATION if your tool needs"
+                             " more time to clean up after cancellation.")
+            remaining_tasks = [task for task in asyncio.all_tasks(loop) if not task.done()]
+            flow_logger.info(f"Remaining tasks: {[task.get_name() for task in remaining_tasks]}")
         sys.exit(0)

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -149,6 +149,8 @@ def mointor_coroutine_after_cancellation(loop: asyncio.AbstractEventLoop):
     :param loop: event loop of main thread
     :type loop: asyncio.AbstractEventLoop
     """
+    # TODO: Use environment variable to ensure it is flow test / node test scenario
+    # to avoid unexpected exit.
     global SIGINT_RECEIVED
     max_wait_seconds = os.environ.get("PF_WAIT_SECONDS_AFTER_CANCELLATION", 30)
 

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -135,12 +135,12 @@ def signal_handler(sig, frame):
     flow_logger.info(f"Received signal {sig}({signal.Signals(sig).name}),"
                      " start coroutint monitor thread.")
     loop = asyncio.get_running_loop()
-    monitor = threading.Thread(target=mointor_coroutine_after_cancellation, args=(loop,))
+    monitor = threading.Thread(target=monitor_coroutine_after_cancellation, args=(loop,))
     monitor.start()
     raise KeyboardInterrupt
 
 
-def mointor_coroutine_after_cancellation(loop: asyncio.AbstractEventLoop):
+def monitor_coroutine_after_cancellation(loop: asyncio.AbstractEventLoop):
     """Exit the process when all coroutines are done.
     We add this function because if a sync tool is running in async mode,
     the task will be cancelled after receiving SIGINT,

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -133,7 +133,7 @@ class AsyncNodesScheduler:
 def signal_handler(sig, frame):
     """
     Set SIGINT_RECEIVED to True when SIGINT is received.
-    It's used to pass the signal to child thread for graceful exit.
+    It's used to pass the signal to child thread for program exit.
     """
     global SIGINT_RECEIVED
     flow_logger.info("Received SIGINT, set SIGINT_RECEIVED to True.")
@@ -162,12 +162,12 @@ def mointor_coroutine_after_cancellation(loop: asyncio.AbstractEventLoop):
         if SIGINT_RECEIVED:
             if not receive_signal_time:
                 receive_signal_time = time.time()
+                flow_logger.info("SIGINT received, monitoring tasks...")
 
-            flow_logger.info("SIGINT received, checking tasks...")
             # For sync tool running in async mode, the task will be cancelled,
             # but the thread will not be terminated, we exit the process despite of it.
             # TODO: Detect whether there is any sync tool running in async mode,
-            # if there is none, avoida sys._exit and let the program exit gracefully.
+            # if there is none, avoid sys._exit and let the program exit gracefully.
             all_tasks_are_done = all(task.done() for task in asyncio.all_tasks(loop))
             if all_tasks_are_done:
                 flow_logger.info("All coroutines are done. Exiting.")

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -42,7 +42,7 @@ class AsyncNodesScheduler:
     ) -> Tuple[dict, dict]:
         signal.signal(signal.SIGINT, signal_handler)
         loop = asyncio.get_running_loop()
-        monitor = threading.Thread(target=monitor_coroutine_thread, args=(loop,))
+        monitor = threading.Thread(target=mointor_coroutine_after_cancellation, args=(loop,))
         monitor.start()
 
         parent_context = contextvars.copy_context()
@@ -141,7 +141,7 @@ def signal_handler(sig, frame):
     raise KeyboardInterrupt
 
 
-def monitor_coroutine_thread(loop: asyncio.AbstractEventLoop):
+def mointor_coroutine_after_cancellation(loop: asyncio.AbstractEventLoop):
     """Exit the process when all coroutines are done.
     We add this function because if a sync tool is running in async mode,
     the task will be cancelled after receiving SIGINT,

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -185,7 +185,6 @@ class FlowExecutor:
         :return: A new instance of FlowExecutor.
         :rtype: ~promptflow.executor.flow_executor.FlowExecutor
         """
-
         flow = Flow.from_yaml(flow_file, working_dir=working_dir)
         return cls._create_from_flow(
             flow_file=flow_file,
@@ -884,7 +883,6 @@ class FlowExecutor:
         return outputs
 
     def _should_use_async(self):
-        return True
         return all(
             inspect.iscoroutinefunction(f) for f in self._tools_manager._tools.values()
         ) or os.environ.get("PF_USE_ASYNC", "false").lower() == "true"

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -51,8 +51,6 @@ from promptflow.executor.flow_validator import FlowValidator
 from promptflow.storage import AbstractRunStorage
 from promptflow.storage._run_storage import DefaultRunStorage
 
-SIGINT_RECEIVED = False
-
 
 class FlowExecutor:
     """This class is used to execute a single flow for different inputs.

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -51,6 +51,8 @@ from promptflow.executor.flow_validator import FlowValidator
 from promptflow.storage import AbstractRunStorage
 from promptflow.storage._run_storage import DefaultRunStorage
 
+SIGINT_RECEIVED = False
+
 
 class FlowExecutor:
     """This class is used to execute a single flow for different inputs.
@@ -183,6 +185,7 @@ class FlowExecutor:
         :return: A new instance of FlowExecutor.
         :rtype: ~promptflow.executor.flow_executor.FlowExecutor
         """
+
         flow = Flow.from_yaml(flow_file, working_dir=working_dir)
         return cls._create_from_flow(
             flow_file=flow_file,
@@ -881,6 +884,7 @@ class FlowExecutor:
         return outputs
 
     def _should_use_async(self):
+        return True
         return all(
             inspect.iscoroutinefunction(f) for f in self._tools_manager._tools.values()
         ) or os.environ.get("PF_USE_ASYNC", "false").lower() == "true"

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/async_passthrough.py
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/async_passthrough.py
@@ -3,7 +3,7 @@ import asyncio
 
 
 @tool
-async def passthrough_str_and_wait(input1: str, wait_seconds=3) -> str:
+async def passthrough_str_and_wait(input1: str, wait_seconds=3, wait_seconds_in_cancellation=1) -> str:
     assert isinstance(input1, str), f"input1 should be a string, got {input1}"
     try:
         print(f"Wait for {wait_seconds} seconds in async function")
@@ -11,9 +11,9 @@ async def passthrough_str_and_wait(input1: str, wait_seconds=3) -> str:
             print(i)
             await asyncio.sleep(1)
     except asyncio.CancelledError:
-        print("Async function is cancelled, start time consuming cancellation process")
-        import time
-        for i in range(10):
+        print(f"Async function is cancelled, wait for {wait_seconds_in_cancellation}"
+              " in cancellation process")
+        for i in range(wait_seconds_in_cancellation):
             print(f"Wait for {i} seconds in async tool cancellation logic")
             await asyncio.sleep(1)
         print(f"End time consuming cancellation process")

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/async_passthrough.py
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/async_passthrough.py
@@ -13,9 +13,9 @@ async def passthrough_str_and_wait(input1: str, wait_seconds=3) -> str:
     except asyncio.CancelledError:
         print("Async function is cancelled, start time consuming cancellation process")
         import time
-        for i in range(3):
-            print(i)
-            time.sleep(1)
+        for i in range(10):
+            print(f"Wait for {i} seconds in async tool cancellation logic")
+            await asyncio.sleep(1)
         print(f"End time consuming cancellation process")
         raise
     return input1

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
@@ -25,7 +25,8 @@ nodes:
     path: async_passthrough.py
   inputs:
     input1: ${async_passthrough.output}
-    wait_seconds: 8
+    wait_seconds: 30
+    wait_seconds_in_cancellation: 1
 - name: sync_passthrough1
   type: python
   source:


### PR DESCRIPTION
# Description

Exit the process if all async tools are done or exceeds wait timeout after received SIGINT or SIGTERM.
This is particularly useful when user press ctrl-c to cancel a flow with mixed sync and async nodes, in which case the sync node will run in a thread that is not killed by the signal and blocks the process from exiting.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
