### PR TITLE
[promptflow][bugfix] Fix "Without Import Data" error in run visualize page due to invalid JSON value

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs Fixed
 
 - Fix unaligned inputs & outputs or pandas exception during get details against run in Azure.
+- Fix "Without Import Data" in run visualize page results from invalid JSON value (`-Infinity`, `Infinity` and `NaN`).
 
 ## 1.3.0 (2023.12.27)
 

--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -340,7 +340,7 @@ class LocalStorageOperations(AbstractRunStorage):
             with open(self._detail_path, mode="r", encoding=DEFAULT_ENCODING) as f:
                 return json.load(f)
         else:
-            # float nan, inf and -inf is not JSON serializable
+            # nan, inf and -inf are not JSON serializable
             # according to https://docs.python.org/3/library/json.html#json.loads
             # `parse_constant` will be called to handle these values
             # so if parse_const_as_str is True, we will parse these values as str with a lambda function

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -302,7 +302,7 @@ class RunOperations(TelemetryMixin):
             run._check_run_status_is_completed()
 
             local_storage = LocalStorageOperations(run)
-            detail = local_storage.load_detail()
+            detail = local_storage.load_detail(parse_const_as_str=True)
             # ad-hoc step: make logs field empty to avoid too big HTML file
             # we don't provide logs view in visualization page for now
             # when we enable, we will save those big data (e.g. logs) in separate file(s)

--- a/src/promptflow/promptflow/_sdk/operations/_run_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_run_operations.py
@@ -302,6 +302,8 @@ class RunOperations(TelemetryMixin):
             run._check_run_status_is_completed()
 
             local_storage = LocalStorageOperations(run)
+            # nan, inf and -inf are not JSON serializable, which will lead to JavaScript parse error
+            # so specify `parse_const_as_str` as True to parse them as string
             detail = local_storage.load_detail(parse_const_as_str=True)
             # ad-hoc step: make logs field empty to avoid too big HTML file
             # we don't provide logs view in visualization page for now

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -5,6 +5,7 @@ import uuid
 from pathlib import Path
 from unittest.mock import patch
 
+import numpy as np
 import pandas as pd
 import pytest
 from pytest_mock import MockerFixture
@@ -1117,3 +1118,30 @@ class TestFlowRun:
         for _, row in details2.iterrows():
             if str(row["outputs.output"]) != "(Failed)":
                 assert int(row["inputs.number"]) == int(row["outputs.output"])
+
+    # TODO: remove this patch after executor switch to default spawn
+    @patch.dict(os.environ, {"PF_BATCH_METHOD": "spawn"}, clear=True)
+    def test_flow_with_nan_inf(self, pf: PFClient) -> None:
+        run = pf.run(
+            flow=f"{FLOWS_DIR}/flow-with-nan-inf",
+            data=f"{DATAS_DIR}/numbers.jsonl",
+            column_mapping={"number": "${data.value}"},
+        )
+        pf.stream(run)
+        local_storage = LocalStorageOperations(run=run)
+
+        # default behavior: no special logic for nan and inf
+        detail = local_storage.load_detail()
+        first_line_run_output = detail["flow_runs"][0]["output"]["output"]
+        assert isinstance(first_line_run_output["nan"], float)
+        assert np.isnan(first_line_run_output["nan"])
+        assert isinstance(first_line_run_output["inf"], float)
+        assert np.isinf(first_line_run_output["inf"])
+
+        # handles nan and inf, which is real scenario during visualize
+        detail = local_storage.load_detail(parse_const_as_str=True)
+        first_line_run_output = detail["flow_runs"][0]["output"]["output"]
+        assert isinstance(first_line_run_output["nan"], str)
+        assert first_line_run_output["nan"] == "NaN"
+        assert isinstance(first_line_run_output["inf"], str)
+        assert first_line_run_output["inf"] == "Infinity"

