### PR TITLE
[PromptFlow][ProcessPool] Solve spawned fork process manager hangs for a long time when parameters are passed incorrectly.

### DIFF
--- a/src/promptflow/promptflow/executor/_errors.py
+++ b/src/promptflow/promptflow/executor/_errors.py
@@ -210,6 +210,13 @@ class ProcessInfoObtainedTimeout(SystemErrorException):
         super().__init__(message=f"Failed to get process info after {timeout} seconds", target=ErrorTarget.EXECUTOR)
 
 
+class SpawnedForkProcessManagerStartFailure(SystemErrorException):
+    """Exception raised when failed to start spawned fork process manager."""
+
+    def __init__(self):
+        super().__init__(message="Failed to start spawned fork process manager", target=ErrorTarget.EXECUTOR)
+
+
 class EmptyLLMApiMapping(UserErrorException):
     """Exception raised when connection_type_to_api_mapping is empty and llm node provider can't be inferred"""
 

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -457,6 +457,7 @@ class LineExecutionProcessPool:
             while time.time() - ensure_spawn_process_healthy_start_time < 6:
                 if psutil.Process(self._managed_process_id).status() == "zombie":
                     return
+                time.sleep(1)
 
         with RepeatLogTimer(
             interval_seconds=self._log_interval,

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -205,8 +205,6 @@ class LineExecutionProcessPool:
                 # try again.
                 time.sleep(1)
                 continue
-            except queue.Empty:
-                pass
             except Exception as e:
                 raise Exception(f"Unexpected error occurred while get process info. Exception: {e}")
 

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -192,21 +192,10 @@ class LineExecutionProcessPool:
             self._monitor_pool.close()
             self._monitor_pool.join()
 
-    def _check_thread_pool_termination_signal(self):
-        try:
-            end_signal = self._end_thread_pool_signal_queue.get(timeout=1)
-            if end_signal == "end":
-                return True
-        except queue.Empty:
-            return False
-
     def _get_process_info(self, index):
         start_time = time.time()
         while True:
             try:
-                is_thread_pool_terminated = self._check_thread_pool_termination_signal()
-                if is_thread_pool_terminated:
-                    break
                 if time.time() - start_time > self._PROCESS_INFO_OBTAINED_TIMEOUT:
                     raise ProcessInfoObtainedTimeout(self._PROCESS_INFO_OBTAINED_TIMEOUT)
                 # Try to get process id and name from the process_info

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -249,6 +249,7 @@ class LineExecutionProcessPool:
         # 2. The batch run has not reached the batch timeout limit.
         while not self._batch_timeout_expired(batch_start_time):
             try:
+                self._processes_manager.ensure_healthy()
                 args = task_queue.get(timeout=1)
             except queue.Empty:
                 break

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -246,8 +246,8 @@ class LineExecutionProcessPool:
         # 1. The task queue is not empty, meaning there are lines yet to be executed.
         # 2. The batch run has not reached the batch timeout limit.
         while not self._batch_timeout_expired(batch_start_time):
+            self._processes_manager.ensure_healthy()
             try:
-                self._processes_manager.ensure_healthy()
                 args = task_queue.get(timeout=1)
             except queue.Empty:
                 break

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -170,8 +170,8 @@ class LineExecutionProcessPool:
                 self._flow_create_kwargs,
                 **common_kwargs,
             )
-            # For fork mode, it's necessary to determine whether the spawn process that created the fork process is
-            # running properly. Therefore, we have obtained the spawn process object here.
+            # In fork mode, it's necessary to determine whether the spawn process that created the fork process is
+            # running properly. Therefore, we obtain the spawn process id here to get the process status.
             self._managed_process_id = self._processes_manager.start_processes()
         else:
             executor_creation_func = partial(FlowExecutor.create, **self._flow_create_kwargs)
@@ -516,8 +516,6 @@ class LineExecutionProcessPool:
                     async_result.get()
                 except KeyboardInterrupt:
                     raise
-                except queue.Empty:
-                    pass
             except PromptflowException:
                 raise
             except Exception as e:

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -194,6 +194,7 @@ class LineExecutionProcessPool:
         start_time = time.time()
         while True:
             try:
