### PR TITLE
[Executor] Support node_concurrency when running an async flow

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -118,13 +118,12 @@ class AsyncNodesScheduler:
         f = self._tools_manager.get_tool(node.name)
         kwargs = dag_manager.get_node_valid_inputs(node, f)
         if inspect.iscoroutinefunction(f):
-            coroutine = context.invoke_tool_async(node, f, kwargs)
-            task = self.run_task_with_semaphore(coroutine)
+            task = context.invoke_tool_async(node, f, kwargs)
         else:
             task = self._sync_function_to_async_task(executor, context, node, f, kwargs)
         # Set the name of the task to the node name for debugging purpose
         # It does not need to be unique by design.
-        return asyncio.create_task(task, name=node.name)
+        return asyncio.create_task(self.run_task_with_semaphore(task), name=node.name)
 
     @staticmethod
     async def _sync_function_to_async_task(

--- a/src/promptflow/tests/executor/e2etests/test_async.py
+++ b/src/promptflow/tests/executor/e2etests/test_async.py
@@ -1,33 +1,41 @@
 import os
+
 import pytest
+
 from promptflow.executor import FlowExecutor
+
 from ..utils import get_flow_folder, get_yaml_file
 
 
 @pytest.mark.e2etest
 class TestAsync:
-    def test_executor_node_concurrency(self):
-        flow_folder = "async_tools"
-        nodes = ["async_passthrough", "async_passthrough1", "async_passthrough2"]
-        os.chdir(get_flow_folder(flow_folder))
-        executor = FlowExecutor.create(get_yaml_file(flow_folder), {})
+    @pytest.mark.parametrize(
+        "folder_name, nodes",
+        [
+            ("async_tools", ["async_passthrough", "async_passthrough1", "async_passthrough2"]),
+            ("async_tools_with_sync_tools", ["async_passthrough", "async_passthrough1", "sync_passthrough1"]),
+        ],
+    )
+    def test_executor_node_concurrency(self, folder_name, nodes):
+        os.chdir(get_flow_folder(folder_name))
+        executor = FlowExecutor.create(get_yaml_file(folder_name), {})
 
         def get_node_times(api_calls, nodes):
-            node_times = {node: {'start': None, 'end': None} for node in nodes}
-            for api_call in api_calls[0]['children']:
+            node_times = {node: {"start": None, "end": None} for node in nodes}
+            for api_call in api_calls[0]["children"]:
                 if api_call["node_name"] in nodes:
-                    node_times[api_call["node_name"]]['start'] = api_call["start_time"]
-                    node_times[api_call["node_name"]]['end'] = api_call["end_time"]
+                    node_times[api_call["node_name"]]["start"] = api_call["start_time"]
+                    node_times[api_call["node_name"]]["end"] = api_call["end_time"]
             return node_times
 
-        # run when node_concurrency is 1, node execute one by one
+        # When node_concurrency is 1, nodes execute one by one
         flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=1)
         node_times = get_node_times(flow_result.run_info.api_calls, nodes)
-        assert node_times[nodes[0]]['end'] < node_times[nodes[1]]['start']
-        assert node_times[nodes[1]]['end'] < node_times[nodes[2]]['start']
+        assert node_times[nodes[0]]["end"] < node_times[nodes[1]]["start"]
+        assert node_times[nodes[1]]["end"] < node_times[nodes[2]]["start"]
 
-        # run when node_concurrency is 2, node async_passthrough1 and 2 execute concurrently
+        # When node_concurrency is 2, two nodes execute concurrently
         flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=2)
         node_times = get_node_times(flow_result.run_info.api_calls, nodes)
-        assert node_times[nodes[1]]['start'] < node_times[nodes[2]]['end']
-        assert node_times[nodes[2]]['start'] < node_times[nodes[1]]['end']
+        assert node_times[nodes[1]]["start"] < node_times[nodes[2]]["end"]
+        assert node_times[nodes[2]]["start"] < node_times[nodes[1]]["end"]

