### PR TITLE
[promptflow][internal] Support configurable additional flow test output folder

### DIFF
--- a/src/promptflow/promptflow/_cli/_pf/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf/_flow.py
@@ -225,6 +225,9 @@ pf flow test --flow my-awesome-flow --node node_name --interactive
     )
     add_param_ui = lambda parser: parser.add_argument("--ui", action="store_true", help=argparse.SUPPRESS)  # noqa: E731
     add_param_input = lambda parser: parser.add_argument("--input", type=str, help=argparse.SUPPRESS)  # noqa: E731
+    add_param_x = lambda parser: parser.add_argument(  # noqa: E731
+        "--x", type=str, default=None, required=False, help=argparse.SUPPRESS
+    )
 
     add_params = [
         add_param_flow,
@@ -237,6 +240,7 @@ pf flow test --flow my-awesome-flow --node node_name --interactive
         add_param_multi_modal,
         add_param_ui,
         add_param_config,
+        add_param_x,
     ] + base_params
     activate_action(
         name="test",
@@ -426,6 +430,7 @@ def test_flow(args):
                 allow_generator_output=False,
                 stream_output=False,
                 dump_test_result=True,
+                x=args.x,
             )
             # Print flow/node test result
             if isinstance(result, dict):

--- a/src/promptflow/promptflow/_cli/_pf/_flow.py
+++ b/src/promptflow/promptflow/_cli/_pf/_flow.py
@@ -225,8 +225,8 @@ pf flow test --flow my-awesome-flow --node node_name --interactive
     )
     add_param_ui = lambda parser: parser.add_argument("--ui", action="store_true", help=argparse.SUPPRESS)  # noqa: E731
     add_param_input = lambda parser: parser.add_argument("--input", type=str, help=argparse.SUPPRESS)  # noqa: E731
