### PR TITLE
disable openai built-in retry mechanism for better debuggability and real-time status updates

### DIFF
--- a/src/promptflow-tools/promptflow/tools/aoai.py
+++ b/src/promptflow-tools/promptflow/tools/aoai.py
@@ -21,7 +21,11 @@ class AzureOpenAI(ToolProvider):
         super().__init__()
         self.connection = connection
         self._connection_dict = normalize_connection_config(self.connection)
-        self._client = AzureOpenAIClient(**self._connection_dict)
+        self._client = AzureOpenAIClient(
+            # disable OpenAI's built-in retry mechanism by using our own retry
+            # for better debuggability and real-time status updates.
+            max_retries=0,            
+            **self._connection_dict)
 
     def calculate_cache_string_for_completion(
         self,

--- a/src/promptflow-tools/promptflow/tools/aoai.py
+++ b/src/promptflow-tools/promptflow/tools/aoai.py
@@ -24,7 +24,7 @@ class AzureOpenAI(ToolProvider):
         self._client = AzureOpenAIClient(
             # disable OpenAI's built-in retry mechanism by using our own retry
             # for better debuggability and real-time status updates.
-            max_retries=0,            
+            max_retries=0,
             **self._connection_dict)
 
     def calculate_cache_string_for_completion(

--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -23,7 +23,11 @@ class AzureOpenAI(ToolProvider):
         api_version = self._connection_dict.get("api_version")
         api_key = self._connection_dict.get("api_key")
 
-        self._client = AzureOpenAIClient(azure_endpoint=azure_endpoint, api_version=api_version, api_key=api_key)
+        self._client = AzureOpenAIClient(
+            azure_endpoint=azure_endpoint, api_version=api_version, api_key=api_key,
+            # disable OpenAI's built-in retry mechanism by using our own retry
+            # for better debuggability and real-time status updates.
+            max_retries=0)
 
     @tool(streaming_option_parameter="stream")
     @handle_openai_error()

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -32,7 +32,11 @@ class OpenAI(ToolProvider):
     def __init__(self, connection: OpenAIConnection):
         super().__init__()
         self._connection_dict = normalize_connection_config(connection)
-        self._client = OpenAIClient(**self._connection_dict)
+        self._client = OpenAIClient(
+            # disable OpenAI's built-in retry mechanism by using our own retry
+            # for better debuggability and real-time status updates.
+            max_retries=0,
+            **self._connection_dict)
 
     @tool
     @handle_openai_error()

--- a/src/promptflow-tools/promptflow/tools/openai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/openai_gpt4v.py
@@ -16,7 +16,11 @@ class OpenAI(ToolProvider):
     def __init__(self, connection: OpenAIConnection):
         super().__init__()
         self._connection_dict = normalize_connection_config(connection)
-        self._client = OpenAIClient(**self._connection_dict)
+        self._client = OpenAIClient(
+            # disable OpenAI's built-in retry mechanism by using our own retry
+            # for better debuggability and real-time status updates.
+            max_retries=0,
+            **self._connection_dict)
 
     @tool(streaming_option_parameter="stream")
     @handle_openai_error()

--- a/src/promptflow-tools/tests/test_aoai.py
+++ b/src/promptflow-tools/tests/test_aoai.py
@@ -36,6 +36,8 @@ class TestAOAI:
             chat_history=chat_history,
         )
         assert "additional details" in result.lower()
+        # verify if openai built-in retry mechanism is disabled
+        assert aoai_provider._client.max_retries == 0
 
     def test_aoai_chat_api(self, azure_open_ai_connection, example_prompt_template, chat_history):
         result = chat(

--- a/src/promptflow-tools/tests/test_aoai_gptv.py
+++ b/src/promptflow-tools/tests/test_aoai_gptv.py
@@ -9,7 +9,6 @@ def azure_openai_provider(azure_open_ai_connection) -> AzureOpenAI:
 
 
 @pytest.mark.usefixtures("use_secrets_config_file")
-@pytest.mark.skip("Skipping until we have a Azure OpenAI GPT-4 Vision deployment")
 class TestAzureOpenAIGPT4V:
     def test_openai_gpt4v_chat(self, azure_openai_provider, example_prompt_template_with_image, example_image):
         result = azure_openai_provider.chat(

--- a/src/promptflow-tools/tests/test_aoai_gptv.py
+++ b/src/promptflow-tools/tests/test_aoai_gptv.py
@@ -21,6 +21,8 @@ class TestAzureOpenAIGPT4V:
             image_input=example_image,
         )
         assert "10" == result
+        # verify if openai built-in retry mechanism is disabled
+        assert azure_openai_provider._client.max_retries == 0
 
     def test_openai_gpt4v_stream_chat(self, azure_openai_provider, example_prompt_template_with_image, example_image):
         result = azure_openai_provider.chat(

--- a/src/promptflow-tools/tests/test_openai.py
+++ b/src/promptflow-tools/tests/test_openai.py
@@ -35,6 +35,8 @@ class TestOpenAI:
             chat_history=chat_history,
         )
         assert "trend 2" in result.lower()
+        # verify if openai built-in retry mechanism is disabled
+        assert openai_provider._client.max_retries == 0
 
     def test_openai_stream_chat(self, openai_provider, example_prompt_template, chat_history):
         result = openai_provider.chat(

--- a/src/promptflow-tools/tests/test_openai_gpt4v.py
+++ b/src/promptflow-tools/tests/test_openai_gpt4v.py
@@ -21,6 +21,8 @@ class TestOpenAIGPT4V:
             image_input=example_image,
         )
         assert "10" == result
+        # verify if openai built-in retry mechanism is disabled
+        assert openai_provider._client.max_retries == 0
 
     def test_openai_gpt4v_stream_chat(self, openai_provider, example_prompt_template_with_image, example_image):
         result = openai_provider.chat(


### PR DESCRIPTION
# Description

openai by default will retry twice, but there is no way to get retry status log by its sync api. 
If use async openai api, we can get the log, but the log level is info, we only save warning level log for batch run considering cost.
A more appropriate way is to disable openai builtin retry by setting `max_retries=0`. We have custom retry mechanism which can provide good debuggability experience.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
