### PR TITLE
[Cli]Add option to skip confirm dialog

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.5.0 (2024.02.06)
+## 1.5.0 (Upcoming)
 
 ### Improvements
 

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.5.0 (2024.02.06)
+
+### Improvements
+
+- [SDK/CLI] For `pf run delete`, `pf connection delete`, introducing an option to skip confirmation prompts.
+
 ## 1.4.0 (2024.01.22)
 
 ### Features Added

--- a/src/promptflow/promptflow/_cli/_pf/_connection.py
+++ b/src/promptflow/promptflow/_cli/_pf/_connection.py
@@ -6,7 +6,13 @@ import argparse
 import json
 from functools import partial
 
-from promptflow._cli._params import add_param_all_results, add_param_max_results, add_param_set, base_params
+from promptflow._cli._params import (
+    add_param_all_results,
+    add_param_max_results,
+    add_param_set,
+    add_param_yes,
+    base_params,
+)
 from promptflow._cli._utils import activate_action, confirm, exception_handler, get_secret_input, print_yellow_warning
 from promptflow._sdk._constants import MAX_LIST_CLI_RESULTS
 from promptflow._sdk._load_functions import load_connection
@@ -121,7 +127,7 @@ pf connection delete -n my_connection_name
         name="delete",
         description="Delete a connection with specific name.",
         epilog=epilog,
-        add_params=[partial(add_param_name, required=True)] + base_params,
+        add_params=[partial(add_param_name, required=True), add_param_yes] + base_params,
         subparsers=subparsers,
         help_message="Delete a connection with specific name.",
         action_param_name="sub_action",
@@ -236,8 +242,8 @@ def update_connection(name, params_override=None):
 
 
 @exception_handler("Connection delete")
-def delete_connection(name):
-    if confirm("Are you sure you want to perform this operation?"):
+def delete_connection(name, skip_confirm: bool = False):
+    if skip_confirm or confirm("Are you sure you want to perform this operation?"):
         _get_pf_client().connections.delete(name)
     else:
         print("The delete operation was canceled.")
@@ -253,4 +259,4 @@ def dispatch_connection_commands(args: argparse.Namespace):
     elif args.sub_action == "update":
         update_connection(args.name, args.params_override)
     elif args.sub_action == "delete":
-        delete_connection(args.name)
+        delete_connection(args.name, args.yes)

--- a/src/promptflow/promptflow/_cli/_pf/_connection.py
+++ b/src/promptflow/promptflow/_cli/_pf/_connection.py
@@ -243,7 +243,7 @@ def update_connection(name, params_override=None):
 
 @exception_handler("Connection delete")
 def delete_connection(name, skip_confirm: bool = False):
-    if skip_confirm or confirm("Are you sure you want to perform this operation?"):
+    if confirm("Are you sure you want to perform this operation?", skip_confirm):
         _get_pf_client().connections.delete(name)
     else:
         print("The delete operation was canceled.")