+                self._processes_manager.ensure_healthy()
                 if time.time() - start_time > self._PROCESS_INFO_OBTAINED_TIMEOUT:
                     raise ProcessInfoObtainedTimeout(self._PROCESS_INFO_OBTAINED_TIMEOUT)
                 # Try to get process id and name from the process_info
@@ -205,6 +206,8 @@ class LineExecutionProcessPool:
                 # try again.
                 time.sleep(1)
                 continue
+            except PromptflowException:
+                raise
             except Exception as e:
                 raise Exception(f"Unexpected error occurred while get process info. Exception: {e}")
 

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -151,7 +151,6 @@ class LineExecutionProcessPool:
         self._input_queues = [manager.Queue() for _ in range(self._n_process)]
         self._output_queues = [manager.Queue() for _ in range(self._n_process)]
         self._control_signal_queue = manager.Queue()
-        self._end_thread_pool_signal_queue = Queue()
         self._process_info = manager.dict()
 
         # when using fork, we first create a process with spawn method to establish a clean environment

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -193,8 +193,8 @@ class LineExecutionProcessPool:
     def _get_process_info(self, index):
         start_time = time.time()
         while True:
+            self._processes_manager.ensure_healthy()
             try:
-                self._processes_manager.ensure_healthy()
                 if time.time() - start_time > self._PROCESS_INFO_OBTAINED_TIMEOUT:
                     raise ProcessInfoObtainedTimeout(self._PROCESS_INFO_OBTAINED_TIMEOUT)
                 # Try to get process id and name from the process_info
@@ -206,8 +206,6 @@ class LineExecutionProcessPool:
                 # try again.
                 time.sleep(1)
                 continue
-            except PromptflowException:
-                raise
             except Exception as e:
                 raise Exception(f"Unexpected error occurred while get process info. Exception: {e}")
 

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -462,6 +462,7 @@ class LineExecutionProcessPool:
                 # within the specified time, its state will be 'zombie'. So, If the spawned process is in 'zombie'
                 # state, return without continuing execution.
                 if psutil.Process(self._spawned_fork_process_manager_pid).status() == "zombie":
+                    bulk_logger.error("The spawned fork process manager failed to start.")
                     return
                 time.sleep(1)
 

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -466,9 +466,9 @@ class LineExecutionProcessPool:
         # If the spawned process is no longer running, exit the main proccess.
         if self._use_fork:
             ensure_spawn_process_healthy_start_time = time.time()
-            while time.time() - ensure_spawn_process_healthy_start_time < 5:
+            while time.time() - ensure_spawn_process_healthy_start_time < 6:
                 if psutil.Process(self._managed_process_id).status() == "zombie":
