### PR TITLE
fix uai get token bug

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [SDK/CLI] The inputs of node test allows the value of reference node output be passed directly in.
 - [SDK/CLI][azure] Fixed bug for cloud batch run referencing registry flow with automatic runtime.
 - [SDK/CLI] Fix "Without Import Data" in run visualize page when invalid JSON value exists in metrics.
+- [SDK/CLI][azure] Fix azureml serving get UAI(user assigned identity) token failure bug.
 
 ### Improvements
 

--- a/src/promptflow/promptflow/_sdk/_serving/extension/azureml_extension.py
+++ b/src/promptflow/promptflow/_sdk/_serving/extension/azureml_extension.py
@@ -5,6 +5,7 @@
 import json
 import os
 import re
+from typing import Any
 
 from promptflow._sdk._serving._errors import InvalidConnectionData, MissingConnectionProvider
 from promptflow._sdk._serving.extension.default_extension import AppExtension
@@ -193,8 +194,13 @@ class AzureMLExtension(AppExtension):
 
 def _get_managed_identity_credential_with_retry(**kwargs):
     from azure.identity import ManagedIdentityCredential
+    from azure.identity._constants import EnvironmentVariables
 
     class ManagedIdentityCredentialWithRetry(ManagedIdentityCredential):
+        def __init__(self, **kwargs: Any) -> None:
+            client_id = kwargs.pop("client_id", None) or os.environ.get(EnvironmentVariables.AZURE_CLIENT_ID)
+            super().__init__(client_id=client_id, **kwargs)
+
         @retry(Exception)
         def get_token(self, *scopes, **kwargs):
             return super().get_token(*scopes, **kwargs)


### PR DESCRIPTION
# Description

there are multiple internal implementation inside ManagedIdentityCredential, not all of the implementations handle the UAI with AZURE_CLIENT_ID, we need to pass it as client_id when initialize the ManagedIdentityCredential 

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
