### PR TITLE
[Tool] Fix invalid tool code generated when initializing the script tool with icon

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix loose flow path validation for run schema.
 - Fix "Without Import Data" in run visualize page results from invalid JSON value (`-Infinity`, `Infinity` and `NaN`).
 - Fix "ValueError: invalid width -1" when show-details against long column(s) in narrow terminal window.
+- Fix invalid tool code generated when initializing the script tool with icon.
 
 ### Improvements
 

--- a/src/promptflow/promptflow/_cli/_pf/_init_entry_generators.py
+++ b/src/promptflow/promptflow/_cli/_pf/_init_entry_generators.py
@@ -38,7 +38,7 @@ class BaseGenerator(ABC):
 
     def generate(self) -> str:
         """Generate content based on given template and actual value of template keys."""
-        with open(self.tpl_file) as f:
+        with open(self.tpl_file, encoding="utf-8") as f:
             entry_template = f.read()
             entry_template = Template(entry_template, trim_blocks=True, lstrip_blocks=True)
 

--- a/src/promptflow/promptflow/_cli/_pf/_init_entry_generators.py
+++ b/src/promptflow/promptflow/_cli/_pf/_init_entry_generators.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from jinja2 import Environment, Template, meta
 
+from promptflow._sdk._constants import DEFAULT_ENCODING
 from promptflow._sdk.operations._flow_operations import FlowOperations
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow.contracts.flow import Flow as ExecutableFlow
@@ -38,7 +39,7 @@ class BaseGenerator(ABC):
 
     def generate(self) -> str:
         """Generate content based on given template and actual value of template keys."""
-        with open(self.tpl_file, encoding="utf-8") as f:
+        with open(self.tpl_file, encoding=DEFAULT_ENCODING) as f:
             entry_template = f.read()
             entry_template = Template(entry_template, trim_blocks=True, lstrip_blocks=True)
 
@@ -49,7 +50,7 @@ class BaseGenerator(ABC):
         target = Path(target).resolve()
         action = "Overwriting" if target.exists() else "Creating"
         print(f"{action} {target.resolve()}...")
-        with open(target, "w", encoding="utf-8") as f:
+        with open(target, "w", encoding=DEFAULT_ENCODING) as f:
             f.write(self.generate())
 
 
@@ -288,7 +289,7 @@ class StreamlitFileReplicator:
             "flow_inputs",
             "label",
             "chat_output_name",
-            "is_streaming"
+            "is_streaming",
         ]
 
     def generate_to_file(self, target):

--- a/src/promptflow/promptflow/_cli/_pf/_tool.py
+++ b/src/promptflow/promptflow/_cli/_pf/_tool.py
@@ -147,9 +147,8 @@ def init_tool(args):
     print("Creating tool from scratch...")
     extra_info = list_of_dict_to_dict(args.extra_info)
     icon_path = extra_info.pop("icon", None)
-    if icon_path:
-        if not Path(icon_path).exists():
-            raise UserErrorException(f"Cannot find the icon path {icon_path}.")
+    if icon_path and not Path(icon_path).exists():
+        raise UserErrorException(f"Cannot find the icon path {icon_path}.")
     if args.package:
         package_path = Path(args.package)
         package_name = package_path.stem
@@ -169,6 +168,8 @@ def init_tool(args):
         ToolReadmeGenerator(package_name=package_name, tool_name=args.tool).generate_to_file(package_path / "README.md")
     else:
         script_code_path = Path(".")
+        if icon_path:
+            icon_path = f'r"{icon_path}"'
     # Generate tool script
     ToolPackageGenerator(tool_name=args.tool, icon=icon_path, extra_info=extra_info).generate_to_file(
         script_code_path / f"{args.tool}.py"

--- a/src/promptflow/promptflow/_cli/data/package_tool/README.md.jinja2
+++ b/src/promptflow/promptflow/_cli/data/package_tool/README.md.jinja2
@@ -9,4 +9,4 @@ The directory structure in the package tool is as follows:
         __init__.py
 ```
 
-Please refer to [tool doc](https://microsoft.github.io/promptflow/how-to-guides/develop-a-tool/index.html) for more details about how to deploy a tool.
+Please refer to [tool doc](https://microsoft.github.io/promptflow/how-to-guides/develop-a-tool/index.html) for more details about how to develop a tool.

--- a/src/promptflow/promptflow/_cli/data/package_tool/setup.py.jinja2
+++ b/src/promptflow/promptflow/_cli/data/package_tool/setup.py.jinja2
@@ -8,10 +8,9 @@ setup(
     description="This is my tools package",
     packages=find_packages(),
     entry_points={
-        "package_tools": ["{{ tool_name }} = {{ package_name }}.utils:list_package_tools"],
+        "package_tools": ["{{ package_name }} = {{ package_name }}.utils:list_package_tools"],
     },
     install_requires=[
         "promptflow",
-        "promptflow-tools"
     ]
 )

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1403,6 +1403,20 @@ class TestCli:
                 f"tags={tags}",
                 cwd=temp_dir,
             )
+            # Add a tool script with icon
+            tool_script_name = "tool_func_with_icon"
+            run_pf_command(
+                "tool",
+                "init",
+                "--tool",
+                tool_script_name,
+                "--set",
+                f"icon={icon_path.absolute()}",
+                f"category={category}",
+                f"tags={tags}",
+                cwd=Path(temp_dir) / package_name / package_name,
+            )
+
             sys.path.append(str(package_folder.absolute()))
             spec = importlib.util.spec_from_file_location(
                 f"{package_name}.utils", package_folder / package_name / "utils.py"
@@ -1416,6 +1430,7 @@ class TestCli:
             assert meta["category"] == category
             assert meta["tags"] == tags
             assert meta["icon"].startswith("data:image")
+            assert tools_meta[f"{package_name}.{tool_script_name}.{tool_script_name}"]["icon"].startswith("data:image")
 
             # icon doesn't exist
             with pytest.raises(SystemExit):


### PR DESCRIPTION
# Description
1. Fix invalid tool code generated when initializing the script tool with
![image](https://github.com/microsoft/promptflow/assets/17938940/f2136d6c-7180-4b0f-b204-78f5bbcba3f8)
2. Fix typo in readme

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
