### PR TITLE
[Internal] Refine the retry-after interval for openai retry error

### DIFF
--- a/src/promptflow-tools/promptflow/tools/aoai.py
+++ b/src/promptflow-tools/promptflow/tools/aoai.py
@@ -21,7 +21,7 @@ class AzureOpenAI(ToolProvider):
         super().__init__()
         self.connection = connection
         self._connection_dict = normalize_connection_config(self.connection)
-        self._client = AzureOpenAIClient(max_retries=0, **self._connection_dict)
+        self._client = AzureOpenAIClient(**self._connection_dict)
 
     def calculate_cache_string_for_completion(
         self,

--- a/src/promptflow-tools/promptflow/tools/aoai.py
+++ b/src/promptflow-tools/promptflow/tools/aoai.py
@@ -21,7 +21,7 @@ class AzureOpenAI(ToolProvider):
         super().__init__()
         self.connection = connection
         self._connection_dict = normalize_connection_config(self.connection)
-        self._client = AzureOpenAIClient(**self._connection_dict)
+        self._client = AzureOpenAIClient(max_retries=0, **self._connection_dict)
 
     def calculate_cache_string_for_completion(
         self,

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import re
-import random
 import sys
 import time
 from typing import List, Mapping
@@ -203,7 +202,6 @@ def handle_openai_error(tries: int = 100):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            i = 0
             for i in range(tries + 1):
                 try:
                     return func(*args, **kwargs)
@@ -230,7 +228,7 @@ def handle_openai_error(tries: int = 100):
                         # Exit retry if max retry reached
                         print(f"{type(e).__name__} reached max retry. Exit retry with user error.", file=sys.stderr)
                         raise ExceedMaxRetryTimes(e)
-                    
+
                     if hasattr(e, 'response') and e.response is not None:
                         retry_after_in_header = e.response.headers.get("retry-after", None)
                     else:

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -191,6 +191,7 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
+            i = 0
             while True:
                 try:
                     return func(*args, **kwargs)
@@ -238,6 +239,7 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
                         )
                         print(msg, file=sys.stderr)
                     time.sleep(retry_after_seconds)
+                    i += 1
                 except OpenAIError as e:
                     # For other non-retriable errors from OpenAIError,
                     # For example, AuthenticationError, APIConnectionError, BadRequestError, NotFoundError

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -228,7 +228,7 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
                         )
                         print(msg, file=sys.stderr)
                     else:
