### PR TITLE
[PromptFlow][Process Pool] Add environment variable 'PF_BATCH_METHOD' to set the multiprocessing start method.

### DIFF
--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -1,6 +1,5 @@
 import multiprocessing
 import os
-import sys
 import uuid
 from multiprocessing import Queue
 from pathlib import Path
@@ -54,10 +53,10 @@ def get_bulk_inputs(nlinee=4, flow_folder="", sample_inputs_file="", return_dict
     return [get_line_inputs() for _ in range(nlinee)]
 
 
-def execute_in_fork_mode_subprocess(
-    dev_connections, flow_folder, is_set_environ_pf_worker_count, pf_worker_count, n_process
+def execute_in_fork_or_forkserver_mode_subprocess(
+    pf_batch_method, dev_connections, flow_folder, is_set_environ_pf_worker_count, pf_worker_count, n_process
 ):
-    os.environ["PF_BATCH_METHOD"] = "fork"
+    os.environ["PF_BATCH_METHOD"] = pf_batch_method
     if is_set_environ_pf_worker_count:
         os.environ["PF_WORKER_COUNT"] = pf_worker_count
     executor = FlowExecutor.create(
@@ -77,6 +76,7 @@ def execute_in_fork_mode_subprocess(
             False,
             None,
         ) as pool:
+            assert pool._use_fork is True
             assert pool._n_process == n_process
             if is_set_environ_pf_worker_count:
                 mock_logger.info.assert_any_call(
@@ -125,7 +125,7 @@ def execute_in_spawn_mode_subprocess(
                     False,
                     None,
                 ) as pool:
-
+                    assert pool._use_fork is False
                     assert pool._n_process == n_process
                     if is_set_environ_pf_worker_count and is_calculation_smaller_than_set:
                         mock_logger.info.assert_any_call(
@@ -343,8 +343,32 @@ class TestLineExecutionProcessPool:
         if "fork" not in multiprocessing.get_all_start_methods():
             pytest.skip("Unsupported start method: fork")
         p = multiprocessing.Process(
-            target=execute_in_fork_mode_subprocess,
-            args=(dev_connections, flow_folder, is_set_environ_pf_worker_count, pf_worker_count, n_process),
+            target=execute_in_fork_or_forkserver_mode_subprocess,
+            args=("fork", dev_connections, flow_folder, is_set_environ_pf_worker_count, pf_worker_count, n_process),
+        )
+        p.start()
+        p.join()
+        assert p.exitcode == 0
+
+    @pytest.mark.parametrize(
+        ("flow_folder", "is_set_environ_pf_worker_count", "pf_worker_count", "n_process"),
+        [(SAMPLE_FLOW, True, "3", 3), (SAMPLE_FLOW, False, None, 4)],
+    )
+    def test_process_pool_parallelism_in_forkserver_mode(
+        self, dev_connections, flow_folder, is_set_environ_pf_worker_count, pf_worker_count, n_process
+    ):
+        if "forkserver" not in multiprocessing.get_all_start_methods():
+            pytest.skip("Unsupported start method: forkserver")
+        p = multiprocessing.Process(
+            target=execute_in_fork_or_forkserver_mode_subprocess,
+            args=(
+                "forkserver",
+                dev_connections,
+                flow_folder,
+                is_set_environ_pf_worker_count,
+                pf_worker_count,
+                n_process,
+            ),
         )
         p.start()
         p.join()
@@ -365,7 +389,6 @@ class TestLineExecutionProcessPool:
             (SAMPLE_FLOW, False, True, None, 2, 2),
         ],
     )
-    @pytest.mark.skipif(sys.platform == "darwin" or sys.platform.startswith("linux"), reason="Skip on Mac and Linux")
     def test_process_pool_parallelism_in_spawn_mode(
         self,
         dev_connections,


### PR DESCRIPTION
# Description

Add environment variable 'PF_BATCH_METHOD' to set the multiprocessing start method.

1. If set and valid, use the user set.
2. If set but invalid, use the system default.
3. If not set, use the system default.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
