### PR TITLE
[Executor][Feature] Support LLM node without connection

### DIFF
--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -289,7 +289,7 @@ class ToolResolver:
             if connection_from_env:
                 return connection_from_env
             raise ConnectionNotFound(
-                message_format="Connection of LLM node '{node_name}' is not set.",
+                message_format="Connection of LLM node '{node_name}' is not found.",
                 node_name=node.name,
                 target=ErrorTarget.EXECUTOR,
             )

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -179,7 +179,7 @@ class TestExecutor:
                 raise_ex=True,
             )
         assert isinstance(e.value.inner_exception, ConnectionNotFound)
-        assert "Connection 'dummy_connection' not found" in str(e.value)
+        assert "Connection of LLM node 'classify_with_llm' is not found." in str(e.value)
 
     @pytest.mark.parametrize(
         "flow_folder",

--- a/src/promptflow/tests/test_configs/flows/llm_no_connection/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/flows/llm_no_connection/flow.dag.yaml
@@ -1,0 +1,17 @@
+inputs:
+  topic:
+    type: string
+    default: apple
+outputs:
+  joke:
+    type: string
+    reference: ${joke.output}
+nodes:
+- name: joke
+  type: llm
+  source:
+    type: code
+    path: joke.jinja2
+  inputs:
+    topic: ${inputs.topic}
+  api: chat

--- a/src/promptflow/tests/test_configs/flows/llm_no_connection/joke.jinja2
+++ b/src/promptflow/tests/test_configs/flows/llm_no_connection/joke.jinja2
@@ -1,0 +1,2 @@
+user:
+Tell me a joke about {{topic}}


### PR DESCRIPTION
# Description

Currently LLM node require connection to initialize openai apis. In this PR, we initialize a connection when it is not set but the environment variable is set so the user doesn't need to create a connection to run a flow.

This pull request primarily focuses on changes in the `src/promptflow/promptflow/executor/_tool_resolver.py` file to improve the resolution of connections for LLM  nodes. It also includes changes to test files to validate these improvements. 

The most significant changes are:

Connection Resolution Improvement:

* [`src/promptflow/promptflow/executor/_tool_resolver.py`](diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65R7): Added the `os` module to access environment variables.
* [`src/promptflow/promptflow/executor/_tool_resolver.py`](diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65L268-R299): Replaced the `_get_node_connection` method with a new method `_resolve_llm_connection_from_env` that fetches the connection details from environment variables. This method is used in the new `_get_llm_node_connection` method which is now used instead of `_get_node_connection` in `_resolve_llm_node` and `_resolve_llm_connection_to_inputs`. [[1]](diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65L268-R299) [[2]](diffhunk://#diff-714d8202b40acb4053e3f9b366ee4972b32f98afc8a2efe8a1750842f1facc65L315-R335)

Test Case Addition:

* [`src/promptflow/tests/executor/e2etests/test_executor_happypath.py`](diffhunk://#diff-44d4009e9df8029bb88432b7a843d3a887764cd6a67070afc49557334af3cbaaR20-R21): Imported `execute_function_in_subprocess` and added a new test case `test_execute_flow_without_llm_connection` to verify the behavior when the LLM connection is not set. [[1]](diffhunk://#diff-44d4009e9df8029bb88432b7a843d3a887764cd6a67070afc49557334af3cbaaR20-R21) [[2]](diffhunk://#diff-44d4009e9df8029bb88432b7a843d3a887764cd6a67070afc49557334af3cbaaR316-R333)
* [`src/promptflow/tests/test_configs/flows/llm_no_connection/flow.dag.yaml`](diffhunk://#diff-608fe6e24219b97f52c00a8866127ab5c10eaea1db1f55d87ffef319aefae729R1-R17): Added a new test configuration for the LLM node without a connection.
* [`src/promptflow/tests/test_configs/flows/llm_no_connection/joke.jinja2`](diffhunk://#diff-8cd642c62af1ec9a0468591aa67f9a2ef1e75b2f4302182b871197da0ec9980bR1-R2): Added a new test template for the LLM node without a connection.

These changes aim to handle the case when the LLM node does not have a connection set, by attempting to resolve the connection from environment variables. The additional test cases ensure that the new functionality works as expected.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
