### PR TITLE
[Tests] Fix environment related eager flow tests & test_get_incomplete_run

### DIFF
--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -1294,8 +1294,8 @@ class TestFlowRun:
                 data=f"{DATAS_DIR}/env_var_names.jsonl",
             )
 
-            # remove run dag
-            shutil.rmtree(f"{temp_dir}/print_env_var")
+            # remove flow dag
+            os.unlink(f"{temp_dir}/print_env_var/flow.dag.yaml")
 
             # can still get run operations
             LocalStorageOperations(run=run)

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -299,14 +299,14 @@ class TestFlowTest:
         assert result.output == "Hello world! val1"
 
     def test_eager_flow_with_environment_variables(self):
-        clear_module_cache("entry")
+        clear_module_cache("env_var")
         flow_path = Path(f"{EAGER_FLOWS_DIR}/environment_variables/").absolute()
         result = _client._flows._test(flow=flow_path, inputs={})
         assert result.run_info.status.value == "Completed", result.run_info.error
         assert result.output == "Hello world! VAL"
 
     def test_eager_flow_with_evc(self):
-        clear_module_cache("entry")
+        clear_module_cache("evc")
         flow_path = Path(f"{EAGER_FLOWS_DIR}/environment_variables_connection/").absolute()
         result = _client._flows._test(flow=flow_path, inputs={})
         assert result.run_info.status.value == "Completed", result.run_info.error

--- a/src/promptflow/tests/test_configs/eager_flows/environment_variables/env_var.py
+++ b/src/promptflow/tests/test_configs/eager_flows/environment_variables/env_var.py
@@ -4,6 +4,6 @@
 import os
 
 
-def my_flow():
+def env_var_flow():
     """Simple flow without yaml."""
     return f"Hello world! {os.environ.get('TEST')}"

--- a/src/promptflow/tests/test_configs/eager_flows/environment_variables/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/eager_flows/environment_variables/flow.dag.yaml
@@ -1,3 +1,3 @@
-entry: entry:my_flow
+entry: env_var:env_var_flow
 environment_variables:
   TEST: VAL

--- a/src/promptflow/tests/test_configs/eager_flows/environment_variables_connection/evc.py
+++ b/src/promptflow/tests/test_configs/eager_flows/environment_variables_connection/evc.py
@@ -4,6 +4,6 @@
 import os
 
 
-def my_flow():
+def evc_flow():
     """Simple flow without yaml."""
     return f"Hello world! {os.environ.get('TEST')}"

--- a/src/promptflow/tests/test_configs/eager_flows/environment_variables_connection/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/eager_flows/environment_variables_connection/flow.dag.yaml
@@ -1,3 +1,3 @@
-entry: entry:my_flow
+entry: evc:evc_flow
 environment_variables:
   TEST: ${azure_open_ai_connection.api_type}


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

This pull request primarily focuses on the refactoring of test cases and related configurations in the `src/promptflow/tests` directory. The changes include renaming of functions and files, modifying the way flow dags are removed, and updating the module names in the `clear_module_cache` function calls.

Test case refactoring:

* [`src/promptflow/tests/sdk_cli_test/e2etests/test_flow_run.py`](diffhunk://#diff-94a59a05643476869fa3c6bc45466f1582944a935488075e2e63b6a6a196958fL1297-R1298): In the `test_get_incomplete_run` function, the removal of the flow dag has been changed from removing the entire directory to unlinking the specific `flow.dag.yaml` file.

* [`src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py`](diffhunk://#diff-acf3c2285ac2a7051d59e3a69abe02224e2d6d5d69e3a0aabd2afd9311f87657L302-R309): In the `test_eager_flow_with_environment_variables` and `test_eager_flow_with_evc` functions, the module names passed to `clear_module_cache` have been updated from "entry" to "env_var" and "evc" respectively.

File and function renaming:

* [`src/promptflow/tests/test_configs/eager_flows/environment_variables/env_var.py`](diffhunk://#diff-68b1561be1c39b9e59da5d34921714a20b9a4ba68789ec42b057a119eab16113L7-R7): The file was renamed from `entry.py` and the function `my_flow` was renamed to `env_var_flow`.
* [`src/promptflow/tests/test_configs/eager_flows/environment_variables_connection/evc.py`](diffhunk://#diff-58ecbd6e228ba14f58314479717bf24cfc771eded0be617c21dfa215933f052eL7-R7): The file was renamed from `entry.py` and the function `my_flow` was renamed to `evc_flow`.

Configuration updates:

* [`src/promptflow/tests/test_configs/eager_flows/environment_variables/flow.dag.yaml`](diffhunk://#diff-50d6b958f9aaf39012cfb90a579dfd9b9c3d5310916041bc06ad1d5f78396177L1-R1): The entry point was updated from `entry:my_flow` to `env_var:env_var_flow`.
* [`src/promptflow/tests/test_configs/eager_flows/environment_variables_connection/flow.dag.yaml`](diffhunk://#diff-7f78917e984730cde25978a04d975bffd92668373e7e8fa24a4db4c88dda028cL1-R1): The entry point was updated from `entry:my_flow` to `evc:evc_flow`.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
