### PR TITLE
Use relative path in gen meta/ load tool error message.

### DIFF
--- a/src/promptflow/promptflow/_core/_errors.py
+++ b/src/promptflow/promptflow/_core/_errors.py
@@ -43,6 +43,10 @@ class ToolCanceledError(UserErrorException):
     pass
 
 
+class InvalidSource(ValidationException):
+    pass
+
+
 class ToolLoadError(UserErrorException):
     """Exception raised when tool load failed."""
 

--- a/src/promptflow/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow/promptflow/_core/tool_meta_generator.py
@@ -256,6 +256,7 @@ def generate_python_meta_dict(name, content, source=None):
     return asdict_without_none(generate_python_tool(name, content, source))
 
 
+# Only used in non-code first experience.
 def generate_python_meta(name, content, source=None):
     return json.dumps(generate_python_meta_dict(name, content, source), indent=2)
 
@@ -269,12 +270,12 @@ def generate_tool_meta_dict_by_file(path: str, tool_type: ToolType):
     note that if a python file is passed, correct working directory must be set and should be added to sys.path.
     """
     tool_type = ToolType(tool_type)
-    file = Path(path).resolve()
+    file = Path(path)
     if not file.is_file():
         raise MetaFileNotFound(
             message_format="Generate tool meta failed for {tool_type} tool. Meta file '{file_path}' can not be found.",
             tool_type=tool_type.value,
-            file_path=str(file),
+            file_path=path,  # Use a relative path here to make the error message more readable.
         )
     try:
         content = file.read_text(encoding="utf-8")
@@ -286,7 +287,7 @@ def generate_tool_meta_dict_by_file(path: str, tool_type: ToolType):
                 "Read meta file '{file_path}' failed: {error_type_and_message}"
             ),
             tool_type=tool_type.value,
-            file_path=str(file),
+            file_path=path,
             error_type_and_message=error_type_and_message,
         ) from e
 

--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -76,10 +76,6 @@ class InvalidFlowRequest(ValidationException):
         )
 
 
-class InvalidSource(ValidationException):
-    pass
-
-
 class NodeInputValidationError(InvalidFlowRequest):
     pass
 

--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -10,6 +10,7 @@ from functools import partial
 from pathlib import Path
 from typing import Callable, List, Optional
 
+from promptflow._core._errors import InvalidSource
 from promptflow._core.connection_manager import ConnectionManager
 from promptflow._core.tool import STREAMING_OPTION_PARAMETER_ATTR
 from promptflow._core.tools_manager import BuiltinsManager, ToolLoader, connection_type_to_api_mapping
@@ -25,7 +26,6 @@ from promptflow.executor._errors import (
     EmptyLLMApiMapping,
     InvalidConnectionType,
     InvalidCustomLLMTool,
-    InvalidSource,
     NodeInputValidationError,
     ResolveToolError,
     ValueTypeUnresolved,

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -4,8 +4,7 @@ from tempfile import mkdtemp
 
 import pytest
 
-from promptflow._core._errors import FlowOutputUnserializable
-from promptflow._core.tool_meta_generator import PythonParsingError
+from promptflow._core._errors import FlowOutputUnserializable, InvalidSource
 from promptflow._core.tools_manager import APINotFound
 from promptflow._sdk._constants import DAG_FILE_NAME
 from promptflow._utils.utils import dump_list_to_jsonl
@@ -20,7 +19,6 @@ from promptflow.executor._errors import (
     InputReferenceNotFound,
     InputTypeError,
     InvalidConnectionType,
-    InvalidSource,
     NodeCircularDependency,
     NodeInputValidationError,
     NodeReferenceNotFound,
@@ -46,7 +44,7 @@ class TestValidation:
                 (
                     "Tool load failed in 'wrong_llm': "
                     "(InvalidConnectionType) Connection type CustomConnection is not supported for LLM."
-                )
+                ),
             ),
             (
                 "nodes_names_duplicated",
@@ -154,7 +152,7 @@ class TestValidation:
     @pytest.mark.parametrize(
         "flow_folder, yml_file, error_class, inner_class",
         [
-            ("source_file_missing", "flow.dag.python.yaml", ResolveToolError, PythonParsingError),
+            ("source_file_missing", "flow.dag.python.yaml", ResolveToolError, InvalidSource),
         ],
     )
     def test_executor_create_failure_type(self, flow_folder, yml_file, error_class, inner_class, dev_connections):

--- a/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
@@ -123,7 +123,7 @@ class TestToolMetaUtils:
                 "python",
                 cd_and_run,
                 r"\(MetaFileNotFound\) Generate tool meta failed for python tool. "
-                r"Meta file '.*aaa.py' can not be found.",
+                r"Meta file 'aaa.py' can not be found.",
                 id="MetaFileNotFound",
             ),
             pytest.param(
@@ -132,7 +132,7 @@ class TestToolMetaUtils:
                 "python",
                 cd_and_run_with_read_text_error,
                 r"\(MetaFileReadError\) Generate tool meta failed for python tool. "
-                r"Read meta file '.*divide_num.py' failed: \(Exception\) Mock read text error.",
+                r"Read meta file 'divide_num.py' failed: \(Exception\) Mock read text error.",
                 id="MetaFileReadError",
             ),
             pytest.param(

--- a/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
+++ b/src/promptflow/tests/executor/unittests/executor/test_tool_resolver.py
@@ -7,6 +7,7 @@ from unittest.mock import mock_open
 import pytest
 from jinja2 import TemplateSyntaxError
 
+from promptflow._core._errors import InvalidSource
 from promptflow._core.tools_manager import ToolLoader
 from promptflow._internal import tool
 from promptflow._sdk.entities import CustomConnection, CustomStrongTypeConnection
@@ -18,7 +19,6 @@ from promptflow.exceptions import UserErrorException
 from promptflow.executor._errors import (
     ConnectionNotFound,
     InvalidConnectionType,
-    InvalidSource,
     NodeInputValidationError,
     ResolveToolError,
     ValueTypeUnresolved,


### PR DESCRIPTION
# Description
Use relative path in gen meta/ load tool error message. Absolute paths convey too much extra info.

Move `InvalidSource` from `executor._errors` to `_core._errors` for circular reference.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
