### PR TITLE
[Executor][Internal] Add line run id to otel span

### DIFF
--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -17,8 +17,17 @@ class OperationContext(Dict):
     """
 
     _CONTEXT_KEY = "operation_context"
+    _OTEL_ATTRIBUTES = "_otel_attributes"
     _current_context = ContextVar(_CONTEXT_KEY, default=None)
     USER_AGENT_KEY = "user_agent"
+
+    def _add_otel_attributes(self, key, value):
+        attributes = self.get(OperationContext._OTEL_ATTRIBUTES, {})
+        attributes[key] = value
+        self[OperationContext._OTEL_ATTRIBUTES] = attributes
+
+    def _get_otel_attributes(self):
+        return self.get(OperationContext._OTEL_ATTRIBUTES, {})
 
     @classmethod
     def get_instance(cls):

--- a/src/promptflow/promptflow/_trace/_start_trace.py
+++ b/src/promptflow/promptflow/_trace/_start_trace.py
@@ -15,7 +15,7 @@ from opentelemetry.sdk.resources import SERVICE_NAME, Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from promptflow._constants import TRACE_SESSION_ID_OP_CTX_NAME
+from promptflow._constants import TRACE_SESSION_ID_OP_CTX_NAME, SpanAttributeFieldName
 from promptflow._core.openai_injector import inject_openai_api
 from promptflow._core.operation_context import OperationContext
 from promptflow._utils.logger_utils import get_cli_sdk_logger
@@ -105,6 +105,7 @@ def _provision_session() -> str:
     session_id = str(uuid.uuid4())
     session_id_context_info = {TRACE_SESSION_ID_OP_CTX_NAME: session_id}
     operation_context.update(session_id_context_info)
+    operation_context._add_otel_attributes(SpanAttributeFieldName.SESSION_ID, session_id)
     return session_id
 
 

--- a/src/promptflow/promptflow/executor/flow_executor.py
+++ b/src/promptflow/promptflow/executor/flow_executor.py
@@ -718,6 +718,8 @@ class FlowExecutor:
         operation_context = OperationContext.get_instance()
         operation_context.run_mode = operation_context.get("run_mode", None) or RunMode.Test.name
         operation_context.update({"flow-id": self._flow_id, "root-run-id": run_id})
+        if operation_context.run_mode == RunMode.Test.name:
+            operation_context._add_otel_attributes("line_run_id", run_id)
 
     def _add_line_results(self, line_results: List[LineResult], run_tracker: Optional[RunTracker] = None):
         run_tracker = run_tracker or self._run_tracker


### PR DESCRIPTION
# Description

Refine the logic to add otel common attributes and add line_run_id in it.

This pull request primarily focuses on enhancing the OpenTelemetry (OTel) attributes handling in the `promptflow` package. The main changes include the addition of OTel attributes handling methods in the `OperationContext` class, the removal of the `TRACE_SESSION_ID_OP_CTX_NAME` constant from the `tracer.py` file, and the modification of the `enrich_span_with_trace` function to use the new OTel attributes methods. Furthermore, the `SpanAttributeFieldName.SESSION_ID` attribute is now added to the operation context in the `_provision_session` function, and a new attribute `line_run_id` is added in the `_update_operation_context` function when the run mode is `Test`.

Enhancements to OpenTelemetry attributes handling:

* [`src/promptflow/promptflow/_core/operation_context.py`](diffhunk://#diff-9178fcc0ca6dea0124a2a13bb8e734a77ffbc4baadfe29d18a366452ff8f865aR20-R31): Added `_add_otel_attributes` and `_get_otel_attributes` methods to the `OperationContext` class for managing OTel attributes. These methods allow adding key-value pairs to the OTel attributes and retrieving them, respectively.

Codebase simplification:

* [`src/promptflow/promptflow/_core/tracer.py`](diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L18): Removed the `TRACE_SESSION_ID_OP_CTX_NAME` constant and updated the `enrich_span_with_trace` function to use the new OTel attributes methods from the `OperationContext` class instead of directly accessing the session ID. [[1]](diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L18) [[2]](diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L211-R220)

Additional changes to operation context:

* [`src/promptflow/promptflow/_trace/_start_trace.py`](diffhunk://#diff-ed1236ad6e2c58ec795bb9bd27e3c83f7c0b61e11524f0b835210e817a3f1309R108): Added the `SpanAttributeFieldName.SESSION_ID` attribute to the operation context in the `_provision_session` function.
* [`src/promptflow/promptflow/executor/flow_executor.py`](diffhunk://#diff-faa6c81d614b7e41b18a42a93139d961d92afa9aa9dd0b72cb6b7176d7541e69R721-R722): Added a new attribute `line_run_id` to the operation context in the `_update_operation_context` function when the run mode is `Test`.
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