-    add_param_x = lambda parser: parser.add_argument(  # noqa: E731
-        "--x", type=str, default=None, required=False, help=argparse.SUPPRESS
+    add_param_detail = lambda parser: parser.add_argument(  # noqa: E731
+        "--detail", type=str, default=None, required=False, help=argparse.SUPPRESS
     )
 
     add_params = [
@@ -240,7 +240,7 @@ pf flow test --flow my-awesome-flow --node node_name --interactive
         add_param_multi_modal,
         add_param_ui,
         add_param_config,
-        add_param_x,
+        add_param_detail,
     ] + base_params
     activate_action(
         name="test",
@@ -430,7 +430,7 @@ def test_flow(args):
                 allow_generator_output=False,
                 stream_output=False,
                 dump_test_result=True,
-                x=args.x,
+                detail=args.detail,
             )
             # Print flow/node test result
             if isinstance(result, dict):

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -943,13 +943,14 @@ def refresh_connections_dir(connection_spec_files, connection_template_yamls):
                     dump_yaml(yaml_data, f)
 
 
-def dump_flow_result(flow_folder, prefix, flow_result=None, node_result=None):
+def dump_flow_result(flow_folder, prefix, flow_result=None, node_result=None, custom_path=None):
     """Dump flow result for extension.
 
     :param flow_folder: The flow folder.
     :param prefix: The file prefix.
     :param flow_result: The flow result returned by exec_line.
     :param node_result: The node result when test node returned by load_and_exec_node.
+    :param custom_path: The custom path to dump flow result.
     """
     if flow_result:
         flow_serialize_result = {
@@ -961,7 +962,8 @@ def dump_flow_result(flow_folder, prefix, flow_result=None, node_result=None):
             "flow_runs": [],
             "node_runs": [serialize(node_result)],
         }
-    dump_folder = Path(flow_folder) / PROMPT_FLOW_DIR_NAME
+
+    dump_folder = Path(flow_folder) / PROMPT_FLOW_DIR_NAME if custom_path is None else Path(custom_path)
     dump_folder.mkdir(parents=True, exist_ok=True)
 
     with open(dump_folder / f"{prefix}.detail.json", "w", encoding=DEFAULT_ENCODING) as f:

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -100,7 +100,7 @@ class FlowOperations(TelemetryMixin):
                     prefix = "flow"
                 dump_flow_result(flow_folder=flow.code, flow_result=result, prefix=prefix)
 
-        additional_output_path = kwargs.get("x", None)
+        additional_output_path = kwargs.get("detail", None)
         if additional_output_path:
             if not dump_test_result:
                 flow = load_flow(flow)

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -100,6 +100,30 @@ class FlowOperations(TelemetryMixin):
                     prefix = "flow"
                 dump_flow_result(flow_folder=flow.code, flow_result=result, prefix=prefix)
 
+        additional_output_path = kwargs.get("x", None)
+        if additional_output_path:
+            if not dump_test_result:
+                flow = load_flow(flow)
+            if node:
+                dump_flow_result(
+                    flow_folder=flow.code,
+                    node_result=result,
+                    prefix=f"flow-{node}.node",
+                    custom_path=additional_output_path,
+                )
+            else:
+                if variant:
+                    tuning_node, node_variant = parse_variant(variant)
+                    prefix = f"flow-{tuning_node}-{node_variant}"
+                else:
+                    prefix = "flow"
+                dump_flow_result(
+                    flow_folder=flow.code,
+                    flow_result=result,
+                    prefix=prefix,
+                    custom_path=additional_output_path,
+                )
+
         TestSubmitter._raise_error_when_test_failed(result, show_trace=node is not None)
         return result.output
 

--- a/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_flow_operations.py
@@ -5,6 +5,7 @@ import contextlib
 import glob
 import json
 import os
+import shutil
 import subprocess
 import sys
 from importlib.metadata import version
@@ -13,7 +14,13 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Tuple, Union
 
 from promptflow._constants import LANGUAGE_KEY, FlowLanguage
-from promptflow._sdk._constants import CHAT_HISTORY, DEFAULT_ENCODING, FLOW_TOOLS_JSON_GEN_TIMEOUT, LOCAL_MGMT_DB_PATH
+from promptflow._sdk._constants import (
+    CHAT_HISTORY,
+    DEFAULT_ENCODING,
+    FLOW_TOOLS_JSON_GEN_TIMEOUT,
+    LOCAL_MGMT_DB_PATH,
+    PROMPT_FLOW_DIR_NAME,
+)
 from promptflow._sdk._load_functions import load_flow
 from promptflow._sdk._submitter import TestSubmitter
 from promptflow._sdk._submitter.utils import SubmitterHelper
@@ -105,24 +112,34 @@ class FlowOperations(TelemetryMixin):
             if not dump_test_result:
                 flow = load_flow(flow)
             if node:
+                # detail and output
                 dump_flow_result(
                     flow_folder=flow.code,
                     node_result=result,
                     prefix=f"flow-{node}.node",
                     custom_path=additional_output_path,
                 )
+                # log
+                log_src_path = Path(flow.code) / PROMPT_FLOW_DIR_NAME / f"{node}.node.log"
+                log_dst_path = Path(additional_output_path) / f"{node}.node.log"
+                shutil.copy(log_src_path, log_dst_path)
             else:
                 if variant:
                     tuning_node, node_variant = parse_variant(variant)
                     prefix = f"flow-{tuning_node}-{node_variant}"
                 else:
                     prefix = "flow"
+                # detail and output
                 dump_flow_result(
                     flow_folder=flow.code,
                     flow_result=result,
                     prefix=prefix,
                     custom_path=additional_output_path,
                 )
+                # log
+                log_src_path = Path(flow.code) / PROMPT_FLOW_DIR_NAME / "flow.log"
+                log_dst_path = Path(additional_output_path) / "flow.log"
+                shutil.copy(log_src_path, log_dst_path)
 
         TestSubmitter._raise_error_when_test_failed(result, show_trace=node is not None)
         return result.output

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -2008,16 +2008,15 @@ class TestCli:
             "--detail",
             Path(tmpdir).as_posix(),
         )
-        # when specify parameter `detail`, detail and output will be saved in both
+        # when specify parameter `detail`, detail, output and log will be saved in both
         # the specified folder and ".promptflow" under flow folder
         for parent_folder in [
             Path(FLOWS_DIR) / "web_classification" / ".promptflow",
             Path(tmpdir),
         ]:
