### PR TITLE
[Executor][Internal]Put only required items in aoai telemetry headers

### DIFF
--- a/src/promptflow/promptflow/_core/openai_injector.py
+++ b/src/promptflow/promptflow/_core/openai_injector.py
@@ -46,14 +46,20 @@ def get_aoai_telemetry_headers() -> dict:
     """
     # get promptflow info from operation context
     operation_context = OperationContext.get_instance()
-    context_info = operation_context.get_context_dict()
-    promptflow_info = {k.replace("_", "-"): v for k, v in context_info.items()}
+    tracking_info = operation_context._get_tracking_info()
+    tracking_info = {k.replace("_", "-"): v for k, v in tracking_info.items()}
+
+    def is_primitive(value):
+        return value is None or isinstance(value, (int, float, str, bool))
+
+    #  Ensure that the telemetry info is primitive
+    tracking_info = {k: v for k, v in tracking_info.items() if is_primitive(v)}
 
     # init headers
     headers = {USER_AGENT_HEADER: operation_context.get_user_agent()}
 
     # update header with promptflow info
-    headers.update({f"{PROMPTFLOW_PREFIX}{k}": str(v) if v is not None else "" for k, v in promptflow_info.items()})
+    headers.update({f"{PROMPTFLOW_PREFIX}{k}": str(v) if v is not None else "" for k, v in tracking_info.items()})
 
     return headers
 

--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -1,6 +1,8 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+import copy
+
 from contextvars import ContextVar
 from typing import Dict, Mapping
 
@@ -20,6 +22,8 @@ class OperationContext(Dict):
     _OTEL_ATTRIBUTES = "_otel_attributes"
     _current_context = ContextVar(_CONTEXT_KEY, default=None)
     USER_AGENT_KEY = "user_agent"
+    _DEFAULT_TRACKING_KEYS = {"run_mode", "root_run_id", "flow_id", "batch_input_source"}
+    _TRACKING_KEYS = "_tracking_keys"
 
     def _add_otel_attributes(self, key, value):
         attributes = self.get(OperationContext._OTEL_ATTRIBUTES, {})
@@ -45,6 +49,8 @@ class OperationContext(Dict):
             # create a new instance and set it in the current context
             instance = OperationContext()
             cls._current_context.set(instance)
+        if cls._TRACKING_KEYS not in instance:
+            instance[cls._TRACKING_KEYS] = copy.copy(cls._DEFAULT_TRACKING_KEYS)
         return instance
 
     def __setattr__(self, name, value):
@@ -63,9 +69,6 @@ class OperationContext(Dict):
         # check that name is a string
         if not isinstance(name, str):
             raise TypeError("Name must be a string")
-        # check that value is a primitive
-        if value is not None and not isinstance(value, (int, float, str, bool)):
-            raise TypeError("Value must be a primitive")
         # set the item in the data attribute
         self[name] = value
 
@@ -188,3 +191,7 @@ class OperationContext(Dict):
             dict: The context dictionary.
         """
         return dict(self)
+
+    def _get_tracking_info(self):
+        keys = getattr(self, self._TRACKING_KEYS, self._DEFAULT_TRACKING_KEYS)
+        return {k: v for k, v in self.items() if k in keys}

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -717,7 +717,7 @@ class FlowExecutor:
     def _update_operation_context(self, run_id: str):
         operation_context = OperationContext.get_instance()
         operation_context.run_mode = operation_context.get("run_mode", None) or RunMode.Test.name
-        operation_context.update({"flow-id": self._flow_id, "root-run-id": run_id})
+        operation_context.update({"flow_id": self._flow_id, "root_run_id": run_id})
         if operation_context.run_mode == RunMode.Test.name:
             operation_context._add_otel_attributes("line_run_id", run_id)
 

--- a/src/promptflow/tests/executor/e2etests/test_eager_flow.py
+++ b/src/promptflow/tests/executor/e2etests/test_eager_flow.py
@@ -130,5 +130,6 @@ class TestEagerFlow:
         line_result = executor.exec_line(inputs={}, index=0)
 
         assert isinstance(line_result, LineResult)
