### PR TITLE
improve get_mac_address

### DIFF
--- a/src/promptflow/promptflow/_sdk/_configuration.py
+++ b/src/promptflow/promptflow/_sdk/_configuration.py
@@ -3,7 +3,6 @@
 # ---------------------------------------------------------
 import logging
 import os.path
-import uuid
 from itertools import product
 from os import PathLike
 from pathlib import Path

--- a/src/promptflow/promptflow/_sdk/_configuration.py
+++ b/src/promptflow/promptflow/_sdk/_configuration.py
@@ -199,9 +199,6 @@ class Configuration(object):
             return installation_id
 
         installation_id = gen_uuid_by_compute_info()
-        if not installation_id:
-            installation_id = str(uuid.uuid4())
-
         self.set_config(key=self.INSTALLATION_ID, value=installation_id)
         return installation_id
 

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -1128,7 +1128,8 @@ def get_mac_address() -> str:
         mac_address = []
         net_addresses = psutil.net_if_addrs()
         # Obtain all MAC addresses, then sort and concatenate them
-        for net_address in net_addresses.values():
+        net_address_list = sorted(net_addresses.items())  # sort by name
+        for name, net_address in net_address_list:
             for net_interface in net_address:
                 if net_interface.family == psutil.AF_LINK and net_interface.address != "00-00-00-00-00-00":
                     mac_address.append(net_interface.address)

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_utils.py
@@ -474,34 +474,14 @@ class TestRetryUtils:
         http_retry_wrapper(mock_http_request, tries=2, delay=1, backoff=1)()
         assert counter == 2
 
-    def test_get_mac_address(self):
-        import psutil
-
-        mac_address = None
-        net_address = psutil.net_if_addrs()
-        eth = []
-        # Query the first network card in order and obtain the MAC address of the first network card.
-        # "Ethernet" is the name of the Windows network card.
-        # "eth", "ens", "eno" are the name of the Linux & Mac network card.
-        net_interface_names = ["Ethernet", "eth0", "eth1", "ens0", "ens1", "eno0", "eno1"]
-        for net_interface_name in net_interface_names:
-            if net_interface_name in net_address:
-                eth = net_address[net_interface_name]
-                break
-        for net_interface in eth:
-            if net_interface.family == psutil.AF_LINK:  # mac address
-                mac_address = str(net_interface.address)
-                break
-
-        assert mac_address != ""
-        assert mac_address == get_mac_address()
-
     def test_gen_uuid_by_compute_info(self):
         uuid1 = gen_uuid_by_compute_info()
         uuid2 = gen_uuid_by_compute_info()
         assert uuid1 == uuid2
 
         mac_address = get_mac_address()
+        assert mac_address
+
         host_name, system, machine = get_system_info()
         system_info_hash = hashlib.sha256((host_name + system + machine).encode()).hexdigest()
         compute_info_hash = hashlib.sha256((mac_address + system_info_hash).encode()).hexdigest()


### PR DESCRIPTION
# Description
Please add an informative description that covers that changes made by the pull request and link all relevant issues.
Due to the inability to fix the name of the first network card, for example, for laptops and Mac mini, their names are different, so change from obtaining the first network card MAC address to obtaining all MAC addresses.
![image](https://github.com/microsoft/promptflow/assets/23182548/4e8a1b2c-24f6-4189-a133-8488ab148775)


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