-                    break
+                    return
 
         with RepeatLogTimer(
             interval_seconds=self._log_interval,

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -232,7 +232,7 @@ class ForkProcessManager(AbstractProcessManager):
         """
         context = multiprocessing.get_context("spawn")
         process = context.Process(
-            target=create_spawned_fork_process_manager_wrapper,
+            target=create_spawned_fork_process_manager,
             args=(
                 self._log_context_initialization_func,
                 self._current_operation_context,
@@ -397,13 +397,6 @@ class SpawnedForkProcessManager(AbstractProcessManager):
             self.restart_process(i)
         elif control_signal == ProcessControlSignal.START:
             self.new_process(i)
-
-
-def create_spawned_fork_process_manager_wrapper(*args, **kwargs):
-    try:
-        create_spawned_fork_process_manager(*args, **kwargs)
-    except Exception as e:
-        bulk_logger.error(f"Error occurred when create spawned fork process manager: {e}")
 
 
 def create_spawned_fork_process_manager(

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -375,7 +375,6 @@ def create_spawned_fork_process_manager_wrapper(*args, **kwargs):
         create_spawned_fork_process_manager(*args, **kwargs)
     except Exception as e:
         bulk_logger.error(f"Error occurred when create spawned fork process manager: {e}")
-        raise e
 
 
 def create_spawned_fork_process_manager(

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -193,7 +193,9 @@ class SpawnProcessManager(AbstractProcessManager):
         """
         Checks the health of the managed processes.
 
-        Note: By default, all processes are assumed to be healthy in spawned mode.
+        Note:
+        Health checks for spawn mode processes are currently not performed.
+        Add detailed checks in this function if needed in the future.
         """
         pass
 

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -277,7 +277,7 @@ class ForkProcessManager(AbstractProcessManager):
 
     def ensure_healthy(self):
         start_time = time.time()
-        while time.time() - start_time < 6:
+        while time.time() - start_time < 3:
             # A 'zombie' process is a process that has finished running but still remains in
             # the process table, waiting for its parent process to collect and handle its exit status.
             # The normal state of the spawned process is 'running'. If the process does not start successfully

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -1,7 +1,6 @@
 import multiprocessing
 import queue
 import signal
-import time
 from dataclasses import dataclass
 from enum import Enum
 from functools import partial
@@ -276,17 +275,14 @@ class ForkProcessManager(AbstractProcessManager):
         self._control_signal_queue.put((ProcessControlSignal.START, i))
 
     def ensure_healthy(self):
-        start_time = time.time()
-        while time.time() - start_time < 3:
-            # A 'zombie' process is a process that has finished running but still remains in
-            # the process table, waiting for its parent process to collect and handle its exit status.
-            # The normal state of the spawned process is 'running'. If the process does not start successfully
-            # within the specified time, its state will be 'zombie'.
-            if psutil.Process(self._spawned_fork_process_manager_pid).status() == "zombie":
-                bulk_logger.error("The spawned fork process manager failed to start.")
-                ex = SpawnedForkProcessManagerStartFailure()
-                raise ex
-            time.sleep(1)
+        # A 'zombie' process is a process that has finished running but still remains in
+        # the process table, waiting for its parent process to collect and handle its exit status.
+        # The normal state of the spawned process is 'running'. If the process does not start successfully
+        # or exit unexpectedly, its state will be 'zombie'.
+        if psutil.Process(self._spawned_fork_process_manager_pid).status() == "zombie":
+            bulk_logger.error("The spawned fork process manager failed to start.")
+            ex = SpawnedForkProcessManagerStartFailure()
+            raise ex
 
 
 class SpawnedForkProcessManager(AbstractProcessManager):

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -226,7 +226,7 @@ class ForkProcessManager(AbstractProcessManager):
             ),
         )
         process.start()
-        return process.pid
+        self._spawned_fork_process_manager_pid = process.pid
 
     def restart_process(self, i):
         """

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -22,7 +22,7 @@ from promptflow.executor._line_execution_process_pool import (
     get_available_max_worker_count,
     log_process_status,
 )
-from promptflow.executor._process_manager import create_spawned_fork_process_manager_wrapper
+from promptflow.executor._process_manager import create_spawned_fork_process_manager
 from promptflow.executor._result import LineResult
 
 from ...utils import get_flow_sample_inputs, get_yaml_file
@@ -191,8 +191,8 @@ def not_set_environment_in_subprocess(dev_connections):
     assert use_fork == (multiprocessing.get_start_method() == "fork")
 
 
-def custom_create_spawned_fork_process_manager_wrapper(*args, **kwargs):
-    create_spawned_fork_process_manager_wrapper("test", *args, **kwargs)
+def custom_create_spawned_fork_process_manager(*args, **kwargs):
+    create_spawned_fork_process_manager("test", *args, **kwargs)
 
 
 @pytest.mark.unittest
@@ -423,8 +423,8 @@ class TestLineExecutionProcessPool:
         ],
     )
     @patch(
-        "promptflow.executor._process_manager.create_spawned_fork_process_manager_wrapper",
-        custom_create_spawned_fork_process_manager_wrapper,
+        "promptflow.executor._process_manager.create_spawned_fork_process_manager",
+        custom_create_spawned_fork_process_manager,
     )
     def test_spawned_fork_process_manager_crashed_in_fork_mode(self, flow_folder, dev_connections):
         executor = FlowExecutor.create(get_yaml_file(flow_folder), dev_connections)

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -436,8 +436,6 @@ class TestLineExecutionProcessPool:
             executor,
             nlines,
             run_id,
-            "",
-            False,
             None,
         ) as pool:
             managed_process_id = pool._managed_process_id

