### PR TITLE
[Improvement][Executor] Exit health check loop if executor service is exited

### DIFF
--- a/src/promptflow/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_base_executor_proxy.py
@@ -138,7 +138,7 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
         within the allocated timeout, an exception is thrown to indicate a potential problem.
         """
         retry_count = 0
-        max_retry_count = 10
+        max_retry_count = 20
         while retry_count < max_retry_count:
             if not self._is_executor_active():
                 bulk_logger.error("The executor service is not active. Please check the logs for more details.")

--- a/src/promptflow/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_base_executor_proxy.py
@@ -141,11 +141,12 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
         max_retry_count = 10
         while retry_count < max_retry_count:
             if not self._is_executor_active():
+                bulk_logger.error("The executor service is not active. Please check the logs for more details.")
                 break
             if await self._check_health():
                 return
             # wait for 1s to prevent calling the API too frequently
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(1)
             retry_count += 1
         raise ExecutorServiceUnhealthy(f"{EXECUTOR_UNHEALTHY_MESSAGE}. Please resubmit your flow and try again.")
 

--- a/src/promptflow/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_base_executor_proxy.py
@@ -127,8 +127,6 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
             bulk_logger.error(f"Failed to start up the executor due to an error: {str(startup_ex)}")
             await self.destroy()
             raise startup_ex
-        finally:
-            Path(error_file).unlink()
 
     async def ensure_executor_health(self):
         """Ensure the executor service is healthy before calling the API to get the results
@@ -142,12 +140,18 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
         retry_count = 0
         max_retry_count = 10
         while retry_count < max_retry_count:
+            if not self._is_executor_active():
+                break
             if await self._check_health():
                 return
             # wait for 1s to prevent calling the API too frequently
             await asyncio.sleep(0.5)
             retry_count += 1
         raise ExecutorServiceUnhealthy(f"{EXECUTOR_UNHEALTHY_MESSAGE}. Please resubmit your flow and try again.")
+
+    def _is_executor_active(self):
+        """The interface function to check if the executor service is active"""
+        return True
 
     async def _check_health(self):
         try:

--- a/src/promptflow/tests/executor/e2etests/test_csharp_executor_proxy.py
+++ b/src/promptflow/tests/executor/e2etests/test_csharp_executor_proxy.py
@@ -127,8 +127,7 @@ class MockCSharpExecutorProxy(CSharpExecutorProxy):
         )
         process.start()
         executor_proxy = cls(process, port)
-        if init_error_file:
-            await executor_proxy.ensure_executor_startup(init_error_file)
+        await executor_proxy.ensure_executor_startup(init_error_file)
         return executor_proxy
 
     async def destroy(self):
@@ -139,3 +138,6 @@ class MockCSharpExecutorProxy(CSharpExecutorProxy):
                 self._process.join(timeout=5)
             except TimeoutError:
                 self._process.kill()
+
+    def _is_executor_active(self):
+        return self._process and self._process.is_alive()

--- a/src/promptflow/tests/executor/mock_execution_server.py
+++ b/src/promptflow/tests/executor/mock_execution_server.py
@@ -3,6 +3,8 @@ from functools import partial
 
 from aiohttp import web
 
+from promptflow.exceptions import ValidationException
+
 
 def run_executor_server(port, has_error=False, init_error_file=None):
     app = web.Application()
@@ -14,6 +16,8 @@ def run_executor_server(port, has_error=False, init_error_file=None):
     print(f"Starting server on port {port}")
     if init_error_file is None:
         web.run_app(app, host="localhost", port=port)
+    else:
+        raise ValidationException("Error for tests")
 
 
 async def _handle_health(request: web.Request):


### PR DESCRIPTION
# Description
- Add `_is_executor_active()` to check if the executor service is active. If the executor terminates due to some validation errors, the health check can exit early without repetition.
- Each executor proxy is responsible for deleting its own init error file, rather than relying on the `ensure_executor_startup` function to do so.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
