### PR TITLE
[Bugfix][Executor] Include line_number in run_info.inputs for eager flow

### DIFF
--- a/src/promptflow/promptflow/executor/_script_executor.py
+++ b/src/promptflow/promptflow/executor/_script_executor.py
@@ -65,10 +65,6 @@ class ScriptExecutor(FlowExecutor):
         run_id: Optional[str] = None,
         **kwargs,
     ) -> LineResult:
-        # Executor will add line_number to batch inputs if there is no line_number in the original inputs,
-        # so, we need remove line_number from inputs if it is not included in input of python function.
-        if LINE_NUMBER_KEY in inputs and LINE_NUMBER_KEY not in self._inputs:
-            inputs.pop(LINE_NUMBER_KEY)
         operation_context = OperationContext.get_instance()
         operation_context.run_mode = operation_context.get("run_mode", None) or RunMode.Test.name
         run_id = run_id or str(uuid.uuid4())
@@ -83,6 +79,9 @@ class ScriptExecutor(FlowExecutor):
             inputs=inputs,
             index=index,
         )
+        # Executor will add line_number to batch inputs if there is no line_number in the original inputs,
+        # which should be removed, so, we only preserve the inputs that are contained in self._inputs.
+        inputs = {k: inputs[k] for k in self._inputs if k in inputs}
         output = None
         traces = []
         try:


### PR DESCRIPTION
# Descriptio

The error occurred when run `pf run show-details -n xxx`, since the inputs of eager flow run info didn't contain `line_number`, which is because we removed the `line_number` before writing it to run info, so we should remove it after creating run info.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
