### PR TITLE
Guess mime type when init Image

### DIFF
--- a/src/promptflow/promptflow/contracts/multimedia.py
+++ b/src/promptflow/promptflow/contracts/multimedia.py
@@ -1,4 +1,5 @@
 import base64
+import filetype
 import hashlib
 from typing import Callable, Optional
 
@@ -43,7 +44,11 @@ class Image(PFBytes):
     ~promptflow.contracts.multimedia.PFBytes.
     """
 
-    def __init__(self, value: bytes, mime_type: str = "image/*", source_url: Optional[str] = None):
+    def __init__(self, value: bytes, mime_type: str = None, source_url: Optional[str] = None):
+        if mime_type is None:
+            mime_type = filetype.guess_mime(value)
+            if not mime_type.startswith("image/"):
+                mime_type = "image/*"
         return super().__init__(value, mime_type, source_url)
 
     def __str__(self):

--- a/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
@@ -91,12 +91,12 @@ class TestMultimediaUtils:
     def test_create_image_with_string(self, mocker):
         ## From path
         image_from_path = create_image(str(TEST_IMAGE_PATH))
-        assert image_from_path._mime_type == "image/jpg"
+        assert image_from_path._mime_type == "image/jpeg"
 
         # From base64
         image_from_base64 = create_image(image_from_path.to_base64())
         assert str(image_from_path) == str(image_from_base64)
-        assert image_from_base64._mime_type in ["image/jpg", "image/jpeg"]
+        assert image_from_base64._mime_type == "image/jpeg"
 
         ## From url
         mocker.patch("promptflow._utils.multimedia_utils._is_url", return_value=True)
@@ -104,7 +104,7 @@ class TestMultimediaUtils:
         mocker.patch("requests.get", return_value=mocker.Mock(content=image_from_path, status_code=200))
         image_from_url = create_image("Test")
         assert str(image_from_path) == str(image_from_url)
-        assert image_from_url._mime_type in ["image/jpg", "image/jpeg"]
+        assert image_from_url._mime_type == "image/jpeg"
 
         ## From image
         image_from_image = create_image(image_from_path)
@@ -136,10 +136,10 @@ class TestMultimediaUtils:
         mocker.patch("builtins.open", mock_open())
         data = {"image": image, "images": [image, image, "other_data"], "other_data": "other_data"}
         persisted_data = persist_multimedia_data(data, base_dir=Path(__file__).parent)
-        file_name = re.compile(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}.jpg$")
-        assert re.match(file_name, persisted_data["image"]["data:image/jpg;path"])
-        assert re.match(file_name, persisted_data["images"][0]["data:image/jpg;path"])
-        assert re.match(file_name, persisted_data["images"][1]["data:image/jpg;path"])
+        file_name = re.compile(r"^[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}.jpeg$")
+        assert re.match(file_name, persisted_data["image"]["data:image/jpeg;path"])
+        assert re.match(file_name, persisted_data["images"][0]["data:image/jpeg;path"])
+        assert re.match(file_name, persisted_data["images"][1]["data:image/jpeg;path"])
 
     def test_convert_multimedia_date_to_base64(self):
         image = _create_image_from_file(TEST_IMAGE_PATH)


### PR DESCRIPTION
# Description
This pull request includes changes related to determining the mime type of image object when initializing Image object. Previously, we determine the mime type before initializing image object, and pass the mime type to create an image, which caused some duplicated code, because we may have multiple code path need to detemine mime type and create image, therefore, in this PR, we moved the mime type guessing to the `__init__` function of Image class to avoid duplicated code.

Main changes:

* <a href="diffhunk://#diff-46760b7ed265c4b29c9cc4111fb19da9b815717e4d7180f61e0d0da023d2a8f9L66-L87">`src/promptflow/promptflow/_utils/multimedia_utils.py`</a>: Removed functionality for determining MIME type.
* <a href="diffhunk://#diff-201a9347f2427df518f6053cf652aa1880a430ea98655c265c49df17037ac735R2">`src/promptflow/promptflow/contracts/multimedia.py`</a>: Added `filetype` library and modified `Image` class to correctly determine MIME type. 

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
