### PR TITLE
[promptflow][internal] BugFix: ignore line run when main root span is absent

### DIFF
--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -230,7 +230,7 @@ class LineRun:
     evaluations: typing.Optional[typing.List[typing.Dict]] = None
 
     @staticmethod
-    def _from_spans(spans: typing.List[Span]) -> "LineRun":
+    def _from_spans(spans: typing.List[Span]) -> typing.Optional["LineRun"]:
         main_line_run_data: _LineRunData = None
         evaluation_line_run_data_dict = dict()
         for span in spans:
@@ -244,6 +244,11 @@ class LineRun:
             else:
                 # eager flow/arbitrary script
                 main_line_run_data = _LineRunData._from_root_span(span)
+        # main line run span is absent, ignore this line run
+        # this may happen when the line is still executing, or terminated
+        if main_line_run_data is None:
+            return None
+
         evaluations = dict()
         for eval_name, eval_line_run_data in evaluation_line_run_data_dict.items():
             evaluations[eval_name] = eval_line_run_data

--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -245,7 +245,8 @@ class LineRun:
                 # eager flow/arbitrary script
                 main_line_run_data = _LineRunData._from_root_span(span)
         # main line run span is absent, ignore this line run
-        # this may happen when the line is still executing, or terminated
+        # this may happen when the line is still executing, or terminated;
+        # or the line run is killed before the traces exported
         if main_line_run_data is None:
             return None
 

--- a/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
@@ -63,5 +63,7 @@ class TraceOperations:
                 pass
         for orm_spans in grouped_orm_spans.values():
             spans = [Span._from_orm_object(orm_span) for orm_span in orm_spans]
-            line_runs.append(LineRun._from_spans(spans))
+            line_run = LineRun._from_spans(spans)
+            if line_run is not None:
+                line_runs.append(line_run)
         return line_runs


### PR DESCRIPTION
# Description

In many scenarios (line is still executing, terminated, or even killed for some reasons), there will be no main root span, to avoid exception, we should ignore this line run.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
