### PR TITLE
Remove unused __wrapped_function

### DIFF
--- a/src/promptflow/promptflow/_core/tracer.py
+++ b/src/promptflow/promptflow/_core/tracer.py
@@ -224,7 +224,6 @@ def _traced(func: Callable = None, *, trace_type=TraceType.FUNCTION) -> Callable
                 raise
 
     wrapped.__original_function = func
-    func.__wrapped_function = wrapped
 
     return wrapped
 

--- a/src/promptflow/tests/executor/unittests/_core/test_tracer.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tracer.py
@@ -252,7 +252,6 @@ class TestTraced:
     def test_original_function_and_wrapped_function_attributes_are_set(self, func):
         traced_func = _traced(func)
         assert getattr(traced_func, "__original_function") == func
-        assert getattr(func, "__wrapped_function") == traced_func
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("func", [sync_func, async_func])

--- a/src/promptflow/tests/sdk_cli_test/recording_utilities/mock_tool.py
+++ b/src/promptflow/tests/sdk_cli_test/recording_utilities/mock_tool.py
@@ -162,7 +162,6 @@ def mock_tool(original_tool):
                 raise UserErrorException(f"Tool type {type} is not supported yet.")
 
             new_f.__original_function = func
-            func.__wrapped_function = new_f
             new_f.__tool = None  # This will be set when generating the tool definition.
             new_f.__name = name
             new_f.__description = description


### PR DESCRIPTION
# Description

Currently, when a function is wrapped with `trace()`, the function will set an attribute `__wrapped_function` to itself to note which function has wrapped it.
However, this operation would fail when the function is a built-in function. i.e.

```python
from promptflow import trace
traced_sum = trace(sum)
```

will get this error:
```
AttributeError: 'builtin_function_or_method' object has no attribute '__wrapped_function'
```

This error is because built-in functions in Python are implemented in C and do not have a `__dict__` attribute where we can set arbitrary attributes.

This attribute is not used in our code, and this PR is to remove it.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
