### PR TITLE
[SDK/CLI] Support user to configure AzureCliCredential for pfazure commands

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - [SDK/CLI] Support configuring environment variable to directly use `AzureCliCredential` for `pfazure` commands.
   ```dotenv
-  USE_AZURE_CLI_CREDENTIAL=true
+  PF_USE_AZURE_CLI_CREDENTIAL=true
   ```
 
 ## 1.5.0 (2024.02.06)

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Release History
 
+## 1.6.0 (TBD)
+
+### Features Added
+
+- [SDK/CLI] Support configuring environment variable to directly use `AzureCliCredential` for `pfazure` commands.
+  ```dotenv
+  USE_AZURE_CLI_CREDENTIAL=true
+  ```
+
 ## 1.5.0 (2024.02.06)
 
 

--- a/src/promptflow/promptflow/_cli/_utils.py
+++ b/src/promptflow/promptflow/_cli/_utils.py
@@ -490,4 +490,4 @@ def _try_delete_existing_run_record(run_name: str):
 
 
 def _use_azure_cli_credential():
-    return os.environ.get(EnvironmentVariables.USE_AZURE_CLI_CREDENTIAL, "false").lower() == "true"
+    return os.environ.get(EnvironmentVariables.PF_USE_AZURE_CLI_CREDENTIAL, "false").lower() == "true"

--- a/src/promptflow/promptflow/_cli/_utils.py
+++ b/src/promptflow/promptflow/_cli/_utils.py
@@ -19,7 +19,7 @@ import pydash
 from dotenv import load_dotenv
 from tabulate import tabulate
 
-from promptflow._sdk._constants import CLIListOutputFormat
+from promptflow._sdk._constants import CLIListOutputFormat, EnvironmentVariables
 from promptflow._sdk._utils import print_red_error, print_yellow_warning
 from promptflow._utils.exception_utils import ExceptionPresenter
 from promptflow._utils.logger_utils import get_cli_sdk_logger
@@ -102,12 +102,15 @@ def get_credentials_for_cli():
     from azure.identity import AzureCliCredential, DefaultAzureCredential, ManagedIdentityCredential
 
     # May return a different one if executing in local
-    # credential priority: OBO > managed identity > default
+    # credential priority: OBO > azure cli > managed identity > default
     # check OBO via environment variable, the referenced code can be found from below search:
     # https://msdata.visualstudio.com/Vienna/_search?text=AZUREML_OBO_ENABLED&type=code&pageSize=25&filters=ProjectFilters%7BVienna%7D&action=contents
     if os.getenv(IdentityEnvironmentVariable.OBO_ENABLED_FLAG):
         logger.debug("User identity is configured, use OBO credential.")
         credential = AzureMLOnBehalfOfCredential()
+    elif _use_azure_cli_credential():
+        logger.debug("Use azure cli credential since specified in environment variable.")
+        credential = AzureCliCredential()
     else:
         client_id_from_env = os.getenv(IdentityEnvironmentVariable.DEFAULT_IDENTITY_CLIENT_ID)
         if client_id_from_env:
@@ -118,7 +121,7 @@ def get_credentials_for_cli():
             credential = ManagedIdentityCredential(client_id=client_id_from_env)
         elif is_in_ci_pipeline():
             # use managed identity when executing in CI pipeline.
-            logger.debug("Use azure cli credential.")
+            logger.debug("Use azure cli credential since in CI pipeline.")
             credential = AzureCliCredential()
         else:
             # use default Azure credential to handle other cases.
@@ -484,3 +487,7 @@ def _try_delete_existing_run_record(run_name: str):
         ORMRun.delete(run_name)
     except RunNotFoundError:
         pass
+
+
+def _use_azure_cli_credential():
+    return os.environ.get(EnvironmentVariables.USE_AZURE_CLI_CREDENTIAL, "false").lower() == "true"

--- a/src/promptflow/promptflow/_constants.py
+++ b/src/promptflow/promptflow/_constants.py
@@ -53,6 +53,7 @@ STREAMING_ANIMATION_TIME = 0.01
 
 # trace related
 OTEL_RESOURCE_SERVICE_NAME = "promptflow"
+DEFAULT_SPAN_TYPE = "default"
 
 
 class TraceEnvironmentVariableName:
@@ -115,6 +116,3 @@ class ResourceAttributeFieldName:
     EXPERIMENT_NAME = "experiment.name"
     SERVICE_NAME = "service.name"
     SESSION_ID = "session.id"
-
-
-DEFAULT_SPAN_TYPE = "default"

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -440,4 +440,4 @@ class ContextAttributeKey:
 class EnvironmentVariables:
     """The environment variables."""
 
-    USE_AZURE_CLI_CREDENTIAL = "USE_AZURE_CLI_CREDENTIAL"
+    PF_USE_AZURE_CLI_CREDENTIAL = "PF_USE_AZURE_CLI_CREDENTIAL"

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -435,3 +435,9 @@ class ContextAttributeKey:
     # Note: referenced id not used for lineage, only for evaluation
     REFERENCED_LINE_RUN_ID = "referenced.line_run_id"
     REFERENCED_BATCH_RUN_ID = "referenced.batch_run_id"
+
+
+class EnvironmentVariables:
+    """The environment variables."""
+
+    USE_AZURE_CLI_CREDENTIAL = "USE_AZURE_CLI_CREDENTIAL"

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
@@ -47,6 +47,6 @@ class TestUtils:
         from promptflow._cli._utils import get_credentials_for_cli
         from promptflow._sdk._constants import EnvironmentVariables
 
-        with patch.dict("os.environ", {EnvironmentVariables.USE_AZURE_CLI_CREDENTIAL: "true"}):
+        with patch.dict("os.environ", {EnvironmentVariables.PF_USE_AZURE_CLI_CREDENTIAL: "true"}):
             cred = get_credentials_for_cli()
             assert isinstance(cred, AzureCliCredential)

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_utils.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -40,3 +40,13 @@ class TestUtils:
         with pytest.raises(UserErrorException) as e:
             FlowServiceCaller(MagicMock(), MagicMock(), MagicMock())
         assert "_FlowServiceCallerFactory" in str(e.value)
+
+    def test_user_specified_azure_cli_credential(self):
+        from azure.identity import AzureCliCredential
+
+        from promptflow._cli._utils import get_credentials_for_cli
+        from promptflow._sdk._constants import EnvironmentVariables
+
+        with patch.dict("os.environ", {EnvironmentVariables.USE_AZURE_CLI_CREDENTIAL: "true"}):
+            cred = get_credentials_for_cli()
+            assert isinstance(cred, AzureCliCredential)


### PR DESCRIPTION
# Description

- [SDK/CLI] Support configuring environment variable to directly use `AzureCliCredential` for `pfazure` commands.
  ```dotenv
  USE_AZURE_CLI_CREDENTIAL=true
  ```

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
