### PR TITLE
[Internal] Filter None value out when get otel attributes

### DIFF
--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -39,7 +39,8 @@ class OperationContext(Dict):
 
     def _get_otel_attributes(self):
         attr_dict = self.get(OperationContext._OTEL_ATTRIBUTES, {})
-        # Filter None value out to avoid error
+        # Filter None value out to avoid error.
+        # case: Experiment run may set 'reference.batch_run_id' to None which cause some exception.
         return {k: v for k, v in attr_dict.items() if v is not None}
 
     @classmethod

--- a/src/promptflow/promptflow/_core/operation_context.py
+++ b/src/promptflow/promptflow/_core/operation_context.py
@@ -38,7 +38,9 @@ class OperationContext(Dict):
         self[OperationContext._OTEL_ATTRIBUTES] = attributes
 
     def _get_otel_attributes(self):
-        return self.get(OperationContext._OTEL_ATTRIBUTES, {})
+        attr_dict = self.get(OperationContext._OTEL_ATTRIBUTES, {})
+        # Filter None value out to avoid error
+        return {k: v for k, v in attr_dict.items() if v is not None}
 
     @classmethod
     def get_instance(cls):


### PR DESCRIPTION
# Description

Experiment run may set 'reference.batch_run_id' to None, filter it out when get otel attributes to avoid following logic exception.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
