### PR TITLE
Add OpenTelemetry Support for Trace Decorator in PromptFlow

### DIFF
--- a/src/promptflow/promptflow/_core/tracer.py
+++ b/src/promptflow/promptflow/_core/tracer.py
@@ -205,21 +205,26 @@ def get_node_name_from_context():
 
 
 def enrich_span_with_trace(span, trace):
-    span.set_attributes(
-        {
-            "framework": "promptflow",
-            "span_type": f"promptflow.{trace.type}",
-            "function": trace.name,
-            "inputs": serialize_attribute(trace.inputs),
-            "node_name": get_node_name_from_context(),
-            "tool_version": "tool_version",  # TODO: Check how to pass the tool version in
-        }
-    )
+    try:
+        span.set_attributes(
+            {
+                "framework": "promptflow",
+                "span_type": trace.type,
+                "function": trace.name,
+                "inputs": serialize_attribute(trace.inputs),
+                "node_name": get_node_name_from_context(),
+            }
+        )
+    except Exception as e:
+        logging.warning(f"Failed to enrich span with trace: {e}")
 
 
 def enrich_span_with_output(span, output):
-    serialized_output = serialize_attribute(output)
-    span.set_attribute("output", serialized_output)
+    try:
+        serialized_output = serialize_attribute(output)
+        span.set_attribute("output", serialized_output)
+    except Exception as e:
+        logging.warning(f"Failed to enrich span with output: {e}")
 
     return output
 

--- a/src/promptflow/setup.py
+++ b/src/promptflow/setup.py
@@ -50,6 +50,8 @@ REQUIRES = [
     "filetype>=1.2.0",  # used to detect the mime type for mulitmedia input
     "jsonschema>=4.0.0,<5.0.0",  # used to validate tool
     "docutils",  # used to generate description for tools
+    "opentelemetry-api>=1.21.0,<2.0.0",  # used to generate trace
+    "opentelemetry-sdk>=1.21.0,<2.0.0",  # used to collect trace
 ]
 
 setup(
@@ -92,18 +94,13 @@ setup(
             "azure-identity>=1.12.0,<2.0.0",
             "azure-ai-ml>=1.11.0,<2.0.0",
             # OTel dependencies for monitoring
-            "opentelemetry-api>=1.21.0,<2.0.0",
-            "opentelemetry-sdk>=1.21.0,<2.0.0",
             "azure-monitor-opentelemetry>=1.1.1,<2.0.0",
             # MDC dependencies for monitoring
             "azureml-ai-monitoring>=0.1.0b3,<1.0.0",
         ],
     },
     packages=find_packages(),
-    scripts=[
-        'pf',
-        'pf.bat'
-    ],
+    scripts=["pf", "pf.bat"],
     entry_points={
         "console_scripts": [
             "pfazure = promptflow._cli._pf_azure.entry:main",

--- a/src/promptflow/tests/executor/unittests/_core/test_tracer.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tracer.py
@@ -407,8 +407,7 @@ class TestOTelTracer:
         span = span_list[0]
         assert span.name == sync_func.__name__
         assert span.attributes["framework"] == "promptflow"
-        assert span.attributes["span_type"] == "promptflow.Function"
+        assert span.attributes["span_type"] == TraceType.FUNCTION
         assert span.attributes["function"] == sync_func.__name__
         assert span.attributes["inputs"] == '{\n  "a": 1\n}'
-        assert span.attributes["tool_version"] == "tool_version"
         assert span.status.status_code == StatusCode.OK

--- a/src/promptflow/tests/executor/unittests/_core/test_tracer.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tracer.py
@@ -1,6 +1,11 @@
 import inspect
 
+import opentelemetry
 import pytest
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace.status import StatusCode
 
 from promptflow._core.generator_proxy import GeneratorProxy
 from promptflow._core.tracer import Tracer, _create_trace_from_function_call, _traced, trace
@@ -380,3 +385,30 @@ class TestTrace:
         assert trace["children"] == []
         assert isinstance(trace["start_time"], float)
         assert isinstance(trace["end_time"], float)
+
+
+@pytest.mark.unittest
+class TestOTelTracer:
+    @pytest.fixture(autouse=True)
+    def setup(self):
+        self.tracer_provider = TracerProvider()
+        self.memory_exporter = InMemorySpanExporter()
+        span_processor = SimpleSpanProcessor(self.memory_exporter)
+        self.tracer_provider.add_span_processor(span_processor)
+        opentelemetry.trace.set_tracer_provider(self.tracer_provider)
+
+    def test_trace_func(self):
+        traced_func = trace(sync_func)
+        result = traced_func(1)
+        assert result == 1
+
+        span_list = self.memory_exporter.get_finished_spans()
+        assert len(span_list) == 1
+        span = span_list[0]
+        assert span.name == sync_func.__name__
+        assert span.attributes["framework"] == "promptflow"
+        assert span.attributes["span_type"] == "promptflow.Function"
+        assert span.attributes["function"] == sync_func.__name__
+        assert span.attributes["inputs"] == '{\n  "a": 1\n}'
+        assert span.attributes["tool_version"] == "tool_version"
+        assert span.status.status_code == StatusCode.OK


### PR DESCRIPTION
# Description

This PR introduces OpenTelemetry support for the trace decorator in PromptFlow. The `trace` decorator, which is applied to tool and openai APIs, now generates OpenTelemetry spans containing execution information. This enhancement allows for detailed tracking of function execution within the PromptFlow scope.

Key changes include:
- Generation of a span before the execution of the decorated function.
- Setting span attributes with execution information such as input and TraceType.
- Addition of the function's result as an output attribute to the span.

A test has been added to validate these changes.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
