### PR TITLE
[promptflow][internal] Support `include_spans` and `line_run_id` query for line runs

### DIFF
--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -463,3 +463,4 @@ class LineRunFieldName:
     KIND = "kind"
     CUMULATIVE_TOKEN_COUNT = "cumulative_token_count"
     EVALUATIONS = "evaluations"
+    SPANS = "spans"

--- a/src/promptflow/promptflow/_sdk/_service/apis/line_run.py
+++ b/src/promptflow/promptflow/_sdk/_service/apis/line_run.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+import hashlib
 import typing
 from dataclasses import asdict, dataclass
 
@@ -10,6 +11,8 @@ from flask_restx import fields
 from promptflow._sdk._constants import PFS_MODEL_DATETIME_FORMAT, CumulativeTokenCountFieldName, LineRunFieldName
 from promptflow._sdk._service import Namespace, Resource
 from promptflow._sdk._service.utils.utils import get_client_from_request
+
+HASH_HEADER_IN_LINE_RUNS_LIST = "X-Line-Runs-List-Hash"
 
 api = Namespace("LineRuns", description="Line runs management")
 
@@ -99,4 +102,15 @@ class LineRuns(Resource):
             line_run_id=args.line_run_id,
             include_spans=args.include_spans,
         )
-        return [asdict(line_run) for line_run in line_runs]
+        line_runs_id_list, line_runs_dict = [], []
+        for line_run in line_runs:
+            line_runs_id_list.append(line_run.line_run_id)
+            line_runs_dict.append(asdict(line_run))
+
+        # create a hash of the sorted list of line run ids
+        # and add it to the response header
+        # so that UX can use it to determine if the line runs have changed
+        line_runs_id_list.sort()
+        line_runs_hash = hashlib.sha256(",".join(line_runs_id_list).encode()).hexdigest()
+
+        return line_runs_dict, 200, {HASH_HEADER_IN_LINE_RUNS_LIST: line_runs_hash}

--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -179,13 +179,7 @@ class _LineRunData:
 
     def _from_root_span(span: Span) -> "_LineRunData":
         attributes: dict = span._content[SpanFieldName.ATTRIBUTES]
-        if SpanAttributeFieldName.LINE_RUN_ID in attributes:
-            line_run_id = attributes[SpanAttributeFieldName.LINE_RUN_ID]
-        elif SpanAttributeFieldName.REFERENCED_LINE_RUN_ID in attributes:
-            line_run_id = attributes[SpanAttributeFieldName.REFERENCED_LINE_RUN_ID]
-        else:
-            # eager flow/arbitrary script
-            line_run_id = span.trace_id
+        line_run_id = span.trace_id
         start_time = datetime.datetime.fromisoformat(span._content[SpanFieldName.START_TIME])
         end_time = datetime.datetime.fromisoformat(span._content[SpanFieldName.END_TIME])
         # calculate `cumulative_token_count`
@@ -235,9 +229,10 @@ class LineRun:
     kind: str
     cumulative_token_count: typing.Optional[typing.Dict[str, int]] = None
     evaluations: typing.Optional[typing.List[typing.Dict]] = None
+    spans: typing.Optional[typing.List[typing.Dict]] = None
 
     @staticmethod
-    def _from_spans(spans: typing.List[Span]) -> typing.Optional["LineRun"]:
+    def _from_spans(spans: typing.List[Span], include_spans: bool = False) -> typing.Optional["LineRun"]:
         main_line_run_data: _LineRunData = None
         evaluations = []
         for span in spans:
@@ -274,4 +269,5 @@ class LineRun:
             kind=main_line_run_data.kind,
             cumulative_token_count=main_line_run_data.cumulative_token_count,
             evaluations=evaluations,
+            spans=list(map(lambda span: span._content, spans)) if include_spans else None,
         )

--- a/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
@@ -25,9 +25,11 @@ class TraceOperations:
     def list_line_runs(
         self,
         session_id: typing.Optional[str] = None,
+        line_run_id: typing.Optional[str] = None,
+        include_spans: bool = False,
     ) -> typing.List[LineRun]:
         line_runs = []
-        orm_spans_group_by_trace_id = ORMLineRun.list(session_id=session_id)
+        orm_spans_group_by_trace_id = ORMLineRun.list(session_id=session_id, line_run_id=line_run_id)
         # merge spans with same `line_run_id` or `referenced.line_run_id` (if exists)
         grouped_orm_spans = {}
         for orm_spans in orm_spans_group_by_trace_id:
@@ -80,7 +82,7 @@ class TraceOperations:
                 pass
         for orm_spans in grouped_orm_spans.values():
             spans = [Span._from_orm_object(orm_span) for orm_span in orm_spans]
-            line_run = LineRun._from_spans(spans)
+            line_run = LineRun._from_spans(spans, include_spans=include_spans)
             if line_run is not None:
                 line_runs.append(line_run)
         return line_runs


### PR DESCRIPTION
# Description

This PR targets to refine the list line runs API `/v1.0/LineRuns/list`:

- Add query parameter `include_spans`: include the spans under that/those line run(s)
- Add query parameter `line_run_id`: query specific line run using id
- Add header `X-Line-Runs-List-Hash` in response header: UX can use it to determine if the line runs have changed

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