-            detail_path = parent_folder / "flow.detail.json"
-            output_path = parent_folder / "flow.output.json"
-            assert detail_path.is_file()
-            assert output_path.is_file()
+            for filename in ["flow.detail.json", "flow.output.json", "flow.log"]:
+                path = parent_folder / filename
+                assert path.is_file()
 
     def test_pf_flow_test_single_node_with_detail(self, tmpdir):
         node_name = "fetch_text_content_from_url"
@@ -2037,13 +2036,16 @@ class TestCli:
         output_path = Path(FLOWS_DIR) / "web_classification" / ".promptflow" / f"flow-{node_name}.node.detail.json"
         assert output_path.exists()
 
-        # when specify parameter `detail`, node detail and output will be saved in both
+        # when specify parameter `detail`, node detail, output and log will be saved in both
         # the specified folder and ".promptflow" under flow folder
         for parent_folder in [
             Path(FLOWS_DIR) / "web_classification" / ".promptflow",
             Path(tmpdir),
         ]:
-            detail_path = parent_folder / f"flow-{node_name}.node.detail.json"
-            output_path = parent_folder / f"flow-{node_name}.node.output.json"
-            assert detail_path.is_file()
-            assert output_path.is_file()
+            for filename in [
+                f"flow-{node_name}.node.detail.json",
+                f"flow-{node_name}.node.output.json",
+                f"{node_name}.node.log",
+            ]:
+                path = parent_folder / filename
+                assert path.is_file()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -1994,3 +1994,56 @@ class TestCli:
                 "run",
                 "list",
             )
+
+    def test_pf_flow_test_with_detail(self, tmpdir):
+        run_pf_command(
+            "flow",
+            "test",
+            "--flow",
+            f"{FLOWS_DIR}/web_classification",
+            "--inputs",
+            "url=https://www.youtube.com/watch?v=o5ZQyXaAv1g",
+            "answer=Channel",
+            "evidence=Url",
+            "--detail",
+            Path(tmpdir).as_posix(),
+        )
+        # when specify parameter `detail`, detail and output will be saved in both
+        # the specified folder and ".promptflow" under flow folder
+        for parent_folder in [
+            Path(FLOWS_DIR) / "web_classification" / ".promptflow",
+            Path(tmpdir),
+        ]:
+            detail_path = parent_folder / "flow.detail.json"
+            output_path = parent_folder / "flow.output.json"
+            assert detail_path.is_file()
+            assert output_path.is_file()
+
+    def test_pf_flow_test_single_node_with_detail(self, tmpdir):
+        node_name = "fetch_text_content_from_url"
+        run_pf_command(
+            "flow",
+            "test",
+            "--flow",
+            f"{FLOWS_DIR}/web_classification",
+            "--inputs",
+            "inputs.url="
+            "https://www.microsoft.com/en-us/d/xbox-wireless-controller-stellar-shift-special-edition/94fbjc7h0h6h",
+            "--node",
+            node_name,
+            "--detail",
+            Path(tmpdir).as_posix(),
+        )
+        output_path = Path(FLOWS_DIR) / "web_classification" / ".promptflow" / f"flow-{node_name}.node.detail.json"
+        assert output_path.exists()
+
+        # when specify parameter `detail`, node detail and output will be saved in both
+        # the specified folder and ".promptflow" under flow folder
+        for parent_folder in [
+            Path(FLOWS_DIR) / "web_classification" / ".promptflow",
+            Path(tmpdir),
+        ]:
+            detail_path = parent_folder / f"flow-{node_name}.node.detail.json"
+            output_path = parent_folder / f"flow-{node_name}.node.output.json"
+            assert detail_path.is_file()
+            assert output_path.is_file()


### PR DESCRIPTION
# Description

For `pf flow test`, this _internal_ PR targets to support suppress parameter `--detail` to specify additional command artifact output path:

- test flow: `pf flow test --flow . --detail </path/to/somewhere>`
- test a single node in the flow: `pf flow test --flow . --node fetch_text_content_from_url --inputs inputs.url=https://www.microsoft.com/en-us/d/xbox-wireless-controller-stellar-shift-special-edition/94fbjc7h0h6h --detail </path/to/somewhere>`

Prompt flow will **ALSO** persist command artifact (detail and output JSON, plus log) under specified path.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
