### PR TITLE
Fixing the AssistantDefinition not serializable warnings when ensure input serializable

### DIFF
--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -15,9 +15,9 @@ from promptflow._core.thread_local_singleton import ThreadLocalSingleton
 from promptflow._utils.dataclass_serializer import serialize
 from promptflow._utils.exception_utils import ExceptionPresenter
 from promptflow._utils.logger_utils import flow_logger
-from promptflow._utils.multimedia_utils import default_json_encoder
 from promptflow._utils.openai_metrics_calculator import OpenAIMetricsCalculator
 from promptflow._utils.run_tracker_utils import _deep_copy_and_extract_items_from_generator_proxy
+from promptflow._utils.utils import default_json_encoder
 from promptflow.contracts.run_info import FlowRunInfo, RunInfo, Status
 from promptflow.contracts.run_mode import RunMode
 from promptflow.contracts.tool import ConnectionType

--- a/src/promptflow/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow/promptflow/_utils/multimedia_utils.py
@@ -167,13 +167,6 @@ def get_file_reference_encoder(folder_path: Path, relative_path: Path = None, *,
     return pfbytes_file_reference_encoder
 
 
-def default_json_encoder(obj):
-    if isinstance(obj, PFBytes):
-        return str(obj)
-    else:
-        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
-
-
 def persist_multimedia_data(value: Any, base_dir: Path, sub_dir: Path = None):
     pfbytes_file_reference_encoder = get_file_reference_encoder(base_dir, sub_dir)
     serialization_funcs = {Image: partial(Image.serialize, **{"encoder": pfbytes_file_reference_encoder})}

--- a/src/promptflow/promptflow/_utils/utils.py
+++ b/src/promptflow/promptflow/_utils/utils.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Iterator, List, Optional, TypeVar, Union
 
 from promptflow._constants import DEFAULT_ENCODING
+from promptflow.contracts.multimedia import PFBytes
+from promptflow.contracts.types import AssistantDefinition
 
 T = TypeVar("T")
 
@@ -309,3 +311,12 @@ def _normalize_identifier_name(name):
 
 def _sanitize_python_variable_name(name: str):
     return _normalize_identifier_name(name).replace(" ", "_")
+
+
+def default_json_encoder(obj):
+    if isinstance(obj, PFBytes):
+        return str(obj)
+    if isinstance(obj, AssistantDefinition):
+        return obj.serialize()
+    else:
+        raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")


### PR DESCRIPTION
# Description

when execute node of assistant, there would a warning message.  This PR is to fix this.

2024-02-20 16:18:49 +0800    4764 execution.flow     WARNING  Input 'assistant_definition' of assistant is not json serializable, use str to store it.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
