### PR TITLE
[promptflow][bugfix] Use `unittest.mock.patch` instead of `MockerFixture`

### DIFF
--- a/src/promptflow/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/conftest.py
@@ -343,14 +343,16 @@ def mock_get_azure_pf_client(mocker: MockerFixture, remote_client) -> None:
 
 
 @pytest.fixture(scope=package_scope_in_live_mode())
-def mock_get_user_identity_info(mocker: MockerFixture, user_object_id: str, tenant_id: str) -> None:
+def mock_get_user_identity_info(user_object_id: str, tenant_id: str) -> None:
     """Mock get user object id and tenant id, currently used in flow list operation."""
     if not is_live():
-        mocker.patch(
+        with patch(
             "promptflow.azure._restclient.flow_service_caller.FlowServiceCaller._get_user_identity_info",
             return_value=(user_object_id, tenant_id),
-        )
-    yield
+        ):
+            yield
+    else:
+        yield
 
 
 @pytest.fixture(scope=package_scope_in_live_mode())
@@ -394,7 +396,6 @@ def created_batch_run_without_llm(pf: PFClient, randstr: Callable[[str], str], r
         flow=f"{FLOWS_DIR}/hello-world",
         data=f"{DATAS_DIR}/webClassification3.jsonl",
         column_mapping={"name": "${data.url}"},
-        runtime=runtime,
         name=name,
         display_name="sdk-cli-test-fixture-batch-run-without-llm",
     )


### PR DESCRIPTION
# Description

`pytest_mock.MockerFixture` is a function scope fixture, this will lead to test error in live test: [sdk-cli-azure-test](https://github.com/microsoft/promptflow/actions/runs/7561447187/job/20589766200#step:12:541). Replace it with `unitest.mock.patch`, so that it can adjust dynamic fixture scope.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
