### PR TITLE
Only assign inputs after validation and loading image.

### DIFF
--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -779,7 +779,9 @@ class FlowExecutor:
             root_run_id=run_id,
             run_id=line_run_id,
             parent_run_id=run_id,
-            inputs={k: inputs[k] for k in self._flow.inputs if k in inputs},
+            # Assign inputs after validation and load_multimedia_data,
+            # incase of input is wrong and can't be persisted by storage.
+            inputs=None,
             index=line_number,
             variant_id=variant_id,
         )

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -779,9 +779,6 @@ class FlowExecutor:
             root_run_id=run_id,
             run_id=line_run_id,
             parent_run_id=run_id,
-            # Assign inputs after validation and load_multimedia_data,
-            # incase of input is wrong and can't be persisted by storage.
-            inputs=None,
             index=line_number,
             variant_id=variant_id,
         )
@@ -800,7 +797,8 @@ class FlowExecutor:
             if validate_inputs:
                 inputs = FlowValidator.ensure_flow_inputs_type(flow=self._flow, inputs=inputs, idx=line_number)
             inputs = load_multimedia_data(self._flow.inputs, inputs)
-            # Make sure the run_info with converted inputs results rather than original inputs
+            # Inputs are assigned after validation and multimedia data loading, instead of at the start of the flow run.
+            # This way, if validation or multimedia data loading fails, we avoid persisting invalid inputs.
             run_info.inputs = inputs
             output, nodes_outputs = self._traverse_nodes(inputs, context)
             output = self._stringify_generator_output(output) if not allow_generator_output else output

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -204,8 +204,7 @@ class TestValidation:
         with pytest.raises(error_class):
             executor.exec_line(line_input)
 
-    def test_flow_run_input_assignment(self, dev_connections):
-        # Flow run -  the input is from get_partial_line_inputs()
+    def test_invalid_flow_run_inputs_should_not_saved_to_run_info(self, dev_connections):
         flow_folder = "simple_flow_with_python_tool"
         executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections, raise_ex=False)
         invalid_input = {"num": "hello"}
@@ -213,8 +212,12 @@ class TestValidation:
         # For invalid inputs, we don't assigin them to run info.
         assert result.run_info.inputs is None
 
+    def test_valid_flow_run_inpust_should_saved_to_run_info(self, dev_connections):
+        flow_folder = "simple_flow_with_python_tool"
+        executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections, raise_ex=False)
         valid_input = {"num": 22}
         result = executor.exec_line(valid_input)
+        # For valid inputs, we assigin them to run info.
         assert result.run_info.inputs == valid_input
 
     @pytest.mark.parametrize(

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -204,6 +204,19 @@ class TestValidation:
         with pytest.raises(error_class):
             executor.exec_line(line_input)
 
+    def test_flow_run_input_assignment(self, dev_connections):
+        # Flow run -  the input is from get_partial_line_inputs()
+        flow_folder = "simple_flow_with_python_tool"
+        executor = FlowExecutor.create(get_yaml_file(flow_folder, FLOW_ROOT), dev_connections, raise_ex=False)
+        invalid_input = {"num": "hello"}
+        result = executor.exec_line(invalid_input)
+        # For invalid inputs, we don't assigin them to run info.
+        assert result.run_info.inputs is None
+
+        valid_input = {"num": 22}
+        result = executor.exec_line(valid_input)
+        assert result.run_info.inputs == valid_input
+
     @pytest.mark.parametrize(
         "flow_folder, line_input, error_class, error_msg",
         [


### PR DESCRIPTION
# Description
Only assign flow run info's input after validation and loading image.

It's a better way to handle inputs, because 
1. A wrong input is not yet the flow run's input from concept.
2. Assign wrong input may introduce bug for storage's persisting. We should not expect storage could handle all abnormal case rightly.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
