### PR TITLE
Fix bug when guessing mime type

### DIFF
--- a/src/promptflow/promptflow/contracts/multimedia.py
+++ b/src/promptflow/promptflow/contracts/multimedia.py
@@ -47,7 +47,7 @@ class Image(PFBytes):
     def __init__(self, value: bytes, mime_type: str = None, source_url: Optional[str] = None):
         if mime_type is None:
             mime_type = filetype.guess_mime(value)
-            if not mime_type.startswith("image/"):
+            if mime_type is None or not mime_type.startswith("image/"):
                 mime_type = "image/*"
         return super().__init__(value, mime_type, source_url)
 

--- a/src/promptflow/tests/executor/unittests/contracts/test_multimedia.py
+++ b/src/promptflow/tests/executor/unittests/contracts/test_multimedia.py
@@ -3,29 +3,49 @@ import pytest
 from promptflow.contracts.multimedia import Image, PFBytes
 
 
-@pytest.mark.e2etest
+@pytest.mark.unittest
 class TestMultimediaContract:
-    def test_constructors(self):
-        content = b"test"
-        mime_type = "image/*"
-        bs = [
-            PFBytes(content, mime_type),
-            Image(content, mime_type),
-            PFBytes(content, mime_type=mime_type),
-            Image(content, mime_type=mime_type),
-            PFBytes(value=content, mime_type=mime_type),
-            Image(value=content, mime_type=mime_type),
+    @pytest.mark.parametrize(
+        "value, mime_type, source_url",
+        [
+            (b"test", "image/*", None),
+            (b"test", "image/jpg", None),
+            (b"test", "image/png", None),
+            (b"test", None, None),
+            (b"test", "image/*", "mock_url"),
         ]
-        for b in bs:
-            assert b._mime_type == "image/*"
-            assert b._hash == "a94a8fe5"
-            assert b.to_base64() == "dGVzdA=="
-            assert b.to_base64(with_type=True) == "data:image/*;base64,dGVzdA=="
-            assert b.to_base64(with_type=True, dict_type=True) == {"data:image/*;base64": "dGVzdA=="}
-            assert bytes(b) == content
-            assert b.source_url is None
-            if isinstance(b, Image):
-                assert str(b) == "Image(a94a8fe5)"
-                assert repr(b) == "Image(a94a8fe5)"
-                assert b.serialize() == "Image(a94a8fe5)"
-                assert b.serialize(lambda x: x.to_base64()) == "dGVzdA=="
+    )
+    def test_image_contract(self, value, mime_type, source_url):
+        image = Image(value, mime_type, source_url)
+        if mime_type is None:
+            mime_type = "image/*"
+        assert image._mime_type == mime_type
+        assert image._hash == "a94a8fe5"
+        assert image.to_base64() == "dGVzdA=="
+        assert image.to_base64(with_type=True) == f"data:{mime_type};base64,dGVzdA=="
+        assert image.to_base64(with_type=True, dict_type=True) == {f"data:{mime_type};base64": "dGVzdA=="}
+        assert bytes(image) == value
+        assert image.source_url == source_url
+        assert str(image) == "Image(a94a8fe5)"
+        assert repr(image) == "Image(a94a8fe5)"
+        assert image.serialize() == "Image(a94a8fe5)"
+        assert image.serialize(lambda x: x.to_base64()) == "dGVzdA=="
+
+    @pytest.mark.parametrize(
+        "value, mime_type, source_url",
+        [
+            (b"test", "image/*", None),
+            (b"test", "image/jpg", None),
+            (b"test", "image/png", None),
+            (b"test", "image/*", "mock_url"),
+        ]
+    )
+    def test_pfbytes_contract(self, value, mime_type, source_url):
+        pfBytes = PFBytes(value, mime_type, source_url)
+        assert pfBytes._mime_type == mime_type
+        assert pfBytes._hash == "a94a8fe5"
+        assert pfBytes.to_base64() == "dGVzdA=="
+        assert pfBytes.to_base64(with_type=True) == f"data:{mime_type};base64,dGVzdA=="
+        assert pfBytes.to_base64(with_type=True, dict_type=True) == {f"data:{mime_type};base64": "dGVzdA=="}
+        assert bytes(pfBytes) == value
+        assert pfBytes.source_url == source_url


### PR DESCRIPTION
# Description

Fix bug when guessing mime type. When loading image, we use `filetype.guess_mime` to guess mime type, if failed to recognize the mime type, it will return none, so we should check the return value before referring it.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
