### PR TITLE
[CLI] Support env variables in yaml file for serving.

### DIFF
--- a/src/promptflow/promptflow/_sdk/_serving/app.py
+++ b/src/promptflow/promptflow/_sdk/_serving/app.py
@@ -52,11 +52,10 @@ class PromptflowServingApp(Flask):
             self.flow = self.flow_entity._init_executable()
 
             # enable environment_variables
-            self.environment_variables = kwargs.get("environment_variables", {})
-            os.environ.update(self.environment_variables)
+            environment_variables = kwargs.get("environment_variables", {})
+            os.environ.update(environment_variables)
             default_environment_variables = self.flow.get_environment_variables_with_overrides()
             self.set_default_environment_variables(default_environment_variables)
-            logger.info(f"Environment variable keys: {self.environment_variables.keys()}")
 
             self.flow_name = self.extension.get_flow_name()
             self.flow.name = self.flow_name
@@ -116,7 +115,6 @@ class PromptflowServingApp(Flask):
         for key, value in default_environment_variables.items():
             if key not in os.environ:
                 os.environ[key] = value
-                self.environment_variables[key] = value
 
 
 def add_default_routes(app: PromptflowServingApp):

--- a/src/promptflow/promptflow/_sdk/_serving/app.py
+++ b/src/promptflow/promptflow/_sdk/_serving/app.py
@@ -3,32 +3,33 @@
 # ---------------------------------------------------------
 
 import json
+import logging
 import mimetypes
 import os
-import logging
 from pathlib import Path
+from typing import Dict
 
-from flask import Flask, jsonify, request, g
+from flask import Flask, g, jsonify, request
 
 from promptflow._sdk._load_functions import load_flow
+from promptflow._sdk._serving.extension.extension_factory import ExtensionFactory
 from promptflow._sdk._serving.flow_invoker import FlowInvoker
 from promptflow._sdk._serving.response_creator import ResponseCreator
-from promptflow._sdk._serving.extension.extension_factory import ExtensionFactory
 from promptflow._sdk._serving.utils import (
+    enable_monitoring,
     get_output_fields_to_remove,
     get_sample_json,
     handle_error_to_response,
     load_request_data,
     streaming_response_required,
-    enable_monitoring,
 )
 from promptflow._sdk._utils import setup_user_agent_to_operation_context
 from promptflow._utils.exception_utils import ErrorResponse
 from promptflow._utils.logger_utils import LoggerFactory
 from promptflow._version import VERSION
-from promptflow.storage._run_storage import DummyRunStorage
 from promptflow.contracts.run_info import Status
 from promptflow.exceptions import SystemErrorException
+from promptflow.storage._run_storage import DummyRunStorage
 
 from .swagger import generate_swagger
 
@@ -40,10 +41,6 @@ USER_AGENT = f"promptflow-local-serving/{VERSION}"
 class PromptflowServingApp(Flask):
     def init(self, **kwargs):
         with self.app_context():
-            self.environment_variables = kwargs.get("environment_variables", {})
-            os.environ.update(self.environment_variables)
-            logger.info(f"Environment variable keys: {self.environment_variables.keys()}")
-
             # default to local, can be override when creating the app
             self.extension = ExtensionFactory.create_extension(logger, **kwargs)
 
@@ -53,6 +50,14 @@ class PromptflowServingApp(Flask):
             logger.info(f"Project path: {self.project_path}")
             self.flow_entity = load_flow(self.project_path)
             self.flow = self.flow_entity._init_executable()
+
+            # enable environment_variables
+            self.environment_variables = kwargs.get("environment_variables", {})
+            os.environ.update(self.environment_variables)
+            default_environment_variables = self.flow.get_environment_variables_with_overrides()
+            self.set_default_environment_variables(default_environment_variables)
+            logger.info(f"Environment variable keys: {self.environment_variables.keys()}")
+
             self.flow_name = self.extension.get_flow_name()
             self.flow.name = self.flow_name
             conn_data_override, conn_name_override = self.extension.get_override_connections(self.flow)
@@ -104,6 +109,14 @@ class PromptflowServingApp(Flask):
     def init_swagger(self):
         self.response_fields_to_remove = get_output_fields_to_remove(self.flow, logger)
         self.swagger = generate_swagger(self.flow, self.sample, self.response_fields_to_remove)
+
+    def set_default_environment_variables(self, default_environment_variables: Dict[str, str] = None):
+        if default_environment_variables is None:
+            return
+        for key, value in default_environment_variables.items():
+            if key not in os.environ:
+                os.environ[key] = value
+                self.environment_variables[key] = value
 
 
 def add_default_routes(app: PromptflowServingApp):

--- a/src/promptflow/promptflow/contracts/flow.py
+++ b/src/promptflow/promptflow/contracts/flow.py
@@ -675,9 +675,15 @@ class Flow:
         with open(working_dir / flow_file, "r", encoding=DEFAULT_ENCODING) as fin:
             flow_dag = load_yaml(fin)
         flow = Flow.deserialize(flow_dag)
+        return flow.get_environment_variables_with_overrides(
+            environment_variables_overrides=environment_variables_overrides
+        )
 
+    def get_environment_variables_with_overrides(
+        self, environment_variables_overrides: Dict[str, str] = None
+    ) -> Dict[str, str]:
         environment_variables = {
-            k: (json.dumps(v) if isinstance(v, (dict, list)) else str(v)) for k, v in flow.environment_variables.items()
+            k: (json.dumps(v) if isinstance(v, (dict, list)) else str(v)) for k, v in self.environment_variables.items()
         }
         if environment_variables_overrides is not None:
             for k, v in environment_variables_overrides.items():

