### PR TITLE
[Internal] When load data for batch run, only read first max_rows_count of  rows.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -160,7 +160,8 @@
     "nohup",
     "metagenai",
     "WBITS",
-    "laddr"
+    "laddr",
+    "nrows"
   ],
   "flagWords": [
     "Prompt Flow"

--- a/src/promptflow/promptflow/_utils/load_data.py
+++ b/src/promptflow/promptflow/_utils/load_data.py
@@ -81,11 +81,10 @@ def _handle_dir(dir_path: str, max_rows_count: int, logger: logging.Logger = Non
         for file in files:
             current_df = _pd_read_file(file, logger=logger, max_rows_count=max_rows_count)
             df = pd.concat([df, current_df])
-        length = len(df)
-        if max_rows_count and length > 0:
-            if length > max_rows_count:
+            length = len(df)
+            if max_rows_count and length >= max_rows_count:
                 df = df.head(max_rows_count)
-            break
+                return df
         # no readable data in current level, dive into next level
         target_dir = dirs
     return df

--- a/src/promptflow/promptflow/_utils/load_data.py
+++ b/src/promptflow/promptflow/_utils/load_data.py
@@ -12,7 +12,7 @@ from promptflow.exceptions import ErrorTarget, UserErrorException
 module_logger = logging.getLogger(__name__)
 
 
-def _pd_read_file(local_path: str, logger: logging.Logger = None) -> "DataFrame":
+def _pd_read_file(local_path: str, logger: logging.Logger = None, max_rows_count: int = None) -> "DataFrame":
     import pandas as pd
 
     local_path = str(local_path)
@@ -30,20 +30,20 @@ def _pd_read_file(local_path: str, logger: logging.Logger = None) -> "DataFrame"
     dtype = object
 
     if local_path.endswith(".csv"):
-        df = pd.read_csv(local_path, dtype=dtype, keep_default_na=False)
+        df = pd.read_csv(local_path, dtype=dtype, keep_default_na=False, nrows=max_rows_count)
     elif local_path.endswith(".json"):
         df = pd.read_json(local_path, dtype=dtype)
     elif local_path.endswith(".jsonl"):
-        df = pd.read_json(local_path, dtype=dtype, lines=True)
+        df = pd.read_json(local_path, dtype=dtype, lines=True, nrows=max_rows_count)
     elif local_path.endswith(".tsv"):
-        df = pd.read_table(local_path, dtype=dtype, keep_default_na=False)
+        df = pd.read_table(local_path, dtype=dtype, keep_default_na=False, nrows=max_rows_count)
     elif local_path.endswith(".parquet"):
         df = pd.read_parquet(local_path)  # read_parquet has no parameter dtype
     else:
         # parse file as jsonl when extension is not known (including unavailable)
         # ignore and logging if failed to load file content.
         try:
-            df = pd.read_json(local_path, dtype=dtype, lines=True)
+            df = pd.read_json(local_path, dtype=dtype, lines=True, nrows=max_rows_count)
         except:  # noqa: E722
             if logger is None:
                 logger = module_logger
@@ -79,7 +79,7 @@ def _handle_dir(dir_path: str, max_rows_count: int, logger: logging.Logger = Non
     while len(target_dir) > 0:
         files, dirs = _bfs_dir(target_dir)
         for file in files:
-            current_df = _pd_read_file(file, logger=logger)
+            current_df = _pd_read_file(file, logger=logger, max_rows_count=max_rows_count)
             df = pd.concat([df, current_df])
         length = len(df)
         if max_rows_count and length > 0:
@@ -109,7 +109,7 @@ def load_df(local_path: Union[str, Path], logger: logging.Logger = None, max_row
     lp = local_path if isinstance(local_path, Path) else Path(local_path)
     try:
         if lp.is_file():
-            df = _pd_read_file(local_path, logger=logger)
+            df = _pd_read_file(local_path, logger=logger, max_rows_count=max_rows_count)
             # honor max_rows_count if it is specified
             if max_rows_count and len(df) > max_rows_count:
                 df = df.head(max_rows_count)

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -51,12 +51,22 @@ class BatchInputsProcessor:
     def _resolve_data_from_input_path(self, input_path: Path):
         """Resolve input data from directory"""
         result = []
+        row_count: int = None
+        if self._max_lines_count:
+            # Add one more row to check if the data exceeds the limit.
+            row_count = self._max_lines_count + 1
         if input_path.is_file():
-            result.extend(resolve_multimedia_data_recursively(input_path.parent, load_data(input_path)))
+            result.extend(resolve_multimedia_data_recursively(
+                input_path.parent,
+                load_data(local_path=input_path, max_rows_count=row_count))
+            )
         else:
             for input_file in input_path.rglob("*"):
                 if input_file.is_file():
-                    result.extend(resolve_multimedia_data_recursively(input_file.parent, load_data(input_file)))
+                    result.extend(resolve_multimedia_data_recursively(
+                        input_file.parent,
+                        load_data(local_path=input_file, max_rows_count=row_count))
+                    )
                     if self._max_lines_count and len(result) >= self._max_lines_count:
                         break
         if self._max_lines_count and len(result) > self._max_lines_count:

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -51,20 +51,17 @@ class BatchInputsProcessor:
     def _resolve_data_from_input_path(self, input_path: Path):
         """Resolve input data from directory"""
         result = []
-        max_rows_count: int = None
-        if self._max_lines_count:
-            max_rows_count = self._max_lines_count
         if input_path.is_file():
             result.extend(resolve_multimedia_data_recursively(
                 input_path.parent,
-                load_data(local_path=input_path, max_rows_count=max_rows_count))
+                load_data(local_path=input_path, max_rows_count=self._max_lines_count))
             )
         else:
             for input_file in input_path.rglob("*"):
                 if input_file.is_file():
                     result.extend(resolve_multimedia_data_recursively(
                         input_file.parent,
-                        load_data(local_path=input_file, max_rows_count=max_rows_count))
+                        load_data(local_path=input_file, max_rows_count=self._max_lines_count))
                     )
                     if self._max_lines_count and len(result) >= self._max_lines_count:
                         break

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -53,8 +53,7 @@ class BatchInputsProcessor:
         result = []
         max_rows_count: int = None
         if self._max_lines_count:
-            # Add one more row to check if the data exceeds the limit.
-            max_rows_count = self._max_lines_count + 1
+            max_rows_count = self._max_lines_count
         if input_path.is_file():
             result.extend(resolve_multimedia_data_recursively(
                 input_path.parent,
@@ -69,7 +68,7 @@ class BatchInputsProcessor:
                     )
                     if self._max_lines_count and len(result) >= self._max_lines_count:
                         break
-        if self._max_lines_count and len(result) > self._max_lines_count:
+        if self._max_lines_count and len(result) >= self._max_lines_count:
             logger.warning(
                 (
                     "The data provided exceeds the maximum lines limit. Currently, only the first "

--- a/src/promptflow/promptflow/batch/_batch_inputs_processor.py
+++ b/src/promptflow/promptflow/batch/_batch_inputs_processor.py
@@ -51,21 +51,21 @@ class BatchInputsProcessor:
     def _resolve_data_from_input_path(self, input_path: Path):
         """Resolve input data from directory"""
         result = []
-        row_count: int = None
+        max_rows_count: int = None
         if self._max_lines_count:
             # Add one more row to check if the data exceeds the limit.
-            row_count = self._max_lines_count + 1
+            max_rows_count = self._max_lines_count + 1
         if input_path.is_file():
             result.extend(resolve_multimedia_data_recursively(
                 input_path.parent,
-                load_data(local_path=input_path, max_rows_count=row_count))
+                load_data(local_path=input_path, max_rows_count=max_rows_count))
             )
         else:
             for input_file in input_path.rglob("*"):
                 if input_file.is_file():
                     result.extend(resolve_multimedia_data_recursively(
                         input_file.parent,
-                        load_data(local_path=input_file, max_rows_count=row_count))
+                        load_data(local_path=input_file, max_rows_count=max_rows_count))
                     )
                     if self._max_lines_count and len(result) >= self._max_lines_count:
                         break

--- a/src/promptflow/tests/executor/unittests/batch/test_batch_inputs_processor.py
+++ b/src/promptflow/tests/executor/unittests/batch/test_batch_inputs_processor.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 import pytest
 
@@ -272,3 +273,22 @@ class TestBatchInputsProcessor:
         with pytest.raises(error_code) as e:
             BatchInputsProcessor("", {})._apply_inputs_mapping_for_all_lines(inputs, inputs_mapping)
         assert error_message == str(e.value), "Expected: {}, Actual: {}".format(error_message, str(e.value))
+
+    @pytest.mark.parametrize(
+        "data_path",
+        [
+            "./tests/test_configs/datas/load_data_cases/10k.jsonl",
+            "./tests/test_configs/datas/load_data_cases/10k",
+        ],
+    )
+    def test_resolve_data_from_input_path(self, data_path):
+        result = BatchInputsProcessor("", {})._resolve_data_from_input_path(Path(data_path))
+        assert isinstance(result, list)
+        assert len(result) == 10000
+
+        # specify max_rows_count
+        max_rows_count = 5
+        head_results = BatchInputsProcessor("", {}, max_lines_count=max_rows_count)._resolve_data_from_input_path(Path(data_path))
+        assert isinstance(head_results, list)
+        assert len(head_results) == max_rows_count
+        assert result[:max_rows_count] == head_results

--- a/src/promptflow/tests/executor/unittests/batch/test_batch_inputs_processor.py
+++ b/src/promptflow/tests/executor/unittests/batch/test_batch_inputs_processor.py
@@ -288,7 +288,11 @@ class TestBatchInputsProcessor:
 
         # specify max_rows_count
         max_rows_count = 5
-        head_results = BatchInputsProcessor("", {}, max_lines_count=max_rows_count)._resolve_data_from_input_path(Path(data_path))
+        head_results = BatchInputsProcessor(
+            working_dir="",
+            flow_inputs={},
+            max_lines_count=max_rows_count,
+        )._resolve_data_from_input_path(Path(data_path))
         assert isinstance(head_results, list)
         assert len(head_results) == max_rows_count
         assert result[:max_rows_count] == head_results

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -256,8 +256,10 @@ class TestUtils:
         df = load_data(data_path)
         assert len(df) == 10000
         # specify max_rows_count
-        df = load_data(data_path, max_rows_count=5000)
-        assert len(df) == 5000
+        max_rows_count = 5000
+        head_rows = load_data(data_path, max_rows_count=max_rows_count)
+        assert len(head_rows) == max_rows_count
+        assert head_rows == df[:max_rows_count]
 
     @pytest.mark.parametrize(
         "script_name, expected_result",


### PR DESCRIPTION
# Description

When load data for batch run, we will load all the data of file in memory (do truncation after file loaded) even if max_rows_count is set.
This PR pass the max_rows_count to the file loader to speed up loading.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
