### PR TITLE
[BugFix][Executor] Fix bug when raising exception in load_multimedia_data

### DIFF
--- a/src/promptflow/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow/promptflow/_utils/multimedia_utils.py
@@ -224,8 +224,9 @@ def load_multimedia_data(inputs: Dict[str, FlowInputDefinition], line_inputs: di
             error_type_and_message = f"({ex.__class__.__name__}) {ex}"
             raise LoadMultimediaDataError(
                 message_format="Failed to load image for input '{key}': {error_type_and_message}",
-                key=key, error_type_and_message=error_type_and_message,
-                target=ex.target
+                key=key,
+                error_type_and_message=error_type_and_message,
+                target=ErrorTarget.EXECUTOR,
             ) from ex
     return updated_inputs
 


### PR DESCRIPTION
# Description

Fix bug when raising exception. When loading multimedia data, we catch all exceptions and raise a `LoadMultimediaDataError`, and we set the target of the exception to the target of original exception, but if the original exception is a python built-in exception, it doesn't have a property target, which may cause problem. We should directly set the target to `ErrorTarget.EXECUTOR`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
