### PR TITLE
[PromptFlow][Document] Modify default worker count to 4.

### DIFF
--- a/docs/how-to-guides/faq.md
+++ b/docs/how-to-guides/faq.md
@@ -84,7 +84,7 @@ Currently, promptflow supports the following environment variables:
 
 Valid for batch run only. The number of workers determine the degree of parallelism of the batch run execution.
 
-The default value is 4. For large number data rows of batch run, if you want to imporove the efficiency, consider increasing the PF_WORKER_COUNT to improve the concurrency.
+The default value is 4. For large number data rows of batch run, if you want to improve the efficiency, consider increasing the PF_WORKER_COUNT to improve the concurrency.
 
 But there are two points to note:
 

--- a/docs/how-to-guides/faq.md
+++ b/docs/how-to-guides/faq.md
@@ -84,7 +84,7 @@ Currently, promptflow supports the following environment variables:
 
 Valid for batch run only. The number of workers to use for parallel execution of the Flow.
 
-Default value is 16. If you have large number of batch run date row count, and want more efficiency, you can increase the PF_WORKER_COUNT to improve the batch run concurrency, make it run faster.
+Default value is 4. If you have large number of batch run date row count, and want more efficiency, you can increase the PF_WORKER_COUNT to improve the batch run concurrency, make it run faster.
 
 When you modify the concurrency, please consider 2 points:
 

--- a/docs/how-to-guides/faq.md
+++ b/docs/how-to-guides/faq.md
@@ -82,15 +82,15 @@ Currently, promptflow supports the following environment variables:
 
 **PF_WORKER_COUNT** 
 
-Valid for batch run only. The number of workers to use for parallel execution of the Flow.
+Valid for batch run only. The number of workers determine the degree of parallelism of the batch run execution.
 
-Default value is 4. If you have large number of batch run date row count, and want more efficiency, you can increase the PF_WORKER_COUNT to improve the batch run concurrency, make it run faster.
+The default value is 4. For large number data rows of batch run, if you want to imporove the efficiency, consider increasing the PF_WORKER_COUNT to improve the concurrency.
 
-When you modify the concurrency, please consider 2 points:
+But there are two points to note:
 
-First, the concurrency should be not bigger than your batch run data row count.  If not, meaning if the concurrency is bigger, it will run slower due to the time taken for process startup and shutdown.
+1. The concurrency should not exceed the total data rows count of your batch run. If not, the execution may slow down due to additional time spend on process startup and shutdown.
 