-                        retry_after_seconds = float(retry_after_in_header) + random.randint(0, 16)
+                        retry_after_seconds = float(retry_after_in_header) + random.randint(0, 30)
                         msg = (
                             f"{type(e).__name__} #{i}, Retry-After={retry_after_in_header}, "
                             f"Back off {retry_after_seconds} seconds for retry."

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -179,12 +179,12 @@ def to_content_str_or_list(chat_str: str, hash2images: Mapping):
 
 
 def generate_retry_interval(retry_count: int) -> float:
-    minBackoffInSec = 3
-    maxBackoffInSec = 60
-    retry_interval = minBackoffInSec + ((2 ** retry_count) - 1)
+    min_backoff_in_sec = 3
+    max_backoff_in_sec = 60
+    retry_interval = min_backoff_in_sec + ((2 ** retry_count) - 1)
 
-    if retry_interval > maxBackoffInSec:
-        retry_interval = maxBackoffInSec
+    if retry_interval > max_backoff_in_sec:
+        retry_interval = max_backoff_in_sec
     return retry_interval
 
 

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -214,11 +214,6 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
                         # Exit retry if this is quota insufficient error
                         print(f"{type(e).__name__} with insufficient quota. Throw user error.", file=sys.stderr)
                         raise WrappedOpenAIError(e)
-                    if i == tries:
-                        # Exit retry if max retry reached
-                        print(f"{type(e).__name__} reached max retry. Exit retry with user error.", file=sys.stderr)
-                        raise ExceedMaxRetryTimes(e)
-
                     if hasattr(e, 'response') and e.response is not None:
                         retry_after_in_header = e.response.headers.get("retry-after", None)
                     else:

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -224,14 +224,14 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
                         retry_after_in_header = None
 
                     if not retry_after_in_header:
-                        retry_after_seconds = delay * (2 ** i)
+                        retry_after_seconds = delay + (2 ** i)
                         msg = (
                             f"{type(e).__name__} #{i}, but no Retry-After header, "
                             + f"Back off {retry_after_seconds} seconds for retry."
                         )
                         print(msg, file=sys.stderr)
                     else:
-                        retry_after_seconds = float(retry_after_in_header) * (2 ** i)
+                        retry_after_seconds = retry_after_in_header
                         msg = (
                             f"{type(e).__name__} #{i}, Retry-After={retry_after_in_header}, "
                             f"Back off {retry_after_seconds} seconds for retry."

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import re
+import random
 import sys
 import time
 from typing import List, Mapping
@@ -227,7 +228,7 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
                         )
                         print(msg, file=sys.stderr)
                     else:
-                        retry_after_seconds = float(retry_after_in_header)
+                        retry_after_seconds = float(retry_after_in_header) + random.randint(0, 16)
                         msg = (
                             f"{type(e).__name__} #{i}, Retry-After={retry_after_in_header}, "
                             f"Back off {retry_after_seconds} seconds for retry."

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -191,7 +191,7 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
     def decorator(func):
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
-            for i in range(tries + 1):
+            while True:
                 try:
                     return func(*args, **kwargs)
                 except (SystemErrorException, UserErrorException) as e:

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -231,7 +231,7 @@ def handle_openai_error(tries: int = 10, delay: float = 8.0):
                         )
                         print(msg, file=sys.stderr)
                     else:
-                        retry_after_seconds = retry_after_in_header
+                        retry_after_seconds = float(retry_after_in_header)
                         msg = (
                             f"{type(e).__name__} #{i}, Retry-After={retry_after_in_header}, "
                             f"Back off {retry_after_seconds} seconds for retry."

--- a/src/promptflow-tools/tests/test_handle_openai_error.py
+++ b/src/promptflow-tools/tests/test_handle_openai_error.py
@@ -161,9 +161,8 @@ class TestHandleOpenAIError:
 
             # Apply the retry decorator to the patched test_method
             max_retry = 2
-            delay = 0.2
             header_delay = 0.3
-            decorated_test_method = handle_openai_error(tries=max_retry, delay=delay)(patched_test_method)
+            decorated_test_method = handle_openai_error(tries=max_retry)(patched_test_method)
             mock_sleep = mocker.patch("time.sleep")  # Create a separate mock for time.sleep
 
             with pytest.raises(UserErrorException) as exc_info:
@@ -175,7 +174,7 @@ class TestHandleOpenAIError:
             assert exc_info.value.error_codes == error_codes.split("/")
             expected_calls = [
                 mocker.call(header_delay),
-                mocker.call(header_delay * 2),
+                mocker.call(header_delay),
             ]
             mock_sleep.assert_has_calls(expected_calls)
 

--- a/src/promptflow-tools/tests/test_handle_openai_error.py
+++ b/src/promptflow-tools/tests/test_handle_openai_error.py
@@ -118,8 +118,7 @@ class TestHandleOpenAIError:
 
             # Apply the retry decorator to the patched test_method
             max_retry = 2
-            delay = 0.2
-            decorated_test_method = handle_openai_error(tries=max_retry, delay=delay)(patched_test_method)
+            decorated_test_method = handle_openai_error(tries=max_retry)(patched_test_method)
             mock_sleep = mocker.patch("time.sleep")  # Create a separate mock for time.sleep
 
             with pytest.raises(UserErrorException) as exc_info:
@@ -130,8 +129,8 @@ class TestHandleOpenAIError:
             error_codes = "UserError/OpenAIError/" + type(dummyEx).__name__
             assert exc_info.value.error_codes == error_codes.split("/")
             expected_calls = [
-                mocker.call(delay),
-                mocker.call(delay * 2),
+                mocker.call(3),
+                mocker.call(4),
             ]
             mock_sleep.assert_has_calls(expected_calls)
 


### PR DESCRIPTION
# Description

Currently the retry-after interval for openai retry error is multiplied by (2 ** i):
1. error without retry-after header: 8 * (2 ** i);
2. error with retry-after header: float(retry_after_in_header) * (2 ** i)
This calculation will cause the retry-after very large when the i (retry_count) is large, e.g.: 608s
![image](https://github.com/microsoft/promptflow/assets/49388944/c3364eba-5f37-4e3a-996d-2bc76f954b00)

This will result in:
1. the job running for a long time, and most of the time are waiting interval, make the resource been wasted.
2. Some lines will failed with timeout because of the long retry-after interval.

Thus, we want to refine the retry-after interval for openai retry error like below:
1. error without retry-after header: minbackoffinsec + (2**i - 1). If this value is larger than 60s, then use 60s instead.
2. error with retry-after header: float(retry_after_in_header). Just respect the retry-after value returned from openai.

Test:
1. Create a test package for this change: 
pip install promptflow-tools==0.0.119298968 --extra-index-url https://azuremlsdktestpypi.azureedge.net/test-promptflow/
3. Create a runtime with this test package, and below is the test result:
original link:
https://ml.azure.com/prompts/flow/f8925d22-478a-4b5c-8e16-a85158d03b9b/bf1c7abc-212e-4544-bcb8-3fce3f0ae627/run/9b6d8fe7-f2da-4328-a454-c2467ecd2db5/details?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourceGroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/promptflow-eastus-dev&tid=72f988bf-86f1-41af-91ab-2d7cd011db47
55 out of 1000 lines has failed because of 10 mins timeout;
link with fix:
https://ml.azure.com/prompts/flow/f8925d22-478a-4b5c-8e16-a85158d03b9b/bf1c7abc-212e-4544-bcb8-3fce3f0ae627/run/1491c004-cc6c-475e-8c75-76b4c9b595e4/details?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourceGroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/promptflow-eastus-dev&tid=72f988bf-86f1-41af-91ab-2d7cd011db47
all 1000 lines has succeeded.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.