### PR TITLE
[Executor][Internal] Adjust legacy tracer logic to avoid warnings when directly uses trace

### DIFF
--- a/src/promptflow/promptflow/_core/tracer.py
+++ b/src/promptflow/promptflow/_core/tracer.py
@@ -58,17 +58,11 @@ class Tracer(ThreadLocalSingleton):
         return tracer._run_id
 
     @classmethod
-    def end_tracing(cls, run_id: Optional[str] = None, raise_ex=False):
+    def end_tracing(cls, run_id: Optional[str] = None):
         tracer = cls.active_instance()
         if not tracer:
-            msg = "Try end tracing but no active tracer in current context."
-            if raise_ex:
-                raise Exception(msg)
-            logging.warning(msg)
             return []
         if run_id is not None and tracer._run_id != run_id:
-            msg = f"Try to end tracing for run {run_id} but {tracer._run_id} is active."
-            logging.warning(msg)
             return []
         tracer._deactivate_in_context()
         return tracer.to_json()
@@ -77,7 +71,6 @@ class Tracer(ThreadLocalSingleton):
     def push(cls, trace: Trace):
         obj = cls.active_instance()
         if not obj:
-            logging.warning("Try to push trace but no active tracer in current context.")
             return
         obj._push(trace)
 
@@ -262,9 +255,11 @@ def enrich_span_with_trace(span, trace):
                 "framework": "promptflow",
                 "span_type": trace.type.value,
                 "function": trace.name,
-                "node_name": get_node_name_from_context(),
             }
         )
+        node_name = get_node_name_from_context()
+        if node_name:
+            span.set_attribute("node_name", node_name)
         enrich_span_with_context(span)
     except Exception as e:
         logging.warning(f"Failed to enrich span with trace: {e}")

--- a/src/promptflow/tests/executor/e2etests/test_batch_engine.py
+++ b/src/promptflow/tests/executor/e2etests/test_batch_engine.py
@@ -1,6 +1,7 @@
 import asyncio
 import multiprocessing
 import os
+import traceback
 import uuid
 from pathlib import Path
 from tempfile import mkdtemp
@@ -36,7 +37,23 @@ async def async_submit_batch_run(flow_folder, inputs_mapping, connections):
     return batch_result
 
 
-def run_batch_with_start_method(multiprocessing_start_method, flow_folder, inputs_mapping, dev_connections):
+def run_batch_with_start_method(
+    multiprocessing_start_method,
+    flow_folder,
+    inputs_mapping,
+    dev_connections,
+    exception_queue,
+):
+    try:
+        _run_batch_with_start_method(multiprocessing_start_method, flow_folder, inputs_mapping, dev_connections)
+    except BaseException as e:
+        msg = f"Hit exception: {e}\nStack trace: {traceback.format_exc()}"
+        print(msg)
+        exception_queue.put(Exception(msg))
+        raise
+
+
+def _run_batch_with_start_method(multiprocessing_start_method, flow_folder, inputs_mapping, dev_connections):
     os.environ["PF_BATCH_METHOD"] = multiprocessing_start_method
     batch_result, output_dir = submit_batch_run(
         flow_folder, inputs_mapping, connections=dev_connections, return_output_dir=True
@@ -166,12 +183,16 @@ class TestBatch:
     def test_spawn_mode_batch_run(self, flow_folder, inputs_mapping, dev_connections):
         if "spawn" not in multiprocessing.get_all_start_methods():
             pytest.skip("Unsupported start method: spawn")
+        exception_queue = multiprocessing.Queue()
         p = multiprocessing.Process(
-            target=run_batch_with_start_method, args=("spawn", flow_folder, inputs_mapping, dev_connections)
+            target=run_batch_with_start_method,
+            args=("spawn", flow_folder, inputs_mapping, dev_connections, exception_queue)
         )
         p.start()
         p.join()
-        assert p.exitcode == 0
+        if p.exitcode != 0:
+            ex = exception_queue.get(timeout=1)
+            raise ex
 
     @pytest.mark.parametrize(
         "flow_folder, inputs_mapping",
@@ -197,12 +218,16 @@ class TestBatch:
     def test_forkserver_mode_batch_run(self, flow_folder, inputs_mapping, dev_connections):
         if "forkserver" not in multiprocessing.get_all_start_methods():
             pytest.skip("Unsupported start method: forkserver")
+        exception_queue = multiprocessing.Queue()
         p = multiprocessing.Process(
-            target=run_batch_with_start_method, args=("forkserver", flow_folder, inputs_mapping, dev_connections)
+            target=run_batch_with_start_method,
+            args=("forkserver", flow_folder, inputs_mapping, dev_connections, exception_queue)
         )
         p.start()
         p.join()
-        assert p.exitcode == 0
+        if p.exitcode != 0:
+            ex = exception_queue.get(timeout=1)
+            raise ex
 
     def test_batch_run_then_eval(self, dev_connections):
         batch_resutls, output_dir = submit_batch_run(

--- a/src/promptflow/tests/executor/unittests/_core/test_tracer.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tracer.py
@@ -36,13 +36,8 @@ class TestTracer:
         # Assert that there is no active tracer instance after ending tracing
         assert Tracer.active_instance() is None
 
-        # Test the raise_ex argument of the end_tracing method
-        with pytest.raises(Exception):
-            # Try to end tracing again with raise_ex=True
-            Tracer.end_tracing(raise_ex=True)
-
         # Try to end tracing again with raise_ex=False
-        traces = Tracer.end_tracing(raise_ex=False)
+        traces = Tracer.end_tracing()
 
         # Assert that the traces are empty
         assert not traces
@@ -109,8 +104,6 @@ class TestTracer:
 
         # test the push method with no active tracer
         Tracer.push(trace1)
-        # assert that the warning message is logged
-        assert "Try to push trace but no active tracer in current context." in caplog.text
 
     def test_unserializable_obj_to_serializable(self):
         # assert that the function returns a str object for unserializable objects


### PR DESCRIPTION
# Description

Currently there are following warnings when directly call some function with @trace
```
WARNING:root:Try to push trace but no active tracer in current context.
WARNING:opentelemetry.attributes:Invalid type NoneType for attribute 'node_name' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequen
WARNING:root:Try to push trace but no active tracer in current context.
WARNING:opentelemetry.attributes:Invalid type NoneType for attribute 'node_name' value. Expected one of ['bool', 'str', 'bytes', 'int', 'float'] or a sequence of those types
```

This pull request for `src/promptflow/promptflow/_core/tracer.py` includes changes that simplify the code and improve error handling. The most significant changes include removing unnecessary logging warnings and exception raising in the `end_tracing` method, removing a logging warning in the `push` method, and improving the handling of the `node_name` attribute in the `enrich_span_with_trace` method.

Code simplification and improved error handling:

* [`src/promptflow/promptflow/_core/tracer.py`](diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L61-L71): Removed unnecessary logging warnings and exception raising in the `end_tracing` method, simplifying the code and making it easier to understand.
* [`src/promptflow/promptflow/_core/tracer.py`](diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L80): Removed a logging warning in the `push` method, making the code cleaner and more straightforward.

Improved attribute handling:

* [`src/promptflow/promptflow/_core/tracer.py`](diffhunk://#diff-8f8c2ae53e5ffd37a14e8a899119fbb2742486db8faab6df3fcf506e1b720ad8L265-R262): Modified the `enrich_span_with_trace` method to only set the `node_name` attribute if it exists, improving the handling of this attribute and preventing potential issues.
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
