### PR TITLE
Add resume from contract to batch engine

### DIFF
--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -42,7 +42,7 @@ from promptflow.exceptions import ErrorTarget, PromptflowException
 from promptflow.executor._line_execution_process_pool import signal_handler
 from promptflow.executor._result import AggregationResult, LineResult
 from promptflow.executor.flow_validator import FlowValidator
-from promptflow.storage._run_storage import AbstractRunStorage
+from promptflow.storage._run_storage import AbstractBatchRunStorage, AbstractRunStorage
 
 OUTPUT_FILE_NAME = "output.jsonl"
 DEFAULT_CONCURRENCY = 10
@@ -128,7 +128,7 @@ class BatchEngine:
         run_id: Optional[str] = None,
         max_lines_count: Optional[int] = None,
         raise_on_line_failure: Optional[bool] = False,
-        resume_from_run_storage: Optional[AbstractRunStorage] = None,
+        resume_from_run_storage: Optional[AbstractBatchRunStorage] = None,
         resume_from_run_output_dir: Optional[Path] = None,
     ) -> BatchResult:
         """Run flow in batch mode

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -145,6 +145,12 @@ class BatchEngine:
         :type max_lines_count: Optional[int]
         :param raise_on_line_failure: Whether to raise exception when a line fails.
         :type raise_on_line_failure: Optional[bool]
+        :param resume_from_run_storage: The run storage to load flow run and node run from the original
+                                        run. The resume behavior is to reuse succeeded line result of
+                                        the original run and run/rerun the remaining/failed lines.
+        :type resume_from_run_storage: Optional[AbstractRunStorage]
+        :param resume_from_run_output_dir: The output dir of the original run.
+        :type resume_from_run_output_dir: Optional[Path]
         :return: The result of this batch run
         :rtype: ~promptflow.batch._result.BatchResult
         """

--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -128,6 +128,8 @@ class BatchEngine:
         run_id: Optional[str] = None,
         max_lines_count: Optional[int] = None,
         raise_on_line_failure: Optional[bool] = False,
+        resume_from_run_storage: Optional[AbstractRunStorage] = None,
+        resume_from_run_output_dir: Optional[Path] = None,
     ) -> BatchResult:
         """Run flow in batch mode
 


### PR DESCRIPTION
# Description

Add input parameters `resume_from_run_storage` and `resume_from_run_output_dir` to `BatchEngine.run` method.
It is the contract between SDK/Runtime and batch engine to support resume from feature.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
