### PR TITLE
feat: use promptflow error for invalid flow metadata

### DIFF
--- a/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
@@ -10,6 +10,7 @@ from typing import Any, Mapping, Optional
 
 from promptflow._sdk._constants import DEFAULT_ENCODING, FLOW_TOOLS_JSON, PROMPT_FLOW_DIR_NAME
 from promptflow.batch._base_executor_proxy import APIBasedExecutorProxy
+from promptflow.batch._errors import InvalidMetadataError
 from promptflow.executor._result import AggregationResult
 from promptflow.storage._run_storage import AbstractRunStorage
 
@@ -98,11 +99,11 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
                 try:
                     return json.load(f)
                 except json.JSONDecodeError:
-                    raise RuntimeError(
+                    raise InvalidMetadataError(
                         f"Failed to fetch meta of tools: {flow_tools_json_path.absolute().as_posix()} "
                         f"is not a valid json file."
                     )
-        raise FileNotFoundError(
+        raise InvalidMetadataError(
             f"Failed to fetch meta of tools: cannot find {flow_tools_json_path.absolute().as_posix()}, "
             f"please build the flow project first."
         )

--- a/src/promptflow/promptflow/batch/_errors.py
+++ b/src/promptflow/promptflow/batch/_errors.py
@@ -16,3 +16,7 @@ class EmptyInputsData(UserErrorException):
 
 class ExecutorServiceUnhealthy(SystemErrorException):
     pass
+
+
+class InvalidMetadataError(UserErrorException):
+    pass


### PR DESCRIPTION
# Description

This pull request focuses on improving error handling in the codebase by introducing a new `InvalidMetadataError` exception class and using it in the relevant files. The most important changes include replacing specific exceptions with the custom `InvalidMetadataError` exception in the `_csharp_executor_proxy.py` file and adding the new `InvalidMetadataError` exception class in the `_errors.py` file.

Main error handling improvements:

* [`src/promptflow/promptflow/batch/_csharp_executor_proxy.py`](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95L101-R106): Improved error handling by replacing `RuntimeError` and `FileNotFoundError` exceptions with a custom `InvalidMetadataError` exception when loading tool metadata from a file or when the file cannot be found.
* [`src/promptflow/promptflow/batch/_errors.py`](diffhunk://#diff-3609320966b5566fd031945b4d3fe19f50ee917354d75a76d6e85b49bb8879efR19-R22): Added a new `InvalidMetadataError` exception class to handle errors related to invalid metadata in the code.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