--- a/src/promptflow/tests/executor/e2etests/test_async.py
+++ b/src/promptflow/tests/executor/e2etests/test_async.py
@@ -1,0 +1,33 @@
+import os
+import pytest
+from promptflow.executor import FlowExecutor
+from ..utils import get_flow_folder, get_yaml_file
+
+
+@pytest.mark.e2etest
+class TestAsync:
+    def test_executor_node_concurrency(self):
+        flow_folder = "async_tools"
+        nodes = ["async_passthrough", "async_passthrough1", "async_passthrough2"]
+        os.chdir(get_flow_folder(flow_folder))
+        executor = FlowExecutor.create(get_yaml_file(flow_folder), {})
+
+        def get_node_times(api_calls, nodes):
+            node_times = {node: {'start': None, 'end': None} for node in nodes}
+            for api_call in api_calls[0]['children']:
+                if api_call["node_name"] in nodes:
+                    node_times[api_call["node_name"]]['start'] = api_call["start_time"]
+                    node_times[api_call["node_name"]]['end'] = api_call["end_time"]
+            return node_times
+
+        # run when node_concurrency is 1, node execute one by one
+        flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=1)
+        node_times = get_node_times(flow_result.run_info.api_calls, nodes)
+        assert node_times[nodes[0]]['end'] < node_times[nodes[1]]['start']
+        assert node_times[nodes[1]]['end'] < node_times[nodes[2]]['start']
+
+        # run when node_concurrency is 2, node async_passthrough1 and 2 execute concurrently
+        flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=2)
+        node_times = get_node_times(flow_result.run_info.api_calls, nodes)
+        assert node_times[nodes[1]]['start'] < node_times[nodes[2]]['end']
+        assert node_times[nodes[2]]['start'] < node_times[nodes[1]]['end']

--- a/src/promptflow/tests/executor/e2etests/test_async.py
+++ b/src/promptflow/tests/executor/e2etests/test_async.py
@@ -7,37 +7,36 @@ from ..utils import get_flow_folder, get_yaml_file
 @pytest.mark.e2etest
 class TestAsync:
     @pytest.mark.parametrize(
-        "folder_name, concurrency_levels",
+        "folder_name, concurrency_levels, expected_concurrency",
         [
-            ("async_tools", [1, 2, 3]),
-            ("async_tools_with_sync_tools", [1, 2, 3]),
+            ("async_tools", [1, 2, 3], [1, 2, 2]),
+            ("async_tools_with_sync_tools", [1, 2, 3], [1, 2, 2]),
         ],
     )
-    def test_executor_node_concurrency(self, folder_name, concurrency_levels):
+    def test_executor_node_concurrency(self, folder_name, concurrency_levels, expected_concurrency):
         os.chdir(get_flow_folder(folder_name))
         executor = FlowExecutor.create(get_yaml_file(folder_name), {})
-        for concurrency in concurrency_levels:
+
+        def calculate_max_concurrency(flow_result):
+            timeline = []
+            api_calls = flow_result.run_info.api_calls[0]["children"]
+            for api_call in api_calls:
+                timeline.append(("start", api_call["start_time"]))
+                timeline.append(("end", api_call["end_time"]))
+            timeline.sort(key=lambda x: x[1])
+            current_concurrency = 0
+            max_concurrency = 0
+            for event, _ in timeline:
+                if event == "start":
+                    current_concurrency += 1
+                    max_concurrency = max(max_concurrency, current_concurrency)
+                elif event == "end":
+                    current_concurrency -= 1
+            return max_concurrency
+
+        for i in range(len(concurrency_levels)):
+            concurrency = concurrency_levels[i]
             flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=concurrency)
-            max_concurrency = self.calculate_max_concurrency(flow_result)
+            max_concurrency = calculate_max_concurrency(flow_result)
+            assert max_concurrency == expected_concurrency[i]
             assert max_concurrency <= concurrency
-
-    def calculate_max_concurrency(self, flow_result):
-        timeline = []
-        api_calls = flow_result.run_info.api_calls[0]["children"]
-        print("api_calls:", api_calls)
-        for api_call in api_calls:
-            timeline.append(("start", api_call["start_time"]))
-            timeline.append(("end", api_call["end_time"]))
-        timeline.sort(key=lambda x: x[1])
-        print("timeline", timeline)
-        current_concurrency = 0
-        max_concurrency = 0
-
-        for event, _ in timeline:
-            if event == "start":
-                current_concurrency += 1
-                max_concurrency = max(max_concurrency, current_concurrency)
-            elif event == "end":
-                current_concurrency -= 1
-
-        return max_concurrency