--- a/src/promptflow/tests/test_configs/flows/flow-with-nan-inf/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/flow-with-nan-inf/flow.dag.yaml
@@ -1,0 +1,15 @@
+inputs:
+  number:
+    type: int
+outputs:
+  output:
+    type: object
+    reference: ${nan_inf.output}
+nodes:
+- name: nan_inf
+  type: python
+  source:
+    type: code
+    path: nan_inf.py
+  inputs:
+    number: ${inputs.number}

--- a/src/promptflow/tests/test_configs/flows/flow-with-nan-inf/nan_inf.py
+++ b/src/promptflow/tests/test_configs/flows/flow-with-nan-inf/nan_inf.py
@@ -1,0 +1,7 @@
+from promptflow import tool
+
+
+@tool
+def nan_inf(number: int):
+    print(number)
+    return {"nan": float("nan"), "inf": float("inf")}


### PR DESCRIPTION
# Description

`-Infinity`, `Infinity` and `NaN` are not valid JSON value, and they will lead to JavaScript parse error (raised in #1516 ). This PR targets to fix this by converting them to string during visualize operation (aligned behavior to PFS/portal experience), leveraging `parse_constant`.

![image](https://github.com/microsoft/promptflow/assets/38847871/2b831a3d-99a0-4a2a-ae8a-9ae0c9d55a6e)

# Copilot-generated description

This pull request includes various changes to improve the functionality and usability of the codebase. The most important changes include adding a new parameter to the `load_detail` method in `_local_storage_operations.py` to parse special values as strings, adding a new node and function for handling `nan` and `inf` values in the flow configuration, and fixing the handling of invalid JSON values in the visualization.

Main functionality changes:

* <a href="diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L337-R347">`src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py`</a>: Added a new parameter `parse_const_as_str` to the `load_detail` method to parse special values as strings when loading the detail from a local file. <a href="diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L337-R347">[1]</a> <a href="diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L351-R363">[2]</a>
* <a href="diffhunk://#diff-39d51e8023624da687c7464983a469c455ec66f354aec5a7b062f6131062d90eR1-R15">`src/promptflow/tests/test_configs/flows/flow-with-nan-inf/flow.dag.yaml`</a>: Added a new node named `nan_inf` to the `flow.dag.yaml` file, which takes an input `number` and outputs an object referenced by `${nan_inf.output}`.
* <a href="diffhunk://#diff-0997c05030ddc88b139a95049e715220b0a98df48463ff4de30ff2ea7518f9e7R1-R7">`src/promptflow/tests/test_configs/flows/flow-with-nan-inf/nan_inf.py`</a>: Added a new function `nan_inf` to the `nan_inf.py` file, which returns a dictionary with keys `"nan"` and `"inf"` and their corresponding values as `float("nan")` and `float("inf")` respectively.

Bug fixes and improvements:

* <a href="diffhunk://#diff-41ec3f7c4b5d4c0e670407d3c00a03a6966d7ebf617b1536473e33a12e2bc765R8">`src/promptflow/CHANGELOG.md`</a>: Added a bug fix entry in the `CHANGELOG.md` file to document the fix for handling invalid JSON values causing the "Without Import Data" result in the run visualize page.
* <a href="diffhunk://#diff-94a59a05643476869fa3c6bc45466f1582944a935488075e2e63b6a6a196958fR8">`src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py`</a>: Added a new import statement for the `numpy` module and a new test method to verify the handling of `nan` and `inf` values during visualization. <a href="diffhunk://#diff-94a59a05643476869fa3c6bc45466f1582944a935488075e2e63b6a6a196958fR8">[1]</a> <a href="diffhunk://#diff-94a59a05643476869fa3c6bc45466f1582944a935488075e2e63b6a6a196958fR1121-R1147">[2]</a>
* <a href="diffhunk://#diff-a28fe272514a81f000f5c01ae75a1af29af457913a822204fe12444eddfce795L305-R307">`src/promptflow/promptflow/_sdk/operations/_run_operations.py`</a>: Updated the `_visualize` method to parse special values as strings when loading details for visualization.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