--- a/src/promptflow/promptflow/_cli/_pf/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf/_flow.py
@@ -352,8 +352,8 @@ def _init_flow_by_template(flow_name, flow_type, overwrite=False, connection=Non
         if not flow_path.is_dir():
             logger.error(f"{flow_path.resolve()} is not a folder.")
             return
-        answer = overwrite or confirm(
-            "The flow folder already exists, do you want to create the flow in this existing folder?"
+        answer = confirm(
+            "The flow folder already exists, do you want to create the flow in this existing folder?", overwrite
         )
         if not answer:
             print("The 'pf init' command has been cancelled.")

--- a/src/promptflow/promptflow/_cli/_pf/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf/_flow.py
@@ -43,7 +43,7 @@ from promptflow._sdk._constants import PROMPT_FLOW_DIR_NAME, ConnectionProvider
 from promptflow._sdk._pf_client import PFClient
 from promptflow._sdk.operations._flow_operations import FlowOperations
 from promptflow._utils.logger_utils import get_cli_sdk_logger
-from promptflow.exceptions import UserErrorException, ErrorTarget
+from promptflow.exceptions import ErrorTarget, UserErrorException
 
 DEFAULT_CONNECTION = "open_ai_connection"
 DEFAULT_DEPLOYMENT = "gpt-35-turbo"
@@ -352,10 +352,8 @@ def _init_flow_by_template(flow_name, flow_type, overwrite=False, connection=Non
         if not flow_path.is_dir():
             logger.error(f"{flow_path.resolve()} is not a folder.")
             return
-        answer = (
-            overwrite
-            if overwrite
-            else confirm("The flow folder already exists, do you want to create the flow in this existing folder?")
+        answer = overwrite or confirm(
+            "The flow folder already exists, do you want to create the flow in this existing folder?"
         )
         if not answer:
             print("The 'pf init' command has been cancelled.")

--- a/src/promptflow/promptflow/_cli/_pf/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf/_run.py
@@ -17,6 +17,7 @@ from promptflow._cli._params import (
     add_param_output_format,
     add_param_run_name,
     add_param_set,
+    add_param_yes,
     add_parser_build,
     base_params,
 )
@@ -353,7 +354,7 @@ Example:
 # Delete a run:
 pf run delete -n "<name>"
 """
-    add_params = [add_param_run_name] + base_params
+    add_params = [add_param_run_name, add_param_yes] + base_params
 
     activate_action(
         name="delete",
@@ -436,7 +437,7 @@ def dispatch_run_commands(args: argparse.Namespace):
     elif args.sub_action == "export":
         export_run(args)
     elif args.sub_action == "delete":
-        delete_run(name=args.name)
+        delete_run(args.name, args.yes)
     else:
         raise ValueError(f"Unrecognized command: {args.sub_action}")
 
@@ -636,8 +637,8 @@ def create_run(create_func: Callable, args):
 
 
 @exception_handler("Delete run")
-def delete_run(name: str) -> None:
-    if confirm("Are you sure to delete run irreversibly?"):
+def delete_run(name: str, skip_confirm: bool = False) -> None:
+    if skip_confirm or confirm("Are you sure to delete run irreversibly?"):
         pf_client = PFClient()
         pf_client.runs.delete(name=name)
     else:

--- a/src/promptflow/promptflow/_cli/_pf/_run.py
+++ b/src/promptflow/promptflow/_cli/_pf/_run.py
@@ -638,7 +638,7 @@ def create_run(create_func: Callable, args):
 
 @exception_handler("Delete run")
 def delete_run(name: str, skip_confirm: bool = False) -> None:
-    if skip_confirm or confirm("Are you sure to delete run irreversibly?"):
+    if confirm("Are you sure to delete run irreversibly?", skip_confirm):
         pf_client = PFClient()
         pf_client.runs.delete(name=name)
     else:

--- a/src/promptflow/promptflow/_cli/_utils.py
+++ b/src/promptflow/promptflow/_cli/_utils.py
@@ -167,7 +167,9 @@ def get_client_for_cli(*, subscription_id: str = None, resource_group_name: str 
     )
 
 
-def confirm(question) -> bool:
+def confirm(question, skip_confirm) -> bool:
+    if skip_confirm:
+        return True
     answer = input(f"{question} [y/n]")
     while answer.lower() not in ["y", "n"]:
         answer = input("Please input 'y' or 'n':")

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1873,6 +1873,32 @@ class TestCli:
         # both runs are deleted and their folders are deleted
         assert not os.path.exists(path_a)
 
+    def test_basic_flow_run_delete_no_confirm(self, monkeypatch, local_client, capfd) -> None:
+        run_id = str(uuid.uuid4())
+        run_pf_command(
+            "run",
+            "create",
+            "--name",
+            run_id,
+            "--flow",
+            f"{FLOWS_DIR}/print_env_var",
+            "--data",
+            f"{DATAS_DIR}/env_var_names.jsonl",
+        )
+        out, _ = capfd.readouterr()
+        assert "Completed" in out
+
+        run_a = local_client.runs.get(name=run_id)
+        local_storage = LocalStorageOperations(run_a)
+        path_a = local_storage.path
+        assert os.path.exists(path_a)
+
+        # delete the run
+        run_pf_command("run", "delete", "--name", f"{run_id}", "-y")
+
+        # both runs are deleted and their folders are deleted
+        assert not os.path.exists(path_a)
+
     def test_basic_flow_run_delete_error(self, monkeypatch) -> None:
         input_list = ["y"]
 


### PR DESCRIPTION
# Description

This pull request primarily focuses on improving the user experience when deleting connections and runs in the `promptflow` CLI by introducing an option to skip confirmation prompts. The changes also include some minor refactoring of the codebase.

User Experience Improvements:

* [`src/promptflow/promptflow/_cli/_pf/_connection.py`](diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L9-R15): Added `add_param_yes` to the import statement, and modified `add_connection_delete` to include `add_param_yes` in the `add_params` list. This allows users to skip the confirmation prompt when deleting a connection. [[1]](diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L9-R15) [[2]](diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L124-R130)
* [`src/promptflow/promptflow/_cli/_pf/_connection.py`](diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L239-R246): Modified `delete_connection` to include a `skip_confirm` parameter, and changed the `confirm` function call to use this parameter. This allows the confirmation prompt to be skipped when `skip_confirm` is `True`. Also, modified `dispatch_connection_commands` to pass `args.yes` as the `skip_confirm` argument when calling `delete_connection`. [[1]](diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L239-R246) [[2]](diffhunk://#diff-cfa3edaa5d4e3792cdc8df6feab431705cc857b143270b1291f9d8a2cc98b695L256-R262)
* [`src/promptflow/promptflow/_cli/_pf/_run.py`](diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeR20): Similar changes as in `connection.py` were made to allow users to skip the confirmation prompt when deleting a run. [[1]](diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeR20) [[2]](diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL356-R357) [[3]](diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL439-R440) [[4]](diffhunk://#diff-0c9317bbb4cca7fd867af1f48509e5e17aa2a22fe09612467bd002ebfc6d1ebeL639-R641)

Codebase Refactoring:

* [`src/promptflow/promptflow/_cli/_pf/_flow.py`](diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL46-R46): Modified the import order to follow the Python style guide, and simplified the `confirm` function call in `_init_flow_by_template`. [[1]](diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL46-R46) [[2]](diffhunk://#diff-dcf2294774837d1f40eae9676737cb8c50f6ac940b7c1392660d17d64a84b93aL355-R356)
* [`src/promptflow/promptflow/_cli/_utils.py`](diffhunk://#diff-906ffb3b9e4ecb92b93ea44e507b8c769016c91dfb47f008b9f54d12b40ab1fdL170-R172): Modified the `confirm` function to return `True` immediately when `skip_confirm` is `True`.

Test Improvements:

* [`src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py`](diffhunk://#diff-7d74ecb42a689e4b7dea2171b91f90db56f79b6efcd70629df1548a1b091f229R1876-R1901): Added a test case `test_basic_flow_run_delete_no_confirm` to test the deletion of a run without confirmation.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
