### PR TITLE
[promptflow][bugfix] Fix flaky test due to fork mode

### DIFF
--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import uuid
 from pathlib import Path
+from unittest.mock import patch
 
 import pandas as pd
 import pytest
@@ -1082,35 +1083,36 @@ class TestFlowRun:
         assert run_dict["error"] == exception
 
     def test_get_details_against_partial_completed_run(self, pf: PFClient) -> None:
-        flow_mod2 = f"{FLOWS_DIR}/mod-n/two"
-        flow_mod3 = f"{FLOWS_DIR}/mod-n/three"
-        data_path = f"{DATAS_DIR}/numbers.jsonl"
-        # batch run against data
-        run1 = pf.run(
-            flow=flow_mod2,
-            data=data_path,
-            column_mapping={"number": "${data.value}"},
-        )
-        pf.runs.stream(run1)
-        details1 = pf.get_details(run1)
-        assert len(details1) == 20
-        assert len(details1.loc[details1["outputs.output"] != "(Failed)"]) == 10
-        # assert to ensure inputs and outputs are aligned
-        for _, row in details1.iterrows():
-            if str(row["outputs.output"]) != "(Failed)":
-                assert int(row["inputs.number"]) == int(row["outputs.output"])
+        with patch.dict(os.environ, {"PF_BATCH_METHOD": "spawn"}):
+            flow_mod2 = f"{FLOWS_DIR}/mod-n/two"
+            flow_mod3 = f"{FLOWS_DIR}/mod-n/three"
+            data_path = f"{DATAS_DIR}/numbers.jsonl"
+            # batch run against data
+            run1 = pf.run(
+                flow=flow_mod2,
+                data=data_path,
+                column_mapping={"number": "${data.value}"},
+            )
+            pf.runs.stream(run1)
+            details1 = pf.get_details(run1)
+            assert len(details1) == 20
+            assert len(details1.loc[details1["outputs.output"] != "(Failed)"]) == 10
+            # assert to ensure inputs and outputs are aligned
+            for _, row in details1.iterrows():
+                if str(row["outputs.output"]) != "(Failed)":
+                    assert int(row["inputs.number"]) == int(row["outputs.output"])
 
-        # batch run against previous run
-        run2 = pf.run(
-            flow=flow_mod3,
-            run=run1,
-            column_mapping={"number": "${run.outputs.output}"},
-        )
-        pf.runs.stream(run2)
-        details2 = pf.get_details(run2)
-        assert len(details2) == 10
-        assert len(details2.loc[details2["outputs.output"] != "(Failed)"]) == 4
-        # assert to ensure inputs and outputs are aligned
-        for _, row in details2.iterrows():
-            if str(row["outputs.output"]) != "(Failed)":
-                assert int(row["inputs.number"]) == int(row["outputs.output"])
+            # batch run against previous run
+            run2 = pf.run(
+                flow=flow_mod3,
+                run=run1,
+                column_mapping={"number": "${run.outputs.output}"},
+            )
+            pf.runs.stream(run2)
+            details2 = pf.get_details(run2)
+            assert len(details2) == 10
+            assert len(details2.loc[details2["outputs.output"] != "(Failed)"]) == 4
+            # assert to ensure inputs and outputs are aligned
+            for _, row in details2.iterrows():
+                if str(row["outputs.output"]) != "(Failed)":
+                    assert int(row["inputs.number"]) == int(row["outputs.output"])

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -1083,7 +1083,7 @@ class TestFlowRun:
         assert run_dict["error"] == exception
 
     # TODO: remove this patch after executor switch to default spawn
-    @patch.dict(os.environ, {"PF_BATCH_METHOD": "spawn"})
+    @patch.dict(os.environ, {"PF_BATCH_METHOD": "spawn"}, clear=True)
     def test_get_details_against_partial_completed_run(self, pf: PFClient) -> None:
         flow_mod2 = f"{FLOWS_DIR}/mod-n/two"
         flow_mod3 = f"{FLOWS_DIR}/mod-n/three"

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -1082,37 +1082,38 @@ class TestFlowRun:
         assert "error" in run_dict
         assert run_dict["error"] == exception
 
+    # TODO: remove this patch after executor switch to default spawn
+    @patch.dict(os.environ, {"PF_BATCH_METHOD": "spawn"})
     def test_get_details_against_partial_completed_run(self, pf: PFClient) -> None:
-        with patch.dict(os.environ, {"PF_BATCH_METHOD": "spawn"}):
-            flow_mod2 = f"{FLOWS_DIR}/mod-n/two"
-            flow_mod3 = f"{FLOWS_DIR}/mod-n/three"
-            data_path = f"{DATAS_DIR}/numbers.jsonl"
-            # batch run against data
-            run1 = pf.run(
-                flow=flow_mod2,
-                data=data_path,
-                column_mapping={"number": "${data.value}"},
-            )
-            pf.runs.stream(run1)
-            details1 = pf.get_details(run1)
-            assert len(details1) == 20
-            assert len(details1.loc[details1["outputs.output"] != "(Failed)"]) == 10
-            # assert to ensure inputs and outputs are aligned
-            for _, row in details1.iterrows():
-                if str(row["outputs.output"]) != "(Failed)":
-                    assert int(row["inputs.number"]) == int(row["outputs.output"])
+        flow_mod2 = f"{FLOWS_DIR}/mod-n/two"
+        flow_mod3 = f"{FLOWS_DIR}/mod-n/three"
+        data_path = f"{DATAS_DIR}/numbers.jsonl"
+        # batch run against data
+        run1 = pf.run(
+            flow=flow_mod2,
+            data=data_path,
+            column_mapping={"number": "${data.value}"},
+        )
+        pf.runs.stream(run1)
+        details1 = pf.get_details(run1)
+        assert len(details1) == 20
+        assert len(details1.loc[details1["outputs.output"] != "(Failed)"]) == 10
+        # assert to ensure inputs and outputs are aligned
+        for _, row in details1.iterrows():
+            if str(row["outputs.output"]) != "(Failed)":
+                assert int(row["inputs.number"]) == int(row["outputs.output"])
 
-            # batch run against previous run
-            run2 = pf.run(
-                flow=flow_mod3,
-                run=run1,
-                column_mapping={"number": "${run.outputs.output}"},
-            )
-            pf.runs.stream(run2)
-            details2 = pf.get_details(run2)
-            assert len(details2) == 10
-            assert len(details2.loc[details2["outputs.output"] != "(Failed)"]) == 4
-            # assert to ensure inputs and outputs are aligned
-            for _, row in details2.iterrows():
-                if str(row["outputs.output"]) != "(Failed)":
-                    assert int(row["inputs.number"]) == int(row["outputs.output"])
+        # batch run against previous run
+        run2 = pf.run(
+            flow=flow_mod3,
+            run=run1,
+            column_mapping={"number": "${run.outputs.output}"},
+        )
+        pf.runs.stream(run2)
+        details2 = pf.get_details(run2)
+        assert len(details2) == 10
+        assert len(details2.loc[details2["outputs.output"] != "(Failed)"]) == 4
+        # assert to ensure inputs and outputs are aligned
+        for _, row in details2.iterrows():
+            if str(row["outputs.output"]) != "(Failed)":
+                assert int(row["inputs.number"]) == int(row["outputs.output"])


### PR DESCRIPTION
# Description

Newly added test `test_get_details_against_partial_completed_run` is flaky, it will fail due to line run timeout, a known executor bug with fork mode. To work around it before executor switch to default spawn mode, add a patch decorator to force spawn mode for this test.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
