### PR TITLE
[Serving] Upadte logger level after enableing user's environment_variables.

### DIFF
--- a/src/promptflow/promptflow/_sdk/_serving/app.py
+++ b/src/promptflow/promptflow/_sdk/_serving/app.py
@@ -56,6 +56,8 @@ class PromptflowServingApp(Flask):
             os.environ.update(environment_variables)
             default_environment_variables = self.flow.get_environment_variables_with_overrides()
             self.set_default_environment_variables(default_environment_variables)
+            # update logger level after enableing user's environment_variables
+            LoggerFactory.update_logger_level(logger, target_stdout=True)
 
             self.flow_name = self.extension.get_flow_name()
             self.flow.name = self.flow_name

--- a/src/promptflow/promptflow/_utils/logger_utils.py
+++ b/src/promptflow/promptflow/_utils/logger_utils.py
@@ -365,6 +365,15 @@ class LoggerFactory:
         handler.setLevel(verbosity)
         logger.addHandler(handler)
 
+    @staticmethod
+    def update_logger_level(logger: logging.Logger, verbosity: int = logging.INFO, target_stdout: bool = False):
+        verbosity = get_pf_logging_level(default=None) or verbosity
+        stream_handler = LoggerFactory._find_handler(logger, logging.StreamHandler)
+        if not stream_handler:
+            LoggerFactory._add_handler(logger, verbosity, target_stdout)
+        else:
+            stream_handler.setLevel(verbosity)
+
 
 def get_cli_sdk_logger():
     """Get logger used by CLI SDK."""


### PR DESCRIPTION
# Description

The logger level is read from an environment variable PF_LOGGING_LEVEL, and the user may want to change this value.
To ensure that the user's configuration takes effect, we need to upadte logger level after enableing user's environment_variables.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