--- a/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
+++ b/src/promptflow/tests/executor/unittests/processpool/test_line_execution_process_pool.py
@@ -438,7 +438,7 @@ class TestLineExecutionProcessPool:
             run_id,
             None,
         ) as pool:
-            managed_process_id = pool._managed_process_id
+            managed_process_id = pool._spawned_fork_process_manager_pid
             pool.run(zip(range(nlines), bulk_inputs))
             assert psutil.Process(managed_process_id).status() == "zombie"
 

--- a/src/promptflow/tests/sdk_cli_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_test/conftest.py
@@ -17,7 +17,10 @@ from promptflow._sdk._serving.app import create_app as create_serving_app
 from promptflow._sdk.entities import AzureOpenAIConnection as AzureOpenAIConnectionEntity
 from promptflow._sdk.entities._connection import CustomConnection, _Connection
 from promptflow.executor._line_execution_process_pool import _process_wrapper
-from promptflow.executor._process_manager import create_spawned_fork_process_manager
+from promptflow.executor._process_manager import (
+    create_spawned_fork_process_manager,
+    create_spawned_fork_process_manager_wrapper,
+)
 
 from .recording_utilities import RecordStorage, mock_tool, recording_array_extend, recording_array_reset
 
@@ -209,6 +212,8 @@ class MockSpawnProcess(SpawnProcess):
             target = _mock_process_wrapper
         if target == create_spawned_fork_process_manager:
             target = _mock_create_spawned_fork_process_manager
+        if target == create_spawned_fork_process_manager_wrapper:
+            target = _mock_create_spawned_fork_process_manager_wrapper
         super().__init__(group, target, *args, **kwargs)
 
 
@@ -262,3 +267,8 @@ def _mock_process_wrapper(*args, **kwargs):
 def _mock_create_spawned_fork_process_manager(*args, **kwargs):
     setup_recording_injection_if_enabled()
     return create_spawned_fork_process_manager(*args, **kwargs)
+
+
+def _mock_create_spawned_fork_process_manager_wrapper(*args, **kwargs):
+    setup_recording_injection_if_enabled()
+    return create_spawned_fork_process_manager_wrapper(*args, **kwargs)

--- a/src/promptflow/tests/sdk_cli_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_test/conftest.py
@@ -17,10 +17,7 @@ from promptflow._sdk._serving.app import create_app as create_serving_app
 from promptflow._sdk.entities import AzureOpenAIConnection as AzureOpenAIConnectionEntity
 from promptflow._sdk.entities._connection import CustomConnection, _Connection
 from promptflow.executor._line_execution_process_pool import _process_wrapper
-from promptflow.executor._process_manager import (
-    create_spawned_fork_process_manager,
-    create_spawned_fork_process_manager_wrapper,
-)
+from promptflow.executor._process_manager import create_spawned_fork_process_manager
 
 from .recording_utilities import RecordStorage, mock_tool, recording_array_extend, recording_array_reset
 
@@ -212,8 +209,6 @@ class MockSpawnProcess(SpawnProcess):
             target = _mock_process_wrapper
         if target == create_spawned_fork_process_manager:
             target = _mock_create_spawned_fork_process_manager
-        if target == create_spawned_fork_process_manager_wrapper:
-            target = _mock_create_spawned_fork_process_manager_wrapper
         super().__init__(group, target, *args, **kwargs)
 
 
@@ -267,8 +262,3 @@ def _mock_process_wrapper(*args, **kwargs):
 def _mock_create_spawned_fork_process_manager(*args, **kwargs):
     setup_recording_injection_if_enabled()
     return create_spawned_fork_process_manager(*args, **kwargs)
-
-
-def _mock_create_spawned_fork_process_manager_wrapper(*args, **kwargs):
-    setup_recording_injection_if_enabled()
-    return create_spawned_fork_process_manager_wrapper(*args, **kwargs)


### PR DESCRIPTION
# Description

**Problem**
Currently, in fork mode, when spawn process raises an exception, the process will hang and not raise the exception to main process. So we need to solve the problem.

**Solution**

1. In fork mode, the spawn process is the bridge between the main and fork processes. If the spawned process is no longer running, exit the main process.
2. Add try-catch in the spawned process, if an exception occurred, log the error message.
3. In the Monitor thread, if not get the process info within the 60s, raise an exception.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
