### PR TITLE
Update msi package process and get latest json version when msi pf upgrade

### DIFF
--- a/.github/workflows/build_msi_installer.yml
+++ b/.github/workflows/build_msi_installer.yml
@@ -56,13 +56,6 @@ jobs:
       - name: Python Setup
         uses: "./.github/actions/step_create_python_environment"
 
-      - name: Setup and Install dev promptflow
-        if: ${{ github.event.inputs.version == null || github.event.inputs.version == '' }}
-        uses: "./.github/actions/step_sdk_setup"
-        with:
-          setupType: promptflow_with_extra
-          scriptPath: ${{ env.testWorkingDirectory }}
-
       - name: Install stable promptflow
         if: ${{ github.event.inputs.version != null && github.event.inputs.version != '' }}
         run: |
@@ -97,6 +90,24 @@ jobs:
           INPUT_VERSION: ${{ github.event.inputs.version }}
           MSI_PRIVATE_VERSION: ${{ github.event.inputs.set_msi_private_version }}
         shell: pwsh
+
+      - name: Update promptflow package version when set msi private version
+        if: ${{ github.event.inputs.set_msi_private_version != null && github.event.inputs.set_msi_private_version != '' }}
+        run: |
+          $override_version = 'VERSION = "{0}"' -f $env:MSI_PRIVATE_VERSION
+          Write-Host "'$override_version' as version"
+          $override_version | Out-File -FilePath "./src/promptflow/promptflow/_version.py" -Encoding ASCII
+        shell: pwsh
+        env:
+          MSI_PRIVATE_VERSION: ${{ github.event.inputs.set_msi_private_version }}
+
+      - name: Setup and Install dev promptflow
+        if: ${{ github.event.inputs.version == null || github.event.inputs.version == '' }}
+        uses: "./.github/actions/step_sdk_setup"
+        with:
+          setupType: promptflow_with_extra
+          scriptPath: ${{ env.testWorkingDirectory }}
+
 
       - name: Build Pyinstaller project
         working-directory: ${{ github.workspace }}/scripts/installer/windows/scripts

--- a/src/promptflow/promptflow/_cli/_pf/_upgrade.py
+++ b/src/promptflow/promptflow/_cli/_pf/_upgrade.py
@@ -40,10 +40,13 @@ def upgrade_version(args):
     from packaging.version import parse
 
     from promptflow._constants import _ENV_PF_INSTALLER, CLI_PACKAGE_NAME
-    from promptflow._utils.version_hint_utils import get_latest_version_from_pypi
+    from promptflow._utils.version_hint_utils import get_latest_version
     from promptflow._version import VERSION as local_version
 
-    latest_version = get_latest_version_from_pypi(CLI_PACKAGE_NAME)
+    installer = os.getenv(_ENV_PF_INSTALLER) or ""
+    installer = installer.upper()
+    print(f"installer: {installer}")
+    latest_version = get_latest_version(CLI_PACKAGE_NAME, installer=installer)
     if not latest_version:
         logger.warning("Failed to get the latest prompt flow version.")
         return
@@ -53,9 +56,6 @@ def upgrade_version(args):
 
     yes = args.yes
     exit_code = 0
-    installer = os.getenv(_ENV_PF_INSTALLER) or ""
-    installer = installer.upper()
-    print(f"installer: {installer}")
     latest_version_msg = (
         "Upgrading prompt flow CLI version to {}.".format(latest_version)
         if yes
@@ -82,7 +82,7 @@ def upgrade_version(args):
             "pip",
             "install",
             "--upgrade",
-            "promptflow[azure,executable,azureml-serving]",
+            "promptflow[azure,executable,azureml-serving,executor-service]",
             "-vv",
             "--disable-pip-version-check",
             "--no-cache-dir",


### PR DESCRIPTION
# Description
- Update promptflow package version when set msi private version
- get latest json version when msi pf upgrade
https://github.com/microsoft/promptflow/actions/runs/7957234441
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
