### PR TITLE
[promptflow] Revert silence warning for SQLAlchemy and update comment

### DIFF
--- a/src/promptflow/promptflow/_sdk/_orm/session.py
+++ b/src/promptflow/promptflow/_sdk/_orm/session.py
@@ -32,8 +32,9 @@ from promptflow._sdk._utils import (
     use_customized_encryption_key,
 )
 
-# silence RemovedIn20Warning to avoid unexpected warning message printed to users
-# TODO(2587221: migrate to SQLAlchemy 2.0)
+# though we have removed the upper bound of SQLAlchemy version in setup.py
+# still silence RemovedIn20Warning to avoid unexpected warning message printed to users
+# for those who still use SQLAlchemy<2.0.0
 os.environ["SQLALCHEMY_SILENCE_UBER_WARNING"] = "1"
 
 session_maker = None

--- a/src/promptflow/promptflow/_sdk/_orm/session.py
+++ b/src/promptflow/promptflow/_sdk/_orm/session.py
@@ -32,6 +32,10 @@ from promptflow._sdk._utils import (
     use_customized_encryption_key,
 )
 
+# silence RemovedIn20Warning to avoid unexpected warning message printed to users
+# TODO(2587221: migrate to SQLAlchemy 2.0)
+os.environ["SQLALCHEMY_SILENCE_UBER_WARNING"] = "1"
+
 session_maker = None
 lock = FileLock(LOCAL_MGMT_DB_SESSION_ACQUIRE_LOCK_PATH)
 


### PR DESCRIPTION
# Description

This PR reverts #1853 to silence warning for those users who still use SQLAlchemy<2.0.0.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
