### PR TITLE
[promptflow][internal] Fix `cumulative_token_count` schema error

### DIFF
--- a/src/promptflow/MANIFEST.in
+++ b/src/promptflow/MANIFEST.in
@@ -1,5 +1,6 @@
 include promptflow/azure/resources/*
 include promptflow/_sdk/_serving/static/*
+include promptflow/_sdk/_service/static/*
 include promptflow/_sdk/_service/templates/*
 recursive-include promptflow/_cli/data *
 recursive-include promptflow/_sdk/data *

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -443,6 +443,12 @@ class EnvironmentVariables:
     PF_USE_AZURE_CLI_CREDENTIAL = "PF_USE_AZURE_CLI_CREDENTIAL"
 
 
+class CumulativeTokenCountFieldName:
+    COMPLETION = "completion"
+    PROMPT = "prompt"
+    TOTAL = "total"
+
+
 class LineRunFieldName:
     LINE_RUN_ID = "line_run_id"
     TRACE_ID = "trace_id"

--- a/src/promptflow/promptflow/_sdk/_service/apis/line_run.py
+++ b/src/promptflow/promptflow/_sdk/_service/apis/line_run.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, dataclass
 
 from flask_restx import fields
 
-from promptflow._sdk._constants import PFS_MODEL_DATETIME_FORMAT, LineRunFieldName
+from promptflow._sdk._constants import PFS_MODEL_DATETIME_FORMAT, CumulativeTokenCountFieldName, LineRunFieldName
 from promptflow._sdk._service import Namespace, Resource
 from promptflow._sdk._service.utils.utils import get_client_from_request
 
@@ -32,6 +32,14 @@ class ListLineRunParser:
 
 
 # line run models, for strong type support in Swagger
+cumulative_token_count_model = api.model(
+    "CumulativeTokenCount",
+    {
+        CumulativeTokenCountFieldName.COMPLETION: fields.Integer,
+        CumulativeTokenCountFieldName.PROMPT: fields.Integer,
+        CumulativeTokenCountFieldName.TOTAL: fields.Integer,
+    },
+)
 evaluation_line_run_model = api.model(
     "EvaluationLineRun",
     {
@@ -46,7 +54,7 @@ evaluation_line_run_model = api.model(
         LineRunFieldName.LATENCY: fields.String(required=True),
         LineRunFieldName.DISPLAY_NAME: fields.String(required=True),
         LineRunFieldName.KIND: fields.String(required=True),
-        LineRunFieldName.CUMULATIVE_TOKEN_COUNT: fields.String,
+        LineRunFieldName.CUMULATIVE_TOKEN_COUNT: fields.Nested(cumulative_token_count_model, skip_none=True),
     },
 )
 line_run_model = api.model(
@@ -63,7 +71,7 @@ line_run_model = api.model(
         LineRunFieldName.LATENCY: fields.String(required=True),
         LineRunFieldName.DISPLAY_NAME: fields.String(required=True),
         LineRunFieldName.KIND: fields.String(required=True),
-        LineRunFieldName.CUMULATIVE_TOKEN_COUNT: fields.String,
+        LineRunFieldName.CUMULATIVE_TOKEN_COUNT: fields.Nested(cumulative_token_count_model, skip_none=True),
         LineRunFieldName.EVALUATIONS: fields.List(fields.Nested(evaluation_line_run_model, skip_none=True)),
     },
 )

--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -20,6 +20,7 @@ from promptflow._constants import (
     SpanResourceFieldName,
     SpanStatusFieldName,
 )
+from promptflow._sdk._constants import CumulativeTokenCountFieldName
 from promptflow._sdk._orm.trace import Span as ORMSpan
 from promptflow._sdk._utils import (
     convert_time_unix_nano_to_timestamp,
@@ -193,9 +194,9 @@ class _LineRunData:
         # if there is no token usage, set `cumulative_token_count` to None
         if total_token_count > 0:
             cumulative_token_count = {
-                "completion": completion_token_count,
-                "prompt": prompt_token_count,
-                "total": total_token_count,
+                CumulativeTokenCountFieldName.COMPLETION: completion_token_count,
+                CumulativeTokenCountFieldName.PROMPT: prompt_token_count,
+                CumulativeTokenCountFieldName.TOTAL: total_token_count,
             }
         else:
             cumulative_token_count = None

--- a/src/promptflow/tests/sdk_pfs_test/e2etests/test_trace.py
+++ b/src/promptflow/tests/sdk_pfs_test/e2etests/test_trace.py
@@ -1,0 +1,65 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import datetime
+import uuid
+
+import pytest
+
+from promptflow._constants import SpanAttributeFieldName, SpanContextFieldName, SpanStatusFieldName
+from promptflow._sdk._constants import CumulativeTokenCountFieldName, LineRunFieldName
+from promptflow._sdk.entities._trace import Span
+
+from ..utils import PFSOperations
+
+
+# flask-restx uses marshmallow before response, so we do need this test class to execute end-to-end test
+@pytest.mark.e2etest
+class TestTrace:
+    def test_cumulative_token_count_type(self, pfs_op: PFSOperations) -> None:
+        completion_token_count, prompt_token_count, total_token_count = 1, 5620, 5621
+        # generate a session id for this test
+        session_id = str(uuid.uuid4())
+        # insert a root span, so that we can list line run from that later
+        mock_span = Span(
+            name=str(uuid.uuid4()),
+            context={
+                SpanContextFieldName.TRACE_ID: str(uuid.uuid4()),
+                SpanContextFieldName.SPAN_ID: str(uuid.uuid4()),
+                SpanContextFieldName.TRACE_STATE: "",
+            },
+            kind="1",
+            start_time=datetime.datetime.now().isoformat(),
+            end_time=datetime.datetime.now().isoformat(),
+            status={
+                SpanStatusFieldName.STATUS_CODE: "Ok",
+            },
+            attributes={
+                SpanAttributeFieldName.FRAMEWORK: "promptflow",
+                SpanAttributeFieldName.SPAN_TYPE: "Flow",
+                # below attributes are mandatory for this test
+                SpanAttributeFieldName.CUMULATIVE_COMPLETION_TOKEN_COUNT: completion_token_count,
+                SpanAttributeFieldName.CUMULATIVE_PROMPT_TOKEN_COUNT: prompt_token_count,
+                SpanAttributeFieldName.CUMULATIVE_TOTAL_TOKEN_COUNT: total_token_count,
+            },
+            resource={
+                "attributes": {
+                    "service.name": "promptflow",
+                    "session.id": session_id,
+                },
+                "schema_url": "",
+            },
+            span_type="Flow",
+            session_id=session_id,
+        )
+        mock_span._persist()
+        response = pfs_op.list_line_runs(session_id=session_id)
+        line_runs = response.json
+        assert len(line_runs) == 1
+        line_run = line_runs[0]
+        cumulative_token_count = line_run[LineRunFieldName.CUMULATIVE_TOKEN_COUNT]
+        assert isinstance(cumulative_token_count, dict)
+        assert cumulative_token_count[CumulativeTokenCountFieldName.COMPLETION] == completion_token_count
+        assert cumulative_token_count[CumulativeTokenCountFieldName.PROMPT] == prompt_token_count
+        assert cumulative_token_count[CumulativeTokenCountFieldName.TOTAL] == total_token_count

--- a/src/promptflow/tests/sdk_pfs_test/utils.py
+++ b/src/promptflow/tests/sdk_pfs_test/utils.py
@@ -4,7 +4,7 @@
 import contextlib
 import getpass
 import json
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 from unittest import mock
 
 import werkzeug
@@ -49,6 +49,7 @@ class PFSOperations:
     CONNECTION_URL_PREFIX = "/v1.0/Connections"
     RUN_URL_PREFIX = "/v1.0/Runs"
     TELEMETRY_PREFIX = "/v1.0/Telemetries"
+    LINE_RUNS_PREFIX = "/v1.0/LineRuns"
 
     def __init__(self, client: FlaskClient):
         self._client = client
@@ -217,4 +218,17 @@ class PFSOperations:
         )
         if status_code:
             assert status_code == response.status_code, response.text
+        return response
+
+    # trace APIs
+    # LineRuns
+    def list_line_runs(self, *, session_id: Optional[str] = None):
+        query_string = {}
+        if session_id is not None:
+            query_string["session"] = session_id
+        response = self._client.get(
+            f"{self.LINE_RUNS_PREFIX}/list",
+            query_string=query_string,
+            headers=self.remote_user_header(),
+        )
         return response


### PR DESCRIPTION
# Description

There is a schema bug for `cumulative_token_count`, it should be an optional dictionary, instead of an optional string.

This PR targets to fix this, so that we can have correct response, and it will be correctly rendered in trace UI; also try to add an end-to-end test to guard this behavior.

This PR also fixes missing update for MANIFEST in #2035 , which leads to missing files when build.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
