### PR TITLE
pf run create: add more details for --data and --flow when used with --file parameter.

### DIFF
--- a/src/promptflow/promptflow/_cli/_pf/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf/_run.py
@@ -72,7 +72,10 @@ def add_run_create_common(subparsers, add_param_list, epilog: Optional[str] = No
         help="Indicates whether to stream the run's logs to the console.",
     )
     add_param_flow = lambda parser: parser.add_argument(  # noqa: E731
-        "--flow", type=str, help="Local path to the flow directory."
+        "--flow",
+        type=str,
+        help="Local path to the flow directory."
+        "If --file is provided, this path should be relative path to the file.",
     )
     add_param_variant = lambda parser: parser.add_argument(  # noqa: E731
         "--variant", type=str, help="Node & variant name in format of ${node_name.variant_name}."
@@ -118,6 +121,8 @@ Examples:
 
 # Create a run with YAML file:
 pf run create -f <yaml-filename>
+# Create a run with YAML file and replace another data in the YAML file:
+pf run create -f <yaml-filename> --data <path-to-new-data-file-relative-to-yaml-file>
 # Create a run from flow directory and reference a run:
 pf run create --flow <path-to-flow-directory> --data <path-to-data-file> --column-mapping groundtruth='${data.answer}' prediction='${run.outputs.category}' --run <run-name> --variant "${summarize_text_content.variant_0}" --stream  # noqa: E501
 # Create a run from an existing run record folder
@@ -126,7 +131,11 @@ pf run create --source <path-to-run-folder>
 
     # data for pf has different help doc than pfazure
     def add_param_data(parser):
-        parser.add_argument("--data", type=str, help="Local path to the data file.")
+        parser.add_argument(
+            "--data",
+            type=str,
+            help="Local path to the data file." "If --file is provided, this path should be relative path to the file.",
+        )
 
     def add_param_source(parser):
         parser.add_argument("--source", type=str, help="Local path to the existing run record folder.")


### PR DESCRIPTION
# Description

pf run create: add more details for --data and --flow when used with --file parameter.
![image](https://github.com/microsoft/promptflow/assets/2208599/d31fe20e-b7c5-4a62-b3f0-27486f65c4da)


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