+        assert line_result.run_info.status == Status.Completed
         assert line_result.output["flow-id"] == line_result.run_info.flow_id
         assert line_result.output["root-run-id"] == line_result.run_info.root_run_id

--- a/src/promptflow/tests/executor/e2etests/test_telemetry.py
+++ b/src/promptflow/tests/executor/e2etests/test_telemetry.py
@@ -88,7 +88,8 @@ class TestExecutorTelemetry:
             assert isinstance(flow_result.output, dict)
             headers = json.loads(flow_result.output.get("answer", ""))
             assert "promptflow/" in headers.get("x-ms-useragent")
-            assert headers.get("ms-azure-ai-promptflow-scenario") == "test"
+            # User-defined properties `scenario` is not set in headers
+            assert "ms-azure-ai-promptflow-scenario" not in headers
             assert headers.get("ms-azure-ai-promptflow-run-mode") == RunMode.Test.name
             assert headers.get("ms-azure-ai-promptflow-flow-id") == flow_result.run_info.flow_id
             assert headers.get("ms-azure-ai-promptflow-root-run-id") == flow_result.run_info.run_id
@@ -110,7 +111,7 @@ class TestExecutorTelemetry:
             assert run_info.output is not None
             headers = json.loads(run_info.output)
             assert "promptflow/" in headers.get("x-ms-useragent")
-            assert headers.get("ms-azure-ai-promptflow-scenario") == "test"
+            assert "ms-azure-ai-promptflow-scenario" not in headers
             assert headers.get("ms-azure-ai-promptflow-run-mode") == RunMode.SingleNode.name
 
     def test_executor_openai_telemetry_with_batch_run(self, dev_connections):
@@ -124,6 +125,9 @@ class TestExecutorTelemetry:
         operation_context.clear()
         # Set user-defined properties `scenario` in context
         operation_context.scenario = "test"
+        operation_context.dummy_key = "dummy_value"
+        operation_context._tracking_keys = OperationContext._DEFAULT_TRACKING_KEYS
+        operation_context._tracking_keys.add("dummy_key")
 
         with enable_mock_in_process(mock_process_wrapper, mock_process_manager):
             run_id = str(uuid.uuid4())
@@ -141,7 +145,9 @@ class TestExecutorTelemetry:
             for line in outputs:
                 headers = json.loads(line.get("answer", ""))
                 assert "promptflow/" in headers.get("x-ms-useragent")
-                assert headers.get("ms-azure-ai-promptflow-scenario") == "test"
+                assert "ms-azure-ai-promptflow-scenario" not in headers
                 assert headers.get("ms-azure-ai-promptflow-run-mode") == RunMode.Batch.name
                 assert headers.get("ms-azure-ai-promptflow-flow-id") == "default_flow_id"
                 assert headers.get("ms-azure-ai-promptflow-root-run-id") == run_id
+                assert headers.get("ms-azure-ai-promptflow-batch-input-source") == "Data"
+                assert headers.get("ms-azure-ai-promptflow-dummy-key") == "dummy_value"

--- a/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_operation_context.py
@@ -59,9 +59,9 @@ class TestOperationContext:
     def test_setattr_non_primitive(self):
         # Test set non-primitive type
         context = OperationContext()
+        context.foo = [1, 2, 3]
 
-        with pytest.raises(TypeError):
-            context.foo = [1, 2, 3]
+        assert [1, 2, 3] == context.foo
 
     def test_getattr(self):
         context = OperationContext()

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_operation_context/flow_with_context.py
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_operation_context/flow_with_context.py
@@ -3,6 +3,6 @@ from promptflow._core.operation_context import OperationContext
 
 def my_flow():
     context = OperationContext.get_instance()
-    assert "flow-id" in context
-    assert "root-run-id" in context
-    return {"flow-id": context["flow-id"], "root-run-id": context["root-run-id"]}
+    assert "flow_id" in context
+    assert "root_run_id" in context
+    return {"flow-id": context.flow_id, "root-run-id": context.root_run_id}


