### PR TITLE
[Executor] Show long running message for async tool

### DIFF
--- a/src/promptflow/promptflow/_utils/utils.py
+++ b/src/promptflow/promptflow/_utils/utils.py
@@ -261,6 +261,8 @@ def parse_ua_to_dict(ua):
     return ua_dict
 
 
+# TODO: Add "conditions" parameter to pass in a list of lambda functions
+# to check if the environment variable is valid.
 def get_int_env_var(env_var_name, default_value=None):
     """
     The function `get_int_env_var` retrieves an integer environment variable value, with an optional

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -180,7 +180,7 @@ def log_stack_recursively(task: asyncio.Task, elapse_time: float):
         elif asyncio.iscoroutine(task_or_coroutine):
             coroutine = task_or_coroutine
         else:
-            flow_logger.info("\n".join(messages))
+            flow_logger.warning("\n".join(messages))
             return
 
         frame = coroutine.cr_frame

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -197,7 +197,12 @@ def monitor_long_running_coroutine(loop: asyncio.AbstractEventLoop, task_start_t
         running_tasks = [task for task in asyncio.all_tasks(loop) if not task.done()]
         # get duration of running tasks
         for task in running_tasks:
+            # Do not monitor the scheduler task
             if task.get_name() == PF_ASYNC_NODE_SCHEDULER_EXECUTE_TASK_NAME:
+                continue
+            # Do not monitor sync tools, since they will run in executor thread and will
+            # be monitored by RepeatLogTimer.
+            if task.get_stack(limit=1)[0].f_code.co_name == AsyncNodesScheduler._sync_function_to_async_task.__name__:
                 continue
             if task_start_time.get(task) is None:
                 flow_logger.warning(f"task {task.get_name()} has no start time, which should not happen")

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -214,20 +214,20 @@ def monitor_long_running_coroutine(
     dag_manager_completed_event: threading.Event,
 ):
     logging_interval = DEFAULT_TASK_LOGGING_INTERVAL
-    logging_level_in_env = os.environ.get("PF_TASK_PEEKING_INTERVAL")
-    if logging_level_in_env:
+    logging_interval_in_env = os.environ.get("PF_TASK_PEEKING_INTERVAL")
+    if logging_interval_in_env:
         try:
-            value = int(logging_level_in_env)
+            value = int(logging_interval_in_env)
             if value <= 0:
                 raise ValueError
             logging_interval = value
             flow_logger.info(
                 f"Using value of PF_TASK_PEEKING_INTERVAL in environment variable as "
-                f"logging interval: {logging_level_in_env}"
+                f"logging interval: {logging_interval_in_env}"
             )
         except ValueError:
             flow_logger.warning(
-                f"Value of PF_TASK_PEEKING_INTERVAL in environment variable ('{logging_level_in_env}') "
+                f"Value of PF_TASK_PEEKING_INTERVAL in environment variable ('{logging_interval_in_env}') "
                 f"is invalid, use default value {DEFAULT_TASK_LOGGING_INTERVAL}"
             )
     flow_logger.info("monitor_long_running_coroutine started")

--- a/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/async_tools_with_sync_tools/flow.dag.yaml
@@ -25,7 +25,7 @@ nodes:
     path: async_passthrough.py
   inputs:
     input1: ${async_passthrough.output}
-    wait_seconds: 30
+    wait_seconds: 10
     wait_seconds_in_cancellation: 1
 - name: sync_passthrough1
   type: python


### PR DESCRIPTION
# Description

Periodically show stack of long running async tasks.
Sample long running message:
```
2024-01-07 19:23:04 +0800   38892 execution          WARNING  sync_passthrough1 in line 0 has been running for 30 seconds, stacktrace of thread 19416:
  File "D:\Projects\GitHub\promptflow\src\promptflow\tests\test_configs\flows\async_tools_with_sync_tools\sync_passthrough.py", line 11, in passthrough_str_and_wait_sync
    time.sleep(1)

2024-01-07 19:23:04 +0800   38892 execution.flow     WARNING  Task async_passthrough1 has been running for 30 seconds, stacktrace:
  File "D:\Projects\GitHub\promptflow\src\promptflow\tests\test_configs\flows\async_tools_with_sync_tools\async_passthrough.py", line 12, in passthrough_str_and_wait
    await asyncio.sleep(1)
  File "C:\Users\migu\Miniconda3\envs\github-pflow\lib\asyncio\tasks.py", line 652, in sleep
    return await future
```
Note that async tools will have multiple traceback for each await "stack", and sync tools will have the same experience as in sync mode.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
