### PR TITLE
[Bug fix] When calling print(a, b, c) in tools, the log is not as expected.

### DIFF
--- a/src/promptflow/tests/executor/unittests/_core/test_log_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_log_manager.py
@@ -83,6 +83,14 @@ class TestNodeLogManager:
             assert_datetime_prefix(outputs[0], "test")
             assert_datetime_prefix(outputs[1], "test2")
             assert outputs[2] == ""
+    
+    def test_print(self):
+        with NodeLogManager(record_datetime=True) as lm:
+            lm.set_node_context(RUN_ID, NODE_NAME, LINE_NUMBER)
+            print("a", "b", "c")
+            output = lm.get_logs(RUN_ID).get("stdout")
+            lm.clear_node_context(RUN_ID)
+            assert output.endswith("a b c\n") 
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
# Description
[Bug 2815436](https://msdata.visualstudio.com/Vienna/_workitems/edit/2815436): When calling print(a, b, c) in tools, the log is not shown in the same line.

* Bug impact: when user prints in tools by `print("a", "b", "c")`, the log is 
```
 [node in line 1 (index starts from 0)] stdout> a
 [node in line 1 (index starts from 0)] stdout> 
 [node in line 1 (index starts from 0)] stdout> b
 [node in line 1 (index starts from 0)] stdout> 
 [node in line 1 (index starts from 0)] stdout> c
```
This is not unexpected.

* Bug fix: After fix, the log is
```
 [node in line 1 (index starts from 0)] stdout> a
 [node in line 1 (index starts from 0)] stdout> b
 [node in line 1 (index starts from 0)] stdout> c
```

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
