### PR TITLE
Create util method to create new thread with context vars.

### DIFF
--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Tuple
 from promptflow._core.flow_execution_context import FlowExecutionContext
 from promptflow._core.tools_manager import ToolsManager
 from promptflow._utils.logger_utils import flow_logger
+from promptflow._utils.thread_utils import create_thread_with_context_vars
 from promptflow._utils.utils import extract_user_frame_summaries, set_context
 from promptflow.contracts.flow import Node
 from promptflow.executor._dag_manager import DAGManager
@@ -57,10 +58,10 @@ class AsyncNodesScheduler:
         # Semaphore should be created in the loop, otherwise it will not work.
         loop = asyncio.get_running_loop()
         self._semaphore = asyncio.Semaphore(self._node_concurrency)
-        monitor = threading.Thread(
-            target=monitor_long_running_coroutine,
-            args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),
+        monitor = create_thread_with_context_vars(
+            target_function=monitor_long_running_coroutine,
             daemon=True,
+            target_args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),
         )
         monitor.start()
 
@@ -174,7 +175,7 @@ def signal_handler(sig, frame):
     """
     flow_logger.info(f"Received signal {sig}({signal.Signals(sig).name}), start coroutine monitor thread.")
     loop = asyncio.get_running_loop()
-    monitor = threading.Thread(target=monitor_coroutine_after_cancellation, args=(loop,))
+    monitor = create_thread_with_context_vars(target_function=monitor_coroutine_after_cancellation, target_args=(loop,))
     monitor.start()
     raise KeyboardInterrupt
 

--- a/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow/promptflow/executor/_async_nodes_scheduler.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, List, Tuple
 from promptflow._core.flow_execution_context import FlowExecutionContext
 from promptflow._core.tools_manager import ToolsManager
 from promptflow._utils.logger_utils import flow_logger
-from promptflow._utils.thread_utils import create_thread_with_context_vars
+from promptflow._utils.thread_utils import ThreadWithContextVars
 from promptflow._utils.utils import extract_user_frame_summaries, set_context
 from promptflow.contracts.flow import Node
 from promptflow.executor._dag_manager import DAGManager
@@ -58,10 +58,10 @@ class AsyncNodesScheduler:
         # Semaphore should be created in the loop, otherwise it will not work.
         loop = asyncio.get_running_loop()
         self._semaphore = asyncio.Semaphore(self._node_concurrency)
-        monitor = create_thread_with_context_vars(
-            target_function=monitor_long_running_coroutine,
+        monitor = ThreadWithContextVars(
+            target=monitor_long_running_coroutine,
+            args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),
             daemon=True,
-            target_args=(loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event),
         )
         monitor.start()
 
@@ -175,7 +175,7 @@ def signal_handler(sig, frame):
     """
     flow_logger.info(f"Received signal {sig}({signal.Signals(sig).name}), start coroutine monitor thread.")
     loop = asyncio.get_running_loop()
-    monitor = create_thread_with_context_vars(target_function=monitor_coroutine_after_cancellation, target_args=(loop,))
+    monitor = ThreadWithContextVars(target=monitor_coroutine_after_cancellation, args=(loop,))
     monitor.start()
     raise KeyboardInterrupt
 

--- a/src/promptflow/tests/executor/e2etests/test_logs.py
+++ b/src/promptflow/tests/executor/e2etests/test_logs.py
@@ -233,3 +233,14 @@ class TestExecutorLogs:
                 "i.e. '${flow.text}' is equal to 'world'.",
             ]
             assert all(log in log_content for log in logs_list)
+
+    def test_async_log_in_worker_thread(self):
+        logs_directory = Path(mkdtemp())
+        log_path = str(logs_directory / "flow.log")
+        with LogContext(log_path, run_mode=RunMode.Test):
+            executor = FlowExecutor.create(get_yaml_file("async_tools"), {})
+            executor.exec_line(inputs={})
+            log_content = load_content(log_path)
+            # Below log is created by worker thread
+            logs_list = ["INFO     monitor_long_running_coroutine started"]
+            assert all(log in log_content for log in logs_list)

--- a/src/promptflow/tests/executor/unittests/_utils/test_thread_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_thread_utils.py
@@ -1,14 +1,13 @@
 import contextvars
 import re
 import sys
-import threading
 import time
 from io import StringIO
 from logging import WARNING, Logger, StreamHandler
 
 import pytest
 
-from promptflow._utils.thread_utils import RepeatLogTimer, create_thread_with_context_vars
+from promptflow._utils.thread_utils import RepeatLogTimer, ThreadWithContextVars
 from promptflow._utils.utils import generate_elapsed_time_messages
 
 
@@ -45,7 +44,7 @@ class TestRepeatLogTimer:
 
 
 @pytest.mark.unittest
-class TestCreateThreadWithContextVars:
+class TestThreadWithContextVars:
     def test_assert_context_var(self):
         # Collect exception raised by worker thread.
         thread_exceptions = []
