### PR TITLE
[Executor][Feature]Enable serverless connection by converting to openai connection

### DIFF
--- a/src/promptflow/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow/promptflow/executor/_tool_resolver.py
@@ -265,31 +265,48 @@ class ToolResolver:
             if k in node_inputs:
                 del node_inputs[k]
 
-    def _get_node_connection(self, node: Node):
+    def _get_llm_node_connection(self, node: Node):
         connection = self._connection_manager.get(node.connection)
         if connection is None:
             raise ConnectionNotFound(
-                message=f"Connection {node.connection!r} not found, available connection keys "
-                f"{self._connection_manager._connections.keys()}.",
+                message_format="Connection of LLM node '{node_name}' is not found.",
+                node_name=node.name,
                 target=ErrorTarget.EXECUTOR,
             )
         return connection
 
-    def _resolve_llm_node(self, node: Node, convert_input_types=False) -> ResolvedTool:
-        connection = self._get_node_connection(node)
-        if not node.provider:
-            if not connection_type_to_api_mapping:
-                raise EmptyLLMApiMapping()
-            # If provider is not specified, try to resolve it from connection type
-            connection_type = type(connection).__name__
-            if connection_type not in connection_type_to_api_mapping:
+    @staticmethod
+    def _resolve_llm_connection_with_provider(connection):
+        if not connection_type_to_api_mapping:
+            raise EmptyLLMApiMapping()
+        # If provider is not specified, try to resolve it from connection type
+        connection_type = type(connection).__name__
+        if connection_type not in connection_type_to_api_mapping:
+            from promptflow.connections import ServerlessConnection, OpenAIConnection
+            # This is a fallback for the case that ServerlessConnection related tool is not ready
+            # in legacy versions, then we can directly use OpenAIConnection.
+            if isinstance(connection, ServerlessConnection):
+                connection = OpenAIConnection(
+                    api_key=connection.api_key,
+                    base_url=connection.api_base,
+                    name=connection.name,
+                )
+                connection_type = "OpenAIConnection"
+            else:
                 raise InvalidConnectionType(
                     message_format="Connection type {conn_type} is not supported for LLM.",
                     conn_type=connection_type,
                 )
-            node.provider = connection_type_to_api_mapping[connection_type]
+        provider = connection_type_to_api_mapping[connection_type]
+        return connection, provider
+
+    def _resolve_llm_node(self, node: Node, convert_input_types=False) -> ResolvedTool:
+        connection, provider = self._resolve_llm_connection_with_provider(self._get_llm_node_connection(node))
+        # Always set the provider according to the connection type
+        # to make sure the invoking logic is consistent between the connection and the tool.
+        node.provider = provider
         tool: Tool = self._tool_loader.load_tool_for_llm_node(node)
-        key, connection = self._resolve_llm_connection_to_inputs(node, tool)
+        key, connection = self._resolve_llm_connection_to_inputs(node, tool, connection)
         updated_node = copy.deepcopy(node)
         updated_node.inputs[key] = InputAssignment(value=connection, value_type=InputValueType.LITERAL)
         if convert_input_types:
@@ -311,8 +328,10 @@ class ToolResolver:
         api_func = partial(api_func, **{prompt_tpl_param_name: prompt_tpl}) if prompt_tpl_param_name else api_func
         return ResolvedTool(updated_node, tool, api_func, init_args)
 
-    def _resolve_llm_connection_to_inputs(self, node: Node, tool: Tool) -> Node:
-        connection = self._get_node_connection(node)
+    def _resolve_llm_connection_to_inputs(self, node: Node, tool: Tool, connection=None) -> Node:
+        # No need to get connection if it is already provided
+        # TODO: Refine the code here since the connection would always be provided.
+        connection = connection or self._get_llm_node_connection(node)
         for key, input in tool.inputs.items():
             if ConnectionType.is_connection_class_name(input.type[0]):
                 if type(connection).__name__ not in input.type:

--- a/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_happypath.py
@@ -177,7 +177,7 @@ class TestExecutor:
                 raise_ex=True,
             )
         assert isinstance(e.value.inner_exception, ConnectionNotFound)
-        assert "Connection 'dummy_connection' not found" in str(e.value)
+        assert "Connection of LLM node 'classify_with_llm' is not found." in str(e.value)
 
     @pytest.mark.parametrize(
         "flow_folder",

--- a/src/promptflow/tests/executor/e2etests/test_executor_validation.py
+++ b/src/promptflow/tests/executor/e2etests/test_executor_validation.py
@@ -181,7 +181,6 @@ class TestValidation:
             ("tool_type_missing", ResolveToolError, NotImplementedError),
             ("wrong_module", FailedToImportModule, None),
             ("wrong_api", ResolveToolError, APINotFound),
-            ("wrong_provider", ResolveToolError, APINotFound),
         ],
     )
     def test_invalid_flow_dag(self, flow_folder, error_class, inner_class, dev_connections):


### PR DESCRIPTION
# Description

Enable serverless connection in scenario that related tool is not ready.
We achieve this by converting it to an openai connection, which will go to the openai connection code path.
Note that we also changed the logic about provider resolving that we always use the provider from the connection instead of the user provided one to make sure the provider is consistent with the connection.

This pull request includes significant changes to the `src/promptflow/promptflow/executor/_tool_resolver.py` file, which improve the handling of connections and providers in the `_resolve_llm_node` method and related methods. The changes also include updates to the corresponding test cases in `src/promptflow/tests/executor/e2etests/test_executor_happypath.py` and `src/promptflow/tests/executor/e2etests/test_executor_validation.py`.

Here are the most important changes:

* `src/promptflow/promptflow/executor/_tool_resolver.py`: 
  * The `_get_node_connection` method has been renamed to `_get_llm_node_connection` and its error message has been updated.
  * The `_resolve_llm_node` method has been refactored to use a new static method, `_resolve_llm_connection_with_provider`, which handles the resolution of the connection and provider. This change simplifies the `_resolve_llm_node` method and makes the code more maintainable.
  * The `_resolve_llm_connection_to_inputs` method has been updated to accept an optional `connection` parameter. If a connection is provided, the method will use it; otherwise, it will call `_get_llm_node_connection`.

* `src/promptflow/tests/executor/e2etests/test_executor_happypath.py`:
  * The test case `test_executor_node_overrides` has been updated to reflect the new error message in `_get_llm_node_connection`.

* `src/promptflow/tests/executor/e2etests/test_executor_validation.py`:
  * The test case `test_invalid_flow_dag` has been updated to remove a test scenario related to a 'wrong_provider', which is no longer relevant due to the changes in `_resolve_llm_node`.



# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
