### PR TITLE
[Bugfix] fix naming error of legacy 'OpenSourceLLMOnlineEndpointError'

### DIFF
--- a/src/promptflow-tools/promptflow/tools/open_model_llm.py
+++ b/src/promptflow-tools/promptflow/tools/open_model_llm.py
@@ -775,7 +775,7 @@ class MIRCompleteFormatter(ContentFormatterBase):
 
         error_message = f"Unexpected response format. Response: {response_json}"
         print(error_message, file=sys.stderr)
-        raise OpenSourceLLMOnlineEndpointError(message=error_message)
+        raise OpenModelLLMOnlineEndpointError(message=error_message)
 
 
 class LlamaContentFormatter(ContentFormatterBase):


### PR DESCRIPTION
# Description

Legacy error name 'OpenSourceLLMOnlineEndpointError', should be 'OpenModelLLMOnlineEndpointError'

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
