### PR TITLE
Add resource id in rest connection object

### DIFF
--- a/src/promptflow/promptflow/azure/operations/_arm_connection_operations.py
+++ b/src/promptflow/promptflow/azure/operations/_arm_connection_operations.py
@@ -179,6 +179,10 @@ class ArmConnectionOperations(_ScopeDependentOperations):
                 "api_type": get_case_insensitive_key(properties.metadata, "ApiType"),
                 "api_version": get_case_insensitive_key(properties.metadata, "ApiVersion"),
             }
+            # Note: Resource id is required in some cloud scenario, which is not exposed on sdk/cli entity.
+            resource_id = get_case_insensitive_key(properties.metadata, "ResourceId")
+            if resource_id:
+                value["resource_id"] = resource_id
         elif properties.category == ConnectionCategory.CognitiveSearch:
             value = {
                 "api_key": properties.credentials.key,

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_arm_connection_build.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_arm_connection_build.py
@@ -30,6 +30,7 @@ def test_build_azure_openai_connection_from_rest_object():
                 "azureml.flow.module": "promptflow.connections",
                 "apiType": "azure",
                 "ApiVersion": "2023-07-01-preview",
+                "ResourceId": "mock_id",
             },
         },
     }
@@ -41,6 +42,7 @@ def test_build_azure_openai_connection_from_rest_object():
             "api_key": "***",
             "api_type": "azure",
             "api_version": "2023-07-01-preview",
+            "resource_id": "mock_id",
         },
     }
     build_from_data_and_assert(data, expected)


### PR DESCRIPTION
# Description

Note: this change only effect rest dict returned, the extra 'resource_id' will be removed when converting to sdk connection eneities.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
