### PR TITLE
[Bugfix] Remove loop parameter in semaphore

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -56,7 +56,7 @@ class AsyncNodesScheduler:
 
         # Semaphore should be created in the loop, otherwise it will not work.
         loop = asyncio.get_running_loop()
-        self._semaphore = asyncio.Semaphore(self._node_concurrency, loop=loop)
+        self._semaphore = asyncio.Semaphore(self._node_concurrency)
         monitor = threading.Thread(
             target=monitor_long_running_coroutine,
             args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),


### PR DESCRIPTION
# Description

Remove loop parameter in semaphore to avoid TypeError: As of 3.10, the loop parameter was removed from Semaphore() since it is no longer necessary


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
