### PR TITLE
[promptflow][internal] Fix traces missing attributes collection bug

### DIFF
--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -118,7 +118,7 @@ class Span:
 
     @staticmethod
     def _from_protobuf_object(obj: PBSpan, resource: typing.Dict) -> "Span":
-        span_dict = json.loads(MessageToJson(obj))
+        span_dict: dict = json.loads(MessageToJson(obj))
         span_id = obj.span_id.hex()
         trace_id = obj.trace_id.hex()
         context = {
@@ -140,7 +140,7 @@ class Span:
         span_type = attributes.get(SpanAttributeFieldName.SPAN_TYPE, DEFAULT_SPAN_TYPE)
 
         # parse from resource.attributes: session id, experiment
-        resource_attributes = resource[SpanResourceFieldName.ATTRIBUTES]
+        resource_attributes: dict = resource[SpanResourceFieldName.ATTRIBUTES]
         session_id = resource_attributes[SpanResourceAttributesFieldName.SESSION_ID]
         experiment = resource_attributes.get(SpanResourceAttributesFieldName.EXPERIMENT_NAME, None)
 

--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -132,7 +132,8 @@ class Span:
         status = {
             SpanStatusFieldName.STATUS_CODE: parse_otel_span_status_code(obj.status.code),
         }
-        attributes = flatten_pb_attributes(span_dict[SpanFieldName.ATTRIBUTES])
+        # we have observed in some scenarios, there is not `attributes` field
+        attributes = flatten_pb_attributes(span_dict.get(SpanFieldName.ATTRIBUTES, dict()))
         # `span_type` are not standard fields in OpenTelemetry attributes
         # for example, LangChain instrumentation, as we do not inject this;
         # so we need to get it with default value to avoid KeyError


### PR DESCRIPTION
# Description

We have observed scenario that some 3p traces do not have field `attributes`, which will lead to a `KeyError`.

This PR targets to fix that with using `dict.get`, plus adding a unit test to guard this.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