--- a/src/promptflow/tests/executor/unittests/contracts/test_flow.py
+++ b/src/promptflow/tests/executor/unittests/contracts/test_flow.py
@@ -66,6 +66,51 @@ class TestFlowContract:
         assert flow.get_connection_input_names_for_node("not_exist") == []
 
     @pytest.mark.parametrize(
+        "flow_folder_name, environment_variables_overrides, except_environment_variables",
+        [
+            pytest.param(
+                "flow_with_environment_variables",
+                {"env2": "runtime_env2", "env10": "aaaaa"},
+                {
+                    "env1": "2",
+                    "env2": "runtime_env2",
+                    "env3": "[1, 2, 3, 4, 5]",
+                    "env4": '{"a": 1, "b": "2"}',
+                    "env10": "aaaaa",
+                },
+                id="LoadEnvVariablesWithOverrides",
+            ),
+            pytest.param(
+                "flow_with_environment_variables",
+                None,
+                {
+                    "env1": "2",
+                    "env2": "spawn",
+                    "env3": "[1, 2, 3, 4, 5]",
+                    "env4": '{"a": 1, "b": "2"}',
+                },
+                id="LoadEnvVariablesWithoutOverrides",
+            ),
+            pytest.param(
+                "simple_hello_world",
+                {"env2": "runtime_env2", "env10": "aaaaa"},
+                {"env2": "runtime_env2", "env10": "aaaaa"},
+                id="LoadEnvVariablesWithoutYamlLevelEnvVariables",
+            ),
+        ],
+    )
+    def test_flow_get_environment_variables_with_overrides(
+        self, flow_folder_name, environment_variables_overrides, except_environment_variables
+    ):
+        flow_folder = get_flow_folder(flow_folder_name)
+        flow_file = "flow.dag.yaml"
+        flow = Flow.from_yaml(flow_file=flow_file, working_dir=flow_folder)
+        merged_environment_variables = flow.get_environment_variables_with_overrides(
+            environment_variables_overrides=environment_variables_overrides,
+        )
+        assert merged_environment_variables == except_environment_variables
+
+    @pytest.mark.parametrize(
         "flow_folder_name, folder_root, flow_file, environment_variables_overrides, except_environment_variables",
         [
             pytest.param(

--- a/src/promptflow/tests/sdk_cli_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_test/conftest.py
@@ -121,14 +121,15 @@ def evaluation_flow_serving_client(mocker: MockerFixture):
     return app.test_client()
 
 
-def create_client_by_model(model_name: str, mocker: MockerFixture, connections: dict = {}, extension_type=None):
+def create_client_by_model(
+    model_name: str, mocker: MockerFixture, connections: dict = {}, extension_type=None, environment_variables={}
+):
     model_path = (Path(MODEL_ROOT) / model_name).resolve().absolute().as_posix()
     mocker.patch.dict(os.environ, {"PROMPTFLOW_PROJECT_PATH": model_path})
     if connections:
         mocker.patch.dict(os.environ, connections)
-    environment_variables = {}
     if extension_type and extension_type == "azureml":
-        environment_variables = {"API_TYPE": "${azure_open_ai_connection.api_type}"}
+        environment_variables["API_TYPE"] = "${azure_open_ai_connection.api_type}"
     app = create_serving_app(environment_variables=environment_variables, extension_type=extension_type)
     app.config.update(
         {
@@ -162,6 +163,15 @@ def serving_client_image_python_flow(mocker: MockerFixture):
 @pytest.fixture
 def serving_client_composite_image_flow(mocker: MockerFixture):
     return create_client_by_model("python_tool_with_composite_image", mocker)
+
+
+@pytest.fixture
+def serving_client_with_environment_variables(mocker: MockerFixture):
+    return create_client_by_model(
+        "flow_with_environment_variables",
+        mocker,
+        environment_variables={"env2": "runtime_env2", "env10": "aaaaa"},
+    )
 
 
 @pytest.fixture

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -333,3 +333,23 @@ def test_list_image_flow(serving_client_composite_image_flow, sample_image):
     assert (
         "data:image/jpg;base64" in response["output"][0]
     ), f"data:image/jpg;base64 not in output list {response['output']}"
+
+
+@pytest.mark.usefixtures("serving_client_with_environment_variables")
+@pytest.mark.e2etest
+def test_flow_with_environment_variables(serving_client_with_environment_variables):
+    except_environment_variables = {
+        "env1": "2",
+        "env2": "runtime_env2",
+        "env3": "[1, 2, 3, 4, 5]",
+        "env4": '{"a": 1, "b": "2"}',
+        "env10": "aaaaa",
+    }
+    for key, value in except_environment_variables.items():
+        response = serving_client_with_environment_variables.post("/score", data=json.dumps({"key": key}))
+        assert (
+            response.status_code == 200
+        ), f"Response code indicates error {response.status_code} - {response.data.decode()}"
+        response = json.loads(response.data.decode())
+        assert {"output"} == response.keys()
+        assert response["output"] == value


### PR DESCRIPTION
# Description

Support env variables in yaml file for local serving.

priority for serving:
environment variables passed in kwargs > env in current running environment >environments defined in flow.dag.yaml

there will be no environment variables passed in kwargs for online serving
online serving allow overriding environment variables via container environment variables, which should be contained in os.environ.
environment variables defined in flow.dag.yaml is the default value, if there's no override value provided, the default value will be used.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
