### PR TITLE
Copy context when create monitor thread.

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Tuple
 from promptflow._core.flow_execution_context import FlowExecutionContext
 from promptflow._core.tools_manager import ToolsManager
 from promptflow._utils.logger_utils import flow_logger
+from promptflow._utils.thread_utils import create_thread_with_context_vars
 from promptflow._utils.utils import extract_user_frame_summaries, set_context
 from promptflow.contracts.flow import Node
 from promptflow.executor._dag_manager import DAGManager
@@ -57,10 +58,10 @@ class AsyncNodesScheduler:
         # Semaphore should be created in the loop, otherwise it will not work.
         loop = asyncio.get_running_loop()
         self._semaphore = asyncio.Semaphore(self._node_concurrency)
-        monitor = threading.Thread(
-            target=monitor_long_running_coroutine,
-            args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),
+        monitor = create_thread_with_context_vars(
+            target_function=monitor_long_running_coroutine,
             daemon=True,
+            target_args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),
         )
         monitor.start()
 
@@ -174,7 +175,7 @@ def signal_handler(sig, frame):
     """
     flow_logger.info(f"Received signal {sig}({signal.Signals(sig).name}), start coroutine monitor thread.")
     loop = asyncio.get_running_loop()
-    monitor = threading.Thread(target=monitor_coroutine_after_cancellation, args=(loop,))
+    monitor = create_thread_with_context_vars(target_function=monitor_coroutine_after_cancellation, target_args=(loop,))
     monitor.start()
     raise KeyboardInterrupt
 


### PR DESCRIPTION
# Description

Add util method to create new thread with context vars and use it in executor's new thread.

We are using `FileHandlerConcurrentWrapper` to write log content to specific logger file.
Which will retrieve `FileHandler` by context var.
![image](https://github.com/microsoft/promptflow/assets/17527303/a6ca2a45-e258-444b-8f20-48d72a771005)

If don't copy contextvars, the log content will not be written to file.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