### PR DESCRIPTION
# Description

Only include required items in telemetry headers by fetching keys from tracking_keys

This pull request primarily refactors how telemetry data is tracked and validated in the `OperationContext` and `openai_injector` classes of the `promptflow` package. The changes ensure that only primitive data types are included in the telemetry headers, and add the ability to customize which keys are tracked for telemetry. The changes also include updates to the corresponding unit tests.

Key Changes:

**Refactoring of Telemetry Data Handling:**

* [`src/promptflow/promptflow/_core/openai_injector.py`](diffhunk://#diff-5aa1742dea161ecc0d7aab4d778e7ae50dd9c935fd76e1b8f6599cad20473fd8L49-R62): The `get_aoai_telemetry_headers` method now retrieves tracking info from `OperationContext` instead of the context dict. It also includes a new function `is_primitive` to ensure only primitive data types are included in the telemetry headers.

* [`src/promptflow/promptflow/_core/operation_context.py`](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR4-R5): The `OperationContext` class now includes default tracking keys and a method to get tracking info. The `get_instance` method initializes the tracking keys if they are not present. The `__setattr__` method no longer checks if the value is a primitive. [[1]](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR4-R5) [[2]](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR24-R25) [[3]](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR43-R44) [[4]](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aL57-L59) [[5]](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR185-R188)

**Changes in Key Names and Value Assignments:**

* [`src/promptflow/promptflow/executor/flow_executor.py`](diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69L720-R720): Key names were changed from hyphen-separated to underscore-separated in the `_update_operation_context` method.

* [`src/promptflow/tests/test_configs/eager_flows/flow_with_operation_context/flow_with_context.py`](diffhunk://#diff-e586892d375fead2573a44293c3130abb44ffa14c8a331b05b1639a815c4ed7fL6-R8): Key names were changed from hyphen-separated to underscore-separated in the `my_flow` function.

**Updates to Unit Tests:**

* [`src/promptflow/tests/executor/e2etests/test_telemetry.py`](diffhunk://#diff-c52d2b5703d30897fc646af7de0aaef0cad9031b9b50519f962303b54bee246eL91-R92): Tests were updated to reflect changes in telemetry data handling and key names. Additional tests were added to check for the presence of user-defined properties in the headers. [[1]](diffhunk://#diff-c52d2b5703d30897fc646af7de0aaef0cad9031b9b50519f962303b54bee246eL91-R92) [[2]](diffhunk://#diff-c52d2b5703d30897fc646af7de0aaef0cad9031b9b50519f962303b54bee246eL113-R114) [[3]](diffhunk://#diff-c52d2b5703d30897fc646af7de0aaef0cad9031b9b50519f962303b54bee246eR128-R130) [[4]](diffhunk://#diff-c52d2b5703d30897fc646af7de0aaef0cad9031b9b50519f962303b54bee246eL144-R153)

* [`src/promptflow/tests/executor/unittests/_core/test_api_injector.py`](diffhunk://#diff-7f40fa8f30089fd08ec9b591125853a27fcebddd6a7aa5516e54935ba676e47eL422-L430): The `test_get_aoai_telemetry_headers` test was updated to reflect changes in telemetry data handling. Additional tests were added to check for the presence of user-defined properties in the headers. [[1]](diffhunk://#diff-7f40fa8f30089fd08ec9b591125853a27fcebddd6a7aa5516e54935ba676e47eL422-L430) [[2]](diffhunk://#diff-7f40fa8f30089fd08ec9b591125853a27fcebddd6a7aa5516e54935ba676e47eL449-R454)

* [`src/promptflow/tests/executor/unittests/_core/test_operation_context.py`](diffhunk://#diff-963d0112df022bec97a27352ce22ed8fc8756afdf8487817ddd413cf2e2d66c6L62-R65): The `test_setattr_non_primitive` test was updated to reflect the removal of the primitive check in the `__setattr__` method.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
