### PR TITLE
[promptflow][bugfix] XFail for flaky test `test_get_details_against_partial_completed_run`

### DIFF
--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
@@ -853,6 +853,9 @@ class TestFlowRun:
             # request id should be included in FlowRequestException
             assert f"request id: {pf.runs._service_caller._request_id}" in str(e.value)
 
+    # it is a known issue that executor/runtime might write duplicate storage for line records,
+    # this will lead to the lines that assert line count (`len(detail)`) fails.
+    @pytest.mark.xfail(reason="BUG 2819328: Duplicate line in flow artifacts jsonl", run=True, strict=False)
     def test_get_details_against_partial_completed_run(
         self, pf: PFClient, runtime: str, randstr: Callable[[str], str]
     ) -> None:


### PR DESCRIPTION
# Description

We have observed a flaky live test `test_get_details_against_partial_completed_run` that results from a known executor/runtime bug when in Azure. This PR targets to leverage `xfail` to handle this flaky test.

**Reference**: <https://pytest.org/en/7.4.x/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail>

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
