### PR TITLE
[promptflow][test] Add a UT for `get_user_identity_info`

### DIFF
--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_flow_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_flow_operations.py
@@ -50,6 +50,9 @@ class TestFlowOperations:
             pf.flows.list(list_view_type="invalid")
 
     def test_get_user_identity_info(self):
+        # we have a fixture "mock_get_user_identity_info" to mock this function during record and replay
+        # as we don't want to deal with token in these modes; meanwhile, considering coverage, add this
+        # unit test to try to cover this code path.
         import jwt
 
         from promptflow.azure._restclient.flow_service_caller import FlowServiceCaller

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -40,33 +40,3 @@ class TestUtils:
         with pytest.raises(UserErrorException) as e:
             FlowServiceCaller(MagicMock(), MagicMock(), MagicMock())
         assert "_FlowServiceCallerFactory" in str(e.value)
-
-    def test_get_user_identity_info(self):
-        import jwt
-
-        from promptflow.azure._restclient.flow_service_caller import FlowServiceCaller
-
-        mock_oid, mock_tid = "mock_oid", "mock_tid"
-
-        def mock_init(*args, **kwargs) -> str:
-            self = args[0]
-            self._credential = None
-
-        def mock_get_arm_token(*args, **kwargs) -> str:
-            return jwt.encode(
-                payload={
-                    "oid": mock_oid,
-                    "tid": mock_tid,
-                },
-                key="",
-            )
-
-        with patch(
-            "promptflow.azure._restclient.flow_service_caller.get_arm_token",
-            new=mock_get_arm_token,
-        ):
-            with patch.object(FlowServiceCaller, "__init__", new=mock_init):
-                service_caller = FlowServiceCaller(workspace=None, credential=None, operation_scope=None)
-                user_object_id, user_tenant_id = service_caller._get_user_identity_info()
-                assert user_object_id == mock_oid
-                assert user_tenant_id == mock_tid

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -40,3 +40,33 @@ class TestUtils:
         with pytest.raises(UserErrorException) as e:
             FlowServiceCaller(MagicMock(), MagicMock(), MagicMock())
         assert "_FlowServiceCallerFactory" in str(e.value)
+
+    def test_get_user_identity_info(self):
+        import jwt
+
+        from promptflow.azure._restclient.flow_service_caller import FlowServiceCaller
+
+        mock_oid, mock_tid = "mock_oid", "mock_tid"
+
+        def mock_init(*args, **kwargs) -> str:
+            self = args[0]
+            self._credential = None
+
+        def mock_get_arm_token(*args, **kwargs) -> str:
+            return jwt.encode(
+                payload={
+                    "oid": mock_oid,
+                    "tid": mock_tid,
+                },
+                key="",
+            )
+
+        with patch(
+            "promptflow.azure._restclient.flow_service_caller.get_arm_token",
+            new=mock_get_arm_token,
+        ):
+            with patch.object(FlowServiceCaller, "__init__", new=mock_init):
+                service_caller = FlowServiceCaller(workspace=None, credential=None, operation_scope=None)
+                user_object_id, user_tenant_id = service_caller._get_user_identity_info()
+                assert user_object_id == mock_oid
+                assert user_tenant_id == mock_tid


### PR DESCRIPTION
# Description

As our replay tests do not expect real credential/token, we mocked function `FlowServiceCaller._get_user_identity_info`. We detect a regression recently in live test because the regression happens inside the function we mocked, so our replay test cannot cover. This PR targets to add a UT (with some mocks) for better coverage.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