--- a/src/promptflow/tests/executor/e2etests/test_async.py
+++ b/src/promptflow/tests/executor/e2etests/test_async.py
@@ -1,41 +1,43 @@
 import os
-
 import pytest
-
 from promptflow.executor import FlowExecutor
-
 from ..utils import get_flow_folder, get_yaml_file
 
 
 @pytest.mark.e2etest
 class TestAsync:
     @pytest.mark.parametrize(
-        "folder_name, nodes",
+        "folder_name, concurrency_levels",
         [
-            ("async_tools", ["async_passthrough", "async_passthrough1", "async_passthrough2"]),
-            ("async_tools_with_sync_tools", ["async_passthrough", "async_passthrough1", "sync_passthrough1"]),
+            ("async_tools", [1, 2, 3]),
+            ("async_tools_with_sync_tools", [1, 2, 3]),
         ],
     )
-    def test_executor_node_concurrency(self, folder_name, nodes):
+    def test_executor_node_concurrency(self, folder_name, concurrency_levels):
         os.chdir(get_flow_folder(folder_name))
         executor = FlowExecutor.create(get_yaml_file(folder_name), {})
+        for concurrency in concurrency_levels:
+            flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=concurrency)
+            max_concurrency = self.calculate_max_concurrency(flow_result)
+            assert max_concurrency <= concurrency
 
-        def get_node_times(api_calls, nodes):
-            node_times = {node: {"start": None, "end": None} for node in nodes}
-            for api_call in api_calls[0]["children"]:
-                if api_call["node_name"] in nodes:
-                    node_times[api_call["node_name"]]["start"] = api_call["start_time"]
-                    node_times[api_call["node_name"]]["end"] = api_call["end_time"]
-            return node_times
+    def calculate_max_concurrency(self, flow_result):
+        timeline = []
+        api_calls = flow_result.run_info.api_calls[0]["children"]
+        print("api_calls:", api_calls)
+        for api_call in api_calls:
+            timeline.append(("start", api_call["start_time"]))
+            timeline.append(("end", api_call["end_time"]))
+        timeline.sort(key=lambda x: x[1])
+        print("timeline", timeline)
+        current_concurrency = 0
+        max_concurrency = 0
 
-        # When node_concurrency is 1, nodes execute one by one
-        flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=1)
-        node_times = get_node_times(flow_result.run_info.api_calls, nodes)
-        assert node_times[nodes[0]]["end"] < node_times[nodes[1]]["start"]
-        assert node_times[nodes[1]]["end"] < node_times[nodes[2]]["start"]
+        for event, _ in timeline:
+            if event == "start":
+                current_concurrency += 1
+                max_concurrency = max(max_concurrency, current_concurrency)
+            elif event == "end":
+                current_concurrency -= 1
 
-        # When node_concurrency is 2, two nodes execute concurrently
-        flow_result = executor.exec_line({"input_str": "Hello"}, node_concurrency=2)
-        node_times = get_node_times(flow_result.run_info.api_calls, nodes)
-        assert node_times[nodes[1]]["start"] < node_times[nodes[2]]["end"]
-        assert node_times[nodes[2]]["start"] < node_times[nodes[1]]["end"]
+        return max_concurrency


### PR DESCRIPTION
# Description

Use asyncio.semaphore to support concurrency control.

When node_concurrency is set to 2:
sync_passthrough1 and async_passthrough1 can run concurrently:
![1705287434459](https://github.com/microsoft/promptflow/assets/39176492/487f1d03-34fa-4016-bf01-ff31d64d2c3f)


When node_concurrency is set to 1:
Only one of sync_passthrough1 and async_passthrough1 can at the same time:
![1705288060087](https://github.com/microsoft/promptflow/assets/39176492/9ce31cd9-4af4-4451-a898-06cccf5c2321)