-Second, your batch run risks to fail due to rate limit of your LLM endpoint, in this case you need to set up PF_WORKER_COUNT to a smaller number. Take Azure OpenAI endpoint as example, you can go to Azure OpenAI Studio, navigate to Deployment tab, check out the capacity of your endpoints. Then you can refer to this expression to set up the concurrency.
+2. Your batch run may fail if it reaches the rate limit of your LLM endpoint. In such cases, reduce the PF_WORKER_COUNT. Take Azure OpenAI endpoint as example, you can go to Azure OpenAI Studio, navigate to Deployment tab, check out the capacity of your endpoints. Then you can refer to the bellow expression to set up the concurrency.
 
 ```
 PF_WORKER_COUNT <= TPM * duration_seconds / token_count / 60

--- a/docs/how-to-guides/faq.md
+++ b/docs/how-to-guides/faq.md
@@ -82,27 +82,16 @@ Currently, promptflow supports the following environment variables:
 
 **PF_WORKER_COUNT** 
 
-Valid for batch run only. The number of workers determine the degree of parallelism of the batch run execution.
+Effective for batch run only, count of parallel workers in batch run execution.
 
-The default value is 4. For large number data rows of batch run, if you want to improve the efficiency, consider increasing the PF_WORKER_COUNT to improve the concurrency.
+The default value has been updated from 16 to 4.
 
-But there are two points to note:
+Please take the following points into consideration when changing it:
 
-1. The concurrency should not exceed the total data rows count of your batch run. If not, the execution may slow down due to additional time spend on process startup and shutdown.
+1. The concurrency should not exceed the total data rows count. Otherwise, the execution may slow down due to additional time spent on process startup and shutdown.
 
-2. Your batch run may fail if it reaches the rate limit of your LLM endpoint. In such cases, reduce the PF_WORKER_COUNT. Take Azure OpenAI endpoint as example, you can go to Azure OpenAI Studio, navigate to Deployment tab, check out the capacity of your endpoints. Then you can refer to the bellow expression to set up the concurrency.
+2. High parallelism may cause the underlying API call to reach the rate limit of your LLM endpoint. In which case you can decrease the `PF_WORKER_COUNT` or increase the rate limit. Please refer to [this doc](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/quota) on quota management. 
 
-```
-PF_WORKER_COUNT <= TPM * duration_seconds / token_count / 60
-```
-TPM: token per minute, capacity rate limit of your LLM endpoint
-
-duration_seconds: single flow run duration in seconds
-
-token_count: single flow run token count
-
-
-For example, if your endpoint TPM (token per minute) is 50K, the single flow run takes 10k tokens and runs for 30s, pls do not set up PF_WORKER_COUNT bigger than 2. This is a rough estimation. Please also consider collboaration (teammates use the same endpoint at the same time) and tokens consumed in deployed inference endpoints, playground and other cases which might send request to your LLM endpoints.
 
 **PF_BATCH_METHOD**
 

--- a/docs/how-to-guides/faq.md
+++ b/docs/how-to-guides/faq.md
@@ -92,6 +92,17 @@ Please take the following points into consideration when changing it:
 
 2. High parallelism may cause the underlying API call to reach the rate limit of your LLM endpoint. In which case you can decrease the `PF_WORKER_COUNT` or increase the rate limit. Please refer to [this doc](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/quota) on quota management. 
 
+```
+PF_WORKER_COUNT <= TPM * duration_seconds / token_count / 60
+```
+TPM: token per minute, capacity rate limit of your LLM endpoint
+
+duration_seconds: single flow run duration in seconds
+
+token_count: single flow run token count
+
+
+For example, if your endpoint TPM (token per minute) is 50K, the single flow run takes 10k tokens and runs for 30s, pls do not set up PF_WORKER_COUNT bigger than 2. This is a rough estimation. Please also consider collboaration (teammates use the same endpoint at the same time) and tokens consumed in deployed inference endpoints, playground and other cases which might send request to your LLM endpoints.
 
 **PF_BATCH_METHOD**
 

--- a/docs/how-to-guides/faq.md
+++ b/docs/how-to-guides/faq.md
@@ -84,13 +84,13 @@ Currently, promptflow supports the following environment variables:
 
 Effective for batch run only, count of parallel workers in batch run execution.
 
-The default value has been updated from 16 to 4.
+The default value is 4 (was 16 when promptflow<1.4.0)
 
 Please take the following points into consideration when changing it:
 
 1. The concurrency should not exceed the total data rows count. Otherwise, the execution may slow down due to additional time spent on process startup and shutdown.
 
-2. High parallelism may cause the underlying API call to reach the rate limit of your LLM endpoint. In which case you can decrease the `PF_WORKER_COUNT` or increase the rate limit. Please refer to [this doc](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/quota) on quota management. 
+2. High parallelism may cause the underlying API call to reach the rate limit of your LLM endpoint. In which case you can decrease the `PF_WORKER_COUNT` or increase the rate limit. Please refer to [this doc](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/quota) on quota management. Then you can refer to this expression to set up the concurrency.
 
 ```
 PF_WORKER_COUNT <= TPM * duration_seconds / token_count / 60


### PR DESCRIPTION
# Description

The PR  [[PromptFlow][Executor][Internal] Refine process pool.](https://github.com/microsoft/promptflow/pull/1582) modify the default worker count to 4, this PR modify related documents.


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
