### PR TITLE
feat: support csharp eager mode batch run

### DIFF
--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -14,7 +14,6 @@ from typing import Any, Dict, List, NewType, Optional, Tuple, Union
 
 from filelock import FileLock
 
-from promptflow import load_flow
 from promptflow._sdk._constants import (
     HOME_PROMPT_FLOW_DIR,
     LINE_NUMBER,
@@ -24,6 +23,7 @@ from promptflow._sdk._constants import (
     RunInfoSources,
 )
 from promptflow._sdk._errors import BulkRunException, InvalidRunError
+from promptflow._sdk._load_functions import load_flow
 from promptflow._sdk._utils import (
     PromptflowIgnoreFile,
     generate_flow_tools_json,

--- a/src/promptflow/promptflow/_sdk/schemas/_flow.py
+++ b/src/promptflow/promptflow/_sdk/schemas/_flow.py
@@ -71,21 +71,26 @@ class EagerFlowSchema(BaseFlowSchema):
     def validate_entry(self, data, **kwargs):
         """Validate entry."""
         language = data.get(LANGUAGE_KEY, FlowLanguage.Python)
+        entry_regex = None
         if language == FlowLanguage.CSharp:
             entry_regex = r"\((.+)\)[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+"
-        else:
-            entry_regex = None
+        elif language == FlowLanguage.Python:
+            # TODO: remove this after path is removed
+            if data.get("path", None) is None:
+                raise ValidationError(field_name="path", message="Missing data for required field.")
 
         if entry_regex is not None and not re.match(entry_regex, data["entry"]):
-            raise ValidationError(f"Entry function {data['entry']} is not valid.")
+            raise ValidationError(field_name="entry", message=f"Entry function {data['entry']} is not valid.")
 
     @post_load
     def infer_path(self, data: dict, **kwargs):
         """Infer path from entry."""
         # TODO: remove this after path is removed
-        if data.get("path", None) is None:
+        language = data.get(LANGUAGE_KEY, FlowLanguage.Python)
+        if language == FlowLanguage.CSharp and data.get("path", None) is None:
             # for csharp, path to flow entry file will be a dll path inferred from
             # entry by default given customer won't see the dll on authoring
             m = re.match(r"\((.+)\)[a-zA-Z0-9]+(\.[a-zA-Z0-9]+)+", data["entry"])
-            data["path"] = m.group(1) + ".dll"
+            if m:
+                data["path"] = m.group(1) + ".dll"
         return data

--- a/src/promptflow/promptflow/azure/_entities/_flow.py
+++ b/src/promptflow/promptflow/azure/_entities/_flow.py
@@ -13,6 +13,7 @@ import pydash
 from promptflow._sdk._constants import DAG_FILE_NAME, SERVICE_FLOW_TYPE_2_CLIENT_FLOW_TYPE, AzureFlowSource, FlowType
 from promptflow.azure._ml import AdditionalIncludesMixin, Code
 
+from ..._constants import FlowLanguage
 from ..._sdk._utils import PromptflowIgnoreFile, load_yaml, remove_empty_element_from_dict
 from ..._utils.flow_utils import dump_flow_dag, load_flow_dag
 from ..._utils.logger_utils import LoggerFactory
@@ -212,3 +213,7 @@ class Flow(AdditionalIncludesMixin):
             "flow_portal_url": self.flow_portal_url,
         }
         return remove_empty_element_from_dict(result)
+
+    @property
+    def language(self):
+        return self._flow_dict.get("language", FlowLanguage.Python)

--- a/src/promptflow/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_base_executor_proxy.py
@@ -30,6 +30,23 @@ class AbstractExecutorProxy:
         """Generate tool metadata file for the specified flow."""
         return cls._get_tool_metadata(flow_file, working_dir or flow_file.parent)
 
+    def _get_flow_meta(self) -> dict:
+        """Get the flow metadata from"""
+        raise NotImplementedError()
+
+    def get_inputs_definition(self) -> Mapping[str, Any]:
+        """Get the inputs definition of an eager flow"""
+        from promptflow.contracts.flow import FlowInputDefinition
+
+        flow_meta = self._get_flow_meta()
+        inputs = {}
+        for key, value in flow_meta.get("inputs", {}).items():
+            # TODO: Han to confirm - flow.json["inputs"]["xxx"]["type"] is a list in our previous contract, while
+            #  FlowInputDefinition.deserialize() expects a string
+            value["type"] = value.get("type")[0]
+            inputs[key] = FlowInputDefinition.deserialize(value)
+        return inputs
+
     @classmethod
     def _get_tool_metadata(cls, flow_file: Path, working_dir: Path) -> dict:
         raise NotImplementedError()

--- a/src/promptflow/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_base_executor_proxy.py
@@ -41,9 +41,11 @@ class AbstractExecutorProxy:
         flow_meta = self._get_flow_meta()
         inputs = {}
         for key, value in flow_meta.get("inputs", {}).items():
-            # TODO: Han to confirm - flow.json["inputs"]["xxx"]["type"] is a list in our previous contract, while
-            #  FlowInputDefinition.deserialize() expects a string
-            value["type"] = value.get("type")[0]
+            # TODO: update this after we determine whether to accept list here or now
+            _type = value.get("type")
+            if isinstance(_type, list):
+                _type = _type[0]
+            value["type"] = _type
             inputs[key] = FlowInputDefinition.deserialize(value)
         return inputs
 

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Mapping, Optional
 
-from promptflow._constants import LINE_NUMBER_KEY, LINE_TIMEOUT_SEC, FlowLanguage
+from promptflow._constants import LANGUAGE_KEY, LINE_NUMBER_KEY, LINE_TIMEOUT_SEC, FlowLanguage
 from promptflow._core._errors import UnexpectedError
 from promptflow._core.operation_context import OperationContext
 from promptflow._utils.async_utils import async_run_allowing_running_loop
@@ -99,14 +99,13 @@ class BatchEngine:
         """
         self._flow_file = flow_file
         self._working_dir = Flow._resolve_working_dir(flow_file, working_dir)
-        if self._is_eager_flow_yaml():
-            self._is_dag_yaml_flow = False
-            self._program_language = FlowLanguage.Python
-        else:
+
+        self._is_eager_flow, self._program_language = self._check_eager_flow_and_language_from_yaml()
+
+        # TODO: why self._flow is not initialized for eager flow?
+        if not self._is_eager_flow:
             self._flow = Flow.from_yaml(flow_file, working_dir=self._working_dir)
             FlowValidator.ensure_flow_valid_in_batch_mode(self._flow)
-            self._is_dag_yaml_flow = True
-            self._program_language = self._flow.program_language
 
         self._connections = connections
         self._storage = storage
@@ -160,8 +159,8 @@ class BatchEngine:
                 try:
                     # register signal handler for python flow in the main thread
                     # TODO: For all executor proxies that are executed locally, it might be necessary to
-                    # register a signal for Ctrl+C in order to customize some actions beyond just killing
-                    # the process, such as terminating the executor service.
+                    #  register a signal for Ctrl+C in order to customize some actions beyond just killing
+                    #  the process, such as terminating the executor service.
                     if isinstance(self._executor_proxy, PythonExecutorProxy):
                         if threading.current_thread() is threading.main_thread():
                             signal.signal(signal.SIGINT, signal_handler)
@@ -173,9 +172,7 @@ class BatchEngine:
                     # set batch input source from input mapping
                     OperationContext.get_instance().set_batch_input_source_from_inputs_mapping(inputs_mapping)
                     # if using eager flow, the self._flow is none, so we need to get inputs definition from executor
-                    inputs = (
-                        self._flow.inputs if self._is_dag_yaml_flow else self._executor_proxy.get_inputs_definition()
-                    )
+                    inputs = self._executor_proxy.get_inputs_definition() if self._is_eager_flow else self._flow.inputs
                     # resolve input data from input dirs and apply inputs mapping
                     batch_input_processor = BatchInputsProcessor(self._working_dir, inputs, max_lines_count)
                     batch_inputs = batch_input_processor.process_batch_inputs(input_dirs, inputs_mapping)
@@ -245,7 +242,7 @@ class BatchEngine:
         await self._executor_proxy.ensure_executor_health()
         # apply default value in early stage, so we can use it both in line and aggregation nodes execution.
         # if the flow is None, we don't need to apply default value for inputs.
-        if self._is_dag_yaml_flow:
+        if not self._is_eager_flow:
             batch_inputs = [
                 apply_default_value_for_input(self._flow.inputs, each_line_input) for each_line_input in batch_inputs
             ]
@@ -336,7 +333,7 @@ class BatchEngine:
         line_results: List[LineResult],
         run_id: Optional[str] = None,
     ) -> AggregationResult:
-        if not self._is_dag_yaml_flow:
+        if self._is_eager_flow:
             return AggregationResult({}, {}, {})
         aggregation_nodes = {node.name for node in self._flow.nodes if node.aggregation}
         if not aggregation_nodes:
@@ -401,11 +398,13 @@ class BatchEngine:
         aggr_result.node_run_infos = aggr_exec_result.node_run_infos
         aggr_result.output = aggr_exec_result.output
 
-    def _is_eager_flow_yaml(self):
-        if Path(self._flow_file).suffix.lower() in [".yaml", ".yml"]:
-            flow_file = self._working_dir / self._flow_file if self._working_dir else self._flow_file
-            with open(flow_file, "r", encoding="utf-8") as fin:
-                flow_dag = load_yaml(fin)
-            if "entry" in flow_dag:
-                return True
-        return False
+    def _check_eager_flow_and_language_from_yaml(self):
+        flow_file = self._working_dir / self._flow_file if self._working_dir else self._flow_file
+        # TODO: remove this after path is removed
+        if flow_file.suffix == ".dll":
+            return True, FlowLanguage.CSharp
+        with open(flow_file, "r", encoding="utf-8") as fin:
+            flow_dag = load_yaml(fin)
+        is_eager_flow = "entry" in flow_dag
+        language = flow_dag.get(LANGUAGE_KEY, FlowLanguage.Python)
+        return is_eager_flow, language

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -401,7 +401,7 @@ class BatchEngine:
     def _check_eager_flow_and_language_from_yaml(self):
         flow_file = self._working_dir / self._flow_file if self._working_dir else self._flow_file
         # TODO: remove this after path is removed
-        if flow_file.suffix == ".dll":
+        if flow_file.suffix.lower() == ".dll":
             return True, FlowLanguage.CSharp
         with open(flow_file, "r", encoding="utf-8") as fin:
             flow_dag = load_yaml(fin)

--- a/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
@@ -2,13 +2,17 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 import json
+import os
 import socket
 import subprocess
+import tempfile
 import uuid
 from pathlib import Path
 from typing import Any, Mapping, Optional
 
-from promptflow._core._errors import MetaFileNotFound, MetaFileReadError
+import yaml
+
+from promptflow._core._errors import MetaFileNotFound, MetaFileReadError, UnexpectedError
 from promptflow._sdk._constants import DEFAULT_ENCODING, FLOW_TOOLS_JSON, PROMPT_FLOW_DIR_NAME
 from promptflow.batch._base_executor_proxy import APIBasedExecutorProxy
 from promptflow.executor._result import AggregationResult
@@ -19,13 +23,57 @@ EXECUTOR_SERVICE_DLL = "Promptflow.dll"
 
 
 class CSharpExecutorProxy(APIBasedExecutorProxy):
-    def __init__(self, process: subprocess.Popen, port: str):
+    def __init__(
+        self, *, process: subprocess.Popen, port: str, working_dir: Path, temp_dag_file: Optional[Path] = None
+    ):
         self._process = process
         self._port = port
+        self._working_dir = working_dir
+        self._temp_dag_file = temp_dag_file
 
     @property
     def api_endpoint(self) -> str:
         return EXECUTOR_SERVICE_DOMAIN + self._port
+
+    def _get_flow_meta(self) -> dict:
+        # TODO: this should be got from flow.json for all languages by default?
+        flow_meta_json_path = self._working_dir / ".promptflow" / "flow.json"
+        if not flow_meta_json_path.is_file():
+            raise MetaFileNotFound(
+                message_format=(
+                    # TODO: pf flow validate should be able to generate flow.json
+                    "Failed to fetch meta of inputs: cannot find {file_path}, please retry."
+                ),
+                file_path=flow_meta_json_path.absolute().as_posix(),
+            )
+
+        with open(flow_meta_json_path, mode="r", encoding=DEFAULT_ENCODING) as flow_meta_json_path:
+            return json.load(flow_meta_json_path)
+
+    @classmethod
+    def _generate_flow_meta(cls, flow_file: str, assembly_folder: Path):
+        command = [
+            "dotnet",
+            EXECUTOR_SERVICE_DLL,
+            "--flow_meta",
+            "--yaml_path",
+            flow_file,
+            "--assembly_folder",
+            ".",
+        ]
+        try:
+            subprocess.check_output(
+                command,
+                cwd=assembly_folder,
+            )
+        except subprocess.CalledProcessError as e:
+            raise UnexpectedError(
+                message_format=f"Failed to generate flow meta for csharp flow.\n"
+                f"Command: {' '.join(command)}\n"
+                f"Working directory: {assembly_folder.as_posix()}\n"
+                f"Return code: {e.returncode}\n"
+                f"Output: {e.output}",
+            )
 
     @classmethod
     async def create(
@@ -42,6 +90,24 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
         log_path = kwargs.get("log_path", "")
         init_error_file = Path(working_dir) / f"init_error_{str(uuid.uuid4())}.json"
         init_error_file.touch()
+
+        assembly_folder = flow_file.parent
+        # TODO: should we change the interface to init the proxy (always pass entry for eager mode)?
+        if "entry" in kwargs:
+            fd, temp_dag_file = tempfile.mkstemp(suffix=".yaml", text=True)
+            os.write(fd, yaml.dump({"entry": kwargs["entry"], "path": flow_file.as_posix()}).encode(DEFAULT_ENCODING))
+            # need to close the fd manually, or it can't be used in subprocess
+            os.close(fd)
+            flow_file = Path(temp_dag_file)
+
+            # generate flow meta
+            cls._generate_flow_meta(
+                flow_file=temp_dag_file,
+                assembly_folder=assembly_folder,
+            )
+        else:
+            temp_dag_file = None
+
         command = [
             "dotnet",
             EXECUTOR_SERVICE_DLL,
@@ -49,7 +115,7 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
             "-p",
             port,
             "--yaml_path",
-            flow_file,
+            flow_file.as_posix(),
             "--assembly_folder",
             ".",
             "--log_path",
@@ -60,7 +126,12 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
             init_error_file,
         ]
         process = subprocess.Popen(command)
-        executor_proxy = cls(process, port)
+        executor_proxy = cls(
+            process=process,
+            port=port,
+            temp_dag_file=temp_dag_file,
+            working_dir=working_dir,
+        )
         try:
             await executor_proxy.ensure_executor_startup(init_error_file)
         finally:
@@ -75,6 +146,8 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
                 self._process.wait(timeout=5)
             except subprocess.TimeoutExpired:
                 self._process.kill()
+        if self._temp_dag_file and os.path.isfile(self._temp_dag_file):
+            Path(self._temp_dag_file).unlink()
 
     async def exec_aggregation_async(
         self,

--- a/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
+++ b/src/promptflow/promptflow/batch/_csharp_executor_proxy.py
@@ -111,8 +111,8 @@ class CSharpExecutorProxy(APIBasedExecutorProxy):
         command = [
             "dotnet",
             EXECUTOR_SERVICE_DLL,
-            "-e",
-            "-p",
+            "--execution_service",
+            "--port",
             port,
             "--yaml_path",
             flow_file.as_posix(),


### PR DESCRIPTION
# Description

This pull request primarily involves changes that enhance language support and improve the handling of flow schemas in the `promptflow` package. The changes include the introduction of validation and default values for the `language` field in flow schemas, modifications to the handling of eager flows in the batch engine, and the addition of methods to fetch flow metadata and input definitions.

Language Support and Flow Schema Changes:

* [`src/promptflow/promptflow/_sdk/schemas/_flow.py`](diffhunk://#diff-84af29d72d79c61d55daa91de77a03235646967bcaa7c3299f33adcead97bc53R4-R8): The `language` field in the `BaseFlowSchema` class now has a default value and validation to ensure it's either Python or CSharp. In the `EagerFlowSchema` class, the `path` field is no longer required, and a `post_load` method was added to infer the path from the entry depending on the language. [[1]](diffhunk://#diff-84af29d72d79c61d55daa91de77a03235646967bcaa7c3299f33adcead97bc53R4-R8) [[2]](diffhunk://#diff-84af29d72d79c61d55daa91de77a03235646967bcaa7c3299f33adcead97bc53L42-R47) [[3]](diffhunk://#diff-84af29d72d79c61d55daa91de77a03235646967bcaa7c3299f33adcead97bc53L61-R84)

* [`src/promptflow/promptflow/azure/_entities/_flow.py`](diffhunk://#diff-b8b37b2a9593a8fb1f0b078663aad36d8b4009a1205bd4e799a6180d666b7e65R16): Added a `language` property method to fetch the language of the flow. [[1]](diffhunk://#diff-b8b37b2a9593a8fb1f0b078663aad36d8b4009a1205bd4e799a6180d666b7e65R16) [[2]](diffhunk://#diff-b8b37b2a9593a8fb1f0b078663aad36d8b4009a1205bd4e799a6180d666b7e65R216-R219)

Handling of Eager Flows in Batch Engine:

* [`src/promptflow/promptflow/batch/_batch_engine.py`](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L13-R13): Several changes were made to handle eager flows differently. The `__init__` method now checks if the flow is eager and its language. The `run` and `_exec` methods have been adjusted to handle eager flows. The `_update_aggr_result` method has been modified to skip eager flows. [[1]](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L13-R13) [[2]](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L102-L109) [[3]](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L176-R175) [[4]](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L248-R245) [[5]](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L339-R336) [[6]](diffhunk://#diff-ecf0905f2116abe08b5cf2931b856bf39aa8b38a30fadd9042538d076dbfde80L404-R410)

Fetching Flow Metadata and Input Definitions:

* [`src/promptflow/promptflow/batch/_base_executor_proxy.py`](diffhunk://#diff-44ac8eeb30a630bd24987e92f8bd5a180d57a3ad067db5d937561f21771e14c5R33-R49): Added `_get_flow_meta` and `get_inputs_definition` methods to fetch flow metadata and input definitions, respectively.

* [`src/promptflow/promptflow/batch/_csharp_executor_proxy.py`](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95R5-R15): Added `_get_flow_meta` and `_generate_flow_meta` methods to fetch and generate flow metadata, respectively. The `create` method has been modified to generate flow metadata for eager flows. [[1]](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95R5-R15) [[2]](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95L22-R77) [[3]](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95R93-R118) [[4]](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95L63-R134)

Other Changes:

* [`src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py`](diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L17): The import of `load_flow` has been moved to a different location. [[1]](diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L17) [[2]](diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719R26)

* [`src/promptflow/promptflow/batch/_csharp_executor_proxy.py`](diffhunk://#diff-f8219170007d8a89eed104a166ab8c0c9d3af5b5c5e61225659d982f470aeb95R149-R150): The `destroy` method has been updated to delete temporary DAG files if they exist.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
