### PR TITLE
[promptflow][bugfix] Fix `ValueError: invalid width -1` in `show-details` edge case

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Fix unaligned inputs & outputs or pandas exception during get details against run in Azure.
 - Fix loose flow path validation for run schema.
 - Fix "Without Import Data" in run visualize page results from invalid JSON value (`-Infinity`, `Infinity` and `NaN`).
+- Fix "ValueError: invalid width -1" when show-details against long column(s) in narrow terminal window.
 
 ### Improvements
 

--- a/src/promptflow/promptflow/_cli/_utils.py
+++ b/src/promptflow/promptflow/_cli/_utils.py
@@ -328,7 +328,7 @@ def _calculate_column_widths(df: "DataFrame", terminal_width: int) -> List[int]:
         )
 
     max_col_widths = [index_column_width]  # index column
-    max_col_widths += [column_widths[column] - column_margin[column] for column in df.columns]  # sub margin
+    max_col_widths += [max(column_widths[column] - column_margin[column], 1) for column in df.columns]  # sub margin
     return max_col_widths
 
 

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------
 
 import argparse
+import datetime
 import importlib
 import json
 import os
@@ -10,14 +11,13 @@ import shutil
 import sys
 import tempfile
 import threading
+import time
 from pathlib import Path
 from unittest.mock import patch
-import datetime
 
 import mock
 import pandas as pd
 import pytest
-import time
 
 from promptflow._cli._params import AppendToDictAction
 from promptflow._cli._utils import (
@@ -25,7 +25,7 @@ from promptflow._cli._utils import (
     _calculate_column_widths,
     list_of_dict_to_nested_dict,
 )
-from promptflow._constants import PF_VERSION_CHECK, LAST_CHECK_TIME
+from promptflow._constants import LAST_CHECK_TIME, PF_VERSION_CHECK
 from promptflow._sdk._constants import HOME_PROMPT_FLOW_DIR, PROMPT_FLOW_HOME_DIR_ENV_VAR
 from promptflow._sdk._errors import GenerateFlowToolsJsonError
 from promptflow._sdk._telemetry.logging_handler import get_scrubbed_cloud_role
@@ -41,7 +41,6 @@ from promptflow._sdk._utils import (
 )
 from promptflow._utils.load_data import load_data
 from promptflow._utils.version_hint_utils import check_latest_version
-
 
 TEST_ROOT = Path(__file__).parent.parent.parent
 CONNECTION_ROOT = TEST_ROOT / "test_configs/connections"
@@ -210,14 +209,16 @@ class TestUtils:
             time.sleep(5)
             check_latest_version()
 
-        with patch('promptflow._utils.version_hint_utils.datetime') as mock_datetime, patch(
-                "promptflow._utils.version_hint_utils.check_latest_version", side_effect=mock_check_latest_version):
+        with patch("promptflow._utils.version_hint_utils.datetime") as mock_datetime, patch(
+            "promptflow._utils.version_hint_utils.check_latest_version", side_effect=mock_check_latest_version
+        ):
             from promptflow._sdk._telemetry import monitor_operation
 
             class HintForUpdate:
                 @monitor_operation(activity_name="pf.flows.test")
                 def hint_func(self):
                     return
+
             current_time = datetime.datetime.now()
             mock_datetime.datetime.now.return_value = current_time
             mock_datetime.datetime.strptime.return_value = current_time - datetime.timedelta(days=8)
@@ -387,3 +388,45 @@ class TestCLIUtils:
         terminal_width = 120
         res = _calculate_column_widths(df, terminal_width)
         assert res == [4, 23, 13, 15, 15, 15]
+
+    def test_calculate_column_widths_edge_case(self) -> None:
+        nan = float("nan")
+        data = [
+            {
+                "inputs.groundtruth": "The Alpine Explorer Tent has the highest rainfly waterproof rating at 3000m",
+                "inputs.answer": "There are various tents available in the market that offer different levels of waterproofing. However, one tent that is often highly regarded for its waterproofing capabilities is the MSR Hubba Hubba NX tent. It features a durable rainfly and a bathtub-style floor construction, both of which contribute to its excellent water resistance. It is always recommended to read product specifications and customer reviews to ensure you find a tent that meets your specific waterproofing requirements.",  # noqa: E501
+                "inputs.context": "{${data.context}}",
+                "inputs.question": "Which tent is the most waterproof?",
+                "inputs.metrics": "gpt_groundedness,f1_score",
+                "inputs.line_number": 0,
+                "inputs.ground_truth": "The Alpine Explorer Tent has the highest rainfly waterproof rating at 3000m",
+                "outputs.line_number": 0,
+                "outputs.ada_similarity": nan,
+                "outputs.f1_score": 0.049999999999999996,
+                "outputs.gpt_coherence": nan,
+                "outputs.gpt_fluency": nan,
+                "outputs.gpt_groundedness": 3.0,
+                "outputs.gpt_relevance": nan,
+                "outputs.gpt_similarity": nan,
+            },
+            {
+                "inputs.groundtruth": "The Adventure Dining Table has a higher weight capacity than all of the other camping tables mentioned",  # noqa: E501
+                "inputs.answer": "There are various camping tables available that can hold different amounts of weight. Some heavy-duty camping tables can hold up to 300 pounds or more, while others may have lower weight capacities. It's important to check the specifications of each table before purchasing to ensure it can support the weight you require.",  # noqa: E501
+                "inputs.context": "{${data.context}}",
+                "inputs.question": "Which tent is the most waterproof?",
+                "inputs.metrics": "gpt_groundedness,f1_score",
+                "inputs.ground_truth": "The Alpine Explorer Tent has the highest rainfly waterproof rating at 3000m",
+                "outputs.line_number": 1,
+                "outputs.ada_similarity": nan,
+                "outputs.f1_score": 0.0,
+                "outputs.gpt_coherence": nan,
+                "outputs.gpt_fluency": nan,
+                "outputs.gpt_groundedness": 3.0,
+                "outputs.gpt_relevance": nan,
+                "outputs.gpt_similarity": nan,
+            },
+        ]
+        df = pd.DataFrame(data)
+        terminal_width = 74  # GitHub Actions scenario
+        res = _calculate_column_widths(df, terminal_width)
+        assert res == [4, 1, 13, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -391,6 +391,7 @@ class TestCLIUtils:
 
     def test_calculate_column_widths_edge_case(self) -> None:
         nan = float("nan")
+        # test case comes from examples/flow/evaluation/eval-qna-non-rag
         data = [
             {
                 "inputs.groundtruth": "The Alpine Explorer Tent has the highest rainfly waterproof rating at 3000m",
@@ -429,4 +430,5 @@ class TestCLIUtils:
         df = pd.DataFrame(data)
         terminal_width = 74  # GitHub Actions scenario
         res = _calculate_column_widths(df, terminal_width)
+        # the column width should at least 1 to avoid tabulate error
         assert res == [4, 1, 13, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]


### PR DESCRIPTION
# Description

We use `tabulate` to print pandas DataFrame pretty, it requires the column width to be positive. However, in edge case (long column under narrow terminal window), the column width can be negative. This PR targets to fix this by adding a simple `max(1, <width>` to guarantee the postive value, so that users will not run into `ValueError`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