@@ -58,10 +57,10 @@ class TestCreateThreadWithContextVars:
             except Exception as e:
                 thread_exceptions.append(e)
 
-        thread = create_thread_with_context_vars(target_function)
+        thread = ThreadWithContextVars(target=target_function)
         self.start_and_assert_thread(thread, thread_exceptions)
 
-    def test_assert_inputs(self):
+    def test_assert_parameters(self):
         # Collect exception raised by worker thread.
         thread_exceptions = []
 
@@ -72,23 +71,12 @@ class TestCreateThreadWithContextVars:
             except Exception as e:
                 thread_exceptions.append(e)
 
-        thread = create_thread_with_context_vars(target_function, target_args=("args",), target_kwargs={"key": "value"})
-        self.start_and_assert_thread(thread, thread_exceptions)
-
-    def test_assert_daemon(self):
-        # Collect exception raised by worker thread.
-        thread_exceptions = []
-
-        def target_function(is_deamon):
-            try:
-                assert threading.current_thread().daemon == is_deamon
-            except Exception as e:
-                thread_exceptions.append(e)
-
-        thread = create_thread_with_context_vars(target_function, daemon=True, target_args=(True,))
-        self.start_and_assert_thread(thread, thread_exceptions)
-
-        thread = create_thread_with_context_vars(target_function, daemon=False, target_args=(False,))
+        thread_name = "test_name"
+        thread = ThreadWithContextVars(
+            target=target_function, name=thread_name, args=("args",), kwargs={"key": "value"}, daemon=True
+        )
+        assert thread.name == thread_name
+        assert thread.daemon
         self.start_and_assert_thread(thread, thread_exceptions)
 
     def start_and_assert_thread(self, thread, thread_exceptions):

--- a/src/promptflow/tests/executor/unittests/_utils/test_thread_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_thread_utils.py
@@ -1,12 +1,14 @@
+import contextvars
 import re
 import sys
+import threading
 import time
 from io import StringIO
 from logging import WARNING, Logger, StreamHandler
 
 import pytest
 
-from promptflow._utils.thread_utils import RepeatLogTimer
+from promptflow._utils.thread_utils import RepeatLogTimer, create_thread_with_context_vars
 from promptflow._utils.utils import generate_elapsed_time_messages
 
 
@@ -40,3 +42,59 @@ class TestRepeatLogTimer:
         assert logs, "Logs are empty."
         for log in logs:
             assert re.match(log_pattern, log), f"The wrong log: {log}"
+
+
+@pytest.mark.unittest
+class TestCreateThreadWithContextVars:
+    def test_assert_context_var(self):
+        # Collect exception raised by worker thread.
+        thread_exceptions = []
+        context_var = contextvars.ContextVar("context_var", default=None)
+        context_var.set("test_value")
+
+        def target_function():
+            try:
+                assert context_var.get() == "test_value"
+            except Exception as e:
+                thread_exceptions.append(e)
+
+        thread = create_thread_with_context_vars(target_function)
+        self.start_and_assert_thread(thread, thread_exceptions)
+
+    def test_assert_inputs(self):
+        # Collect exception raised by worker thread.
+        thread_exceptions = []
+
+        def target_function(args, **kwargs):
+            try:
+                assert args == "args"
+                assert kwargs == {"key": "value"}
+            except Exception as e:
+                thread_exceptions.append(e)
+
+        thread = create_thread_with_context_vars(target_function, target_args=("args",), target_kwargs={"key": "value"})
+        self.start_and_assert_thread(thread, thread_exceptions)
+
+    def test_assert_daemon(self):
+        # Collect exception raised by worker thread.
+        thread_exceptions = []
+
+        def target_function(is_deamon):
+            try:
+                assert threading.current_thread().daemon == is_deamon
+            except Exception as e:
+                thread_exceptions.append(e)
+
+        thread = create_thread_with_context_vars(target_function, daemon=True, target_args=(True,))
+        self.start_and_assert_thread(thread, thread_exceptions)
+
+        thread = create_thread_with_context_vars(target_function, daemon=False, target_args=(False,))
+        self.start_and_assert_thread(thread, thread_exceptions)
+
+    def start_and_assert_thread(self, thread, thread_exceptions):
+        thread.start()
+        thread.join()
+        assert not thread.is_alive()
+        if thread_exceptions:
+            # Re-raise the exception in the main thread to make the test fail.
+            raise thread_exceptions[0]


### PR DESCRIPTION
# Description

Add subclass for `threading.Thread`, which could copy context vars by default.
Using this subclass to fix async execution's log missing issue.

We are using `FileHandlerConcurrentWrapper` to write log content to specific logger file.
Which will retrieve `FileHandler` by context var.
![image](https://github.com/microsoft/promptflow/assets/17527303/a6ca2a45-e258-444b-8f20-48d72a771005)

If don't copy contextvars, the log content will not be written to file.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
