### PR TITLE
[fundamental] Check enforcer should check against merge_base

### DIFF
--- a/.github/workflows/check_enforcer.yml
+++ b/.github/workflows/check_enforcer.yml
@@ -12,6 +12,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: git fetch origin main
       - run: env | sort >> $GITHUB_OUTPUT
       - name: Python Setup - ubuntu-latest - Python Version 3.9

--- a/.github/workflows/check_enforcer.yml
+++ b/.github/workflows/check_enforcer.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - run: git fetch origin main
       - run: env | sort >> $GITHUB_OUTPUT
       - name: Python Setup - ubuntu-latest - Python Version 3.9
         uses: "./.github/actions/step_create_python_environment"

--- a/.github/workflows/check_enforcer.yml
+++ b/.github/workflows/check_enforcer.yml
@@ -24,6 +24,6 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: pwsh
         run: |
-            python ${{ github.workspace }}/scripts/building/check_enforcer.py -t "${{ github.workspace }}"
+            python ${{ github.workspace }}/scripts/check_enforcer/check_enforcer.py -t "${{ github.workspace }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check_enforcer.yml
+++ b/.github/workflows/check_enforcer.yml
@@ -28,3 +28,4 @@ jobs:
             python ${{ github.workspace }}/scripts/check_enforcer/check_enforcer.py -t "${{ github.workspace }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SNIPPET_DEBUG: 1

--- a/scripts/building/check_enforcer.py
+++ b/scripts/building/check_enforcer.py
@@ -153,7 +153,7 @@ def trigger_prepare(input_paths):
             git_diff_files = [
                 item
                 for item in subprocess.check_output(
-                    ["git", "diff", "--name-only", "HEAD"]
+                    ["git", "diff", "--name-only", "--diff-filter=d", '`git merge-base origin/main HEAD`']
                 )
                 .decode("utf-8")
                 .split("\n")

--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -209,8 +209,8 @@ def run_checks():
         merge_commit = (
             subprocess.check_output(["git", "log", "-1"]).decode("utf-8").split("\n")
         )
+        print(merge_commit)
         for line in merge_commit:
-            print(line)
             if "Merge" in line:
                 merge_commit = line.split(" ")[-3]
                 break

--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -210,6 +210,7 @@ def run_checks():
             subprocess.check_output(["git", "log", "-1"]).decode("utf-8").split("\n")
         )
         for line in merge_commit:
+            print(line)
             if "Merge" in line:
                 merge_commit = line.split(" ")[-3]
                 break
@@ -221,12 +222,18 @@ def run_checks():
     os.chdir(github_workspace)
     # Get diff of current branch and main branch.
     try:
-        git_merge_base = subprocess.check_output(
-            ["git", "merge-base", "origin/main", "HEAD"]
-        ).decode("utf-8").rstrip()
+        git_merge_base = (
+            subprocess.check_output(["git", "merge-base", "origin/main", "HEAD"])
+            .decode("utf-8")
+            .rstrip()
+        )
         git_diff = (
-            subprocess.check_output(["git", "diff", "--name-only", "--diff-filter=d", f"{git_merge_base}"], stderr=subprocess.STDOUT)
-            .decode("utf-8").rstrip()
+            subprocess.check_output(
+                ["git", "diff", "--name-only", "--diff-filter=d", f"{git_merge_base}"],
+                stderr=subprocess.STDOUT,
+            )
+            .decode("utf-8")
+            .rstrip()
             .split("\n")
         )
     except subprocess.CalledProcessError as e:

--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -209,9 +209,10 @@ def run_checks():
         merge_commit = (
             subprocess.check_output(["git", "log", "-1"]).decode("utf-8").split("\n")
         )
-        print(merge_commit)
+        if snippet_debug == 1:
+            print(merge_commit)
         for line in merge_commit:
-            if "Merge" in line:
+            if "Merge" in line and "into" in line:
                 merge_commit = line.split(" ")[-3]
                 break
     if snippet_debug == 1:

--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -26,7 +26,7 @@ import sys
 
 # Define variables
 github_repository = "microsoft/promptflow"
-snippet_debug = 1  # Write debug info to console.
+snippet_debug = os.getenv("SNIPPET_DEBUG", 0)
 merge_commit = ""
 loop_times = 30
 github_workspace = os.path.expanduser("~/promptflow/")
@@ -80,7 +80,7 @@ def trigger_checks(valid_status_array):
     )
     check_suites = json.loads(output)["check_suites"]
     for suite in check_suites:
-        if snippet_debug == 1:
+        if snippet_debug != 0:
             print(f"check-suites id {suite['id']}")
         suite_id = suite["id"]
         output = subprocess.check_output(
@@ -89,7 +89,7 @@ def trigger_checks(valid_status_array):
         )
         check_runs = json.loads(output)["check_runs"]
         for run in check_runs:
-            if snippet_debug == 1:
+            if snippet_debug != 0:
                 print(f"check runs name {run['name']}")
             for key in pipelines.keys():
                 value = pipelines[key]
@@ -209,13 +209,13 @@ def run_checks():
         merge_commit = (
             subprocess.check_output(["git", "log", "-1"]).decode("utf-8").split("\n")
         )
-        if snippet_debug == 1:
+        if snippet_debug != 0:
             print(merge_commit)
         for line in merge_commit:
             if "Merge" in line and "into" in line:
                 merge_commit = line.split(" ")[-3]
                 break
-    if snippet_debug == 1:
+    if snippet_debug != 0:
         print("MergeCommit " + merge_commit)
 
     not_started_counter = 5


### PR DESCRIPTION
# Description

Check enforcer should check against merge_base
move enforcer to new folder, and avoid trigger too many code for check_enforcer changes.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
