### PR TITLE
[Executor]Update LineResult.output for eager flow to dict

### DIFF
--- a/src/promptflow/promptflow/executor/_script_executor.py
+++ b/src/promptflow/promptflow/executor/_script_executor.py
@@ -88,6 +88,7 @@ class ScriptExecutor(FlowExecutor):
         finally:
             run_tracker.persist_flow_run(run_info)
         # Make sure line result output is a mapping like dag flow
+        # For primitive type output, we'll convert it to dict with key 'output'
         line_result = LineResult(output_dict, {}, run_info, {})
         #  Return line result with index
         if index is not None and isinstance(line_result.output, dict):

--- a/src/promptflow/promptflow/executor/_script_executor.py
+++ b/src/promptflow/promptflow/executor/_script_executor.py
@@ -69,6 +69,7 @@ class ScriptExecutor(FlowExecutor):
         # which should be removed, so, we only preserve the inputs that are contained in self._inputs.
         inputs = {k: inputs[k] for k in self._inputs if k in inputs}
         output = None
+        output_dict = {}
         traces = []
         try:
             Tracer.start_tracing(line_run_id)

--- a/src/promptflow/promptflow/executor/_script_executor.py
+++ b/src/promptflow/promptflow/executor/_script_executor.py
@@ -87,7 +87,8 @@ class ScriptExecutor(FlowExecutor):
             run_tracker.end_run(line_run_id, ex=e, traces=traces)
         finally:
             run_tracker.persist_flow_run(run_info)
-        line_result = LineResult(output, {}, run_info, {})
+        # Make sure line result output is a mapping like dag flow
+        line_result = LineResult(output_dict, {}, run_info, {})
         #  Return line result with index
         if index is not None and isinstance(line_result.output, dict):
             line_result.output[LINE_NUMBER_KEY] = index

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -282,6 +282,8 @@ class TestFlowTest:
 
         result = _client._flows._test(flow=flow_path)
         assert result.run_info.status.value == "Failed"
+        # output will be empty as flow failed
+        assert result.output == {}
         assert "my_flow() missing 1 required positional argument: 'input_val'" in str(result.run_info.error)
 
     def test_eager_flow_test_with_additional_includes(self):

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -267,6 +267,7 @@ class TestFlowTest:
         flow_path = Path(f"{EAGER_FLOWS_DIR}/primitive_output/").absolute()
         result = _client._flows._test(flow=flow_path, inputs={"input_val": "val1"})
         assert result.run_info.status.value == "Completed"
+        assert result.output == {"output": "Hello world! val1"}
 
     def test_eager_flow_test_invalid_cases(self):
         # wrong entry provided
@@ -296,7 +297,7 @@ class TestFlowTest:
         flow_path = Path(f"{EAGER_FLOWS_DIR}/nested_entry/").absolute()
         result = _client._flows._test(flow=flow_path, inputs={"input_val": "val1"})
         assert result.run_info.status.value == "Completed"
-        assert result.output == "Hello world! val1"
+        assert result.output == {"output": "Hello world! val1"}
 
     def test_eager_flow_with_dataclass_output(self):
         flow_path = Path(f"{EAGER_FLOWS_DIR}/flow_with_dataclass_output/").absolute()

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -297,3 +297,10 @@ class TestFlowTest:
         result = _client._flows._test(flow=flow_path, inputs={"input_val": "val1"})
         assert result.run_info.status.value == "Completed"
         assert result.output == "Hello world! val1"
+
+    def test_eager_flow_with_dataclass_output(self):
+        flow_path = Path(f"{EAGER_FLOWS_DIR}/flow_with_dataclass_output/").absolute()
+        result = _client._flows._test(flow=flow_path, inputs={"input_val": "val1"})
+        assert result.run_info.status.value == "Completed"
+        assert isinstance(result.output, dict)
+        assert result.output == {"models": ["default_model"], "text": "default_text"}


### PR DESCRIPTION
# Description

Eager flow's LineResult.output will be it's original type, convert to dict since experiment scenario will expect it as a dict.
This pull request primarily focuses on two updates in the `src/promptflow` directory. The first update is in the `_script_executor.py` file, where the output of the `_exec_line` function is now ensured to be a mapping like dag flow. The second update is in the `test_flow_test.py` file, where a new test case `test_eager_flow_with_dataclass_output` has been added to verify the output of a flow with dataclass output.

Here are the key changes:

* [`src/promptflow/promptflow/executor/_script_executor.py`](diffhunk://#diff-3294a0ccdf18c47385db91932bd860940cc3df5df10d206138fbcd48075530d5L90-R91): The output of the `_exec_line` function has been updated to ensure it is a mapping like dag flow. This is achieved by changing the `LineResult` object to use `output_dict` instead of `output`.

* [`src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py`](diffhunk://#diff-acf3c2285ac2a7051d59e3a69abe02224e2d6d5d69e3a0aabd2afd9311f87657R300-R306): A new test case `test_eager_flow_with_dataclass_output` has been added. This test case checks if the output of a flow with dataclass output is a dictionary and matches the expected output.
Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
