### PR TITLE
[promptflow][fundamental] Revert to make Azure test CI required again

### DIFF
--- a/scripts/building/check_enforcer.py
+++ b/scripts/building/check_enforcer.py
@@ -36,7 +36,7 @@ github_workspace = os.path.expanduser("~/promptflow/")
 # Please notice that the key should be the Job Name in the pipeline.
 special_care = {
     "sdk_cli_tests": 4,
-    "sdk_cli_azure_test": 0,
+    "sdk_cli_azure_test": 4,
     # "samples_connections_connection": 0,
 }
 


### PR DESCRIPTION
# Description

As Azure test CI [sdk-cli-azure-test](https://github.com/microsoft/promptflow/actions/workflows/sdk-cli-azure-test.yml) back to normal, this PR targets to revert the check enforcer changes to make it required again.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
