### PR TITLE
Load image in local storage

### DIFF
--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -226,9 +226,6 @@ class LocalStorageOperations(AbstractBatchRunStorage):
         self._dump_meta_file()
         self._eager_mode = self._calculate_eager_mode(run)
 
-        self._loaded_flow_run_info = {}  # {line_number: flow_run_info}
-        self._loaded_node_run_info = {}  # {line_number: [node_run_info]}
-
     @property
     def eager_mode(self) -> bool:
         return self._eager_mode
@@ -410,10 +407,6 @@ class LocalStorageOperations(AbstractBatchRunStorage):
                 node_run_infos.extend(new_runs)
                 for new_run in new_runs:
                     new_run = resolve_multimedia_data_recursively(node_run_record_file, new_run)
-                    run_info = NodeRunInfo.deserialize(new_run)
-                    line_number = run_info.index
-                    self._loaded_node_run_info[line_number] = self._loaded_node_run_info.get(line_number, [])
-                    self._loaded_node_run_info[line_number].append(run_info)
         return node_run_infos
 
     def load_node_run_info_for_line(self, line_number: int = None) -> List[NodeRunInfo]:
@@ -451,9 +444,6 @@ class LocalStorageOperations(AbstractBatchRunStorage):
             flow_run_infos.extend(new_runs)
             for new_run in new_runs:
                 new_run = resolve_multimedia_data_recursively(line_run_record_file, new_run)
-                run_info = FlowRunInfo.deserialize(new_run)
-                line_number = run_info.index
-                self._loaded_flow_run_info[line_number] = run_info
         return flow_run_infos
 
     def load_flow_run_info(self, line_number: int) -> FlowRunInfo:

--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -415,7 +415,7 @@ class LocalStorageOperations(AbstractBatchRunStorage):
 
     def load_node_run_info_for_line(self, line_number: int = None) -> List[NodeRunInfo]:
         node_run_infos = []
-        for node_folder in sorted(self._node_infos_folder.iterdir()):
+        for node_folder in self._node_infos_folder.iterdir():
             filename = f"{str(line_number).zfill(self.LINE_NUMBER_WIDTH)}.jsonl"
             node_run_record_file = node_folder / filename
             if node_run_record_file.is_file():
@@ -423,7 +423,7 @@ class LocalStorageOperations(AbstractBatchRunStorage):
                 if runs:
                     run = runs[0]
                 run = resolve_multimedia_data_recursively(node_run_record_file, run)
-                load_multimedia_data_recursively(run)
+                run = load_multimedia_data_recursively(run)
                 run_info = NodeRunInfo.deserialize(run)
                 node_run_infos.append(run_info)
         return node_run_infos
@@ -468,12 +468,12 @@ class LocalStorageOperations(AbstractBatchRunStorage):
         if not file_path.is_file():
             return None
         runs = self._load_info_from_file(file_path)
-        run = next((run for run in runs if run.get(LINE_NUMBER) == line_number), None)
+        run = next((run for run in runs if run.get("index") == line_number), None)
         if not run:
             return None
 
         run = resolve_multimedia_data_recursively(self._run_infos_folder, run)
-        load_multimedia_data_recursively(run)
+        run = load_multimedia_data_recursively(run)
         run_info = FlowRunInfo.deserialize(run)
         return run_info
 

--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -400,6 +400,9 @@ class LocalStorageOperations(AbstractBatchRunStorage):
         return run_infos
 
     def _load_all_node_run_info(self, parse_const_as_str: bool = False) -> List[Dict]:
+        if not self._node_infos_folder.is_dir():
+            return []
+
         node_run_infos = []
         for node_folder in sorted(self._node_infos_folder.iterdir()):
             for node_run_record_file in sorted(node_folder.iterdir()):
@@ -414,6 +417,9 @@ class LocalStorageOperations(AbstractBatchRunStorage):
         return node_run_infos
 
     def load_node_run_info_for_line(self, line_number: int = None) -> List[NodeRunInfo]:
+        if not self._node_infos_folder.is_dir():
+            return []
+
         node_run_infos = []
         for node_folder in self._node_infos_folder.iterdir():
             filename = self._get_node_run_info_file_name(line_number)

--- a/src/promptflow/tests/executor/unittests/storage/test_local_storage_operations.py
+++ b/src/promptflow/tests/executor/unittests/storage/test_local_storage_operations.py
@@ -1,11 +1,12 @@
 import datetime
 import json
-from pathlib import Path
 
 import pytest
 
 from promptflow._sdk.entities._run import Run
 from promptflow._sdk.operations._local_storage_operations import LocalStorageOperations
+from promptflow._utils.multimedia_utils import create_image
+from promptflow.contracts.multimedia import Image
 from promptflow.contracts.run_info import FlowRunInfo, RunInfo, Status
 
 
@@ -26,8 +27,8 @@ def node_run_info():
         flow_run_id="flow_run_id",
         run_id="run_id",
         status=Status.Completed,
-        inputs={"image1": {"data:image/png;path": "test.png"}},
-        output={"output1": {"data:image/png;path": "test.png"}},
+        inputs={"image1": create_image({"data:image/png;base64": "R0lGODlhAQABAAAAACw="})},
+        output={"output1": create_image({"data:image/png;base64": "R0lGODlhAQABAAAAACw="})},
         metrics={},
         error={},
         parent_run_id="parent_run_id",
@@ -43,8 +44,8 @@ def flow_run_info():
         run_id="run_id",
         status=Status.Completed,
         error=None,
-        inputs={"image1": {"data:image/png;path": "test.png"}},
-        output={"output1": {"data:image/png;path": "test.png"}},
+        inputs={"image1": create_image({"data:image/png;base64": "R0lGODlhAQABAAAAACw="})},
+        output={"output1": create_image({"data:image/png;base64": "R0lGODlhAQABAAAAACw="})},
         metrics={},
         request="request",
         parent_run_id="parent_run_id",
@@ -81,36 +82,21 @@ class TestLocalStorageOperations:
 
     def test_load_node_run_info(self, local_storage, node_run_info):
         local_storage.persist_node_run(node_run_info)
-        loaded_node_run_info = local_storage._load_all_node_run_info()
-        assert len(loaded_node_run_info) == 1
-        assert loaded_node_run_info[0]["node"] == node_run_info.node
-        assert loaded_node_run_info[0]["index"] == node_run_info.index
-        assert loaded_node_run_info[0]["inputs"]["image1"]["data:image/png;path"] == str(
-            Path(local_storage._node_infos_folder, node_run_info.node, "test.png")
-        )
-        assert loaded_node_run_info[0]["output"]["output1"]["data:image/png;path"] == str(
-            Path(local_storage._node_infos_folder, node_run_info.node, "test.png")
-        )
+        loaded_node_run_info = local_storage.load_node_run_info_for_line(1)
 
-        res = local_storage.load_node_run_info_for_line(1)
-        assert isinstance(res, list)
-        assert isinstance(res[0], RunInfo)
-        assert res[0].node == node_run_info.node
+        assert len(loaded_node_run_info) == 1
+        assert isinstance(loaded_node_run_info[0], RunInfo)
+        assert loaded_node_run_info[0].node == node_run_info.node
+        assert loaded_node_run_info[0].index == node_run_info.index
+        assert isinstance(loaded_node_run_info[0].inputs["image1"], Image)
+        assert isinstance(loaded_node_run_info[0].output["output1"], Image)
 
     def test_load_flow_run_info(self, local_storage, flow_run_info):
         local_storage.persist_flow_run(flow_run_info)
+        loaded_flow_run_info = local_storage.load_flow_run_info(1)
 
-        loaded_flow_run_info = local_storage._load_all_flow_run_info()
-        assert len(loaded_flow_run_info) == 1
-        assert loaded_flow_run_info[0]["run_id"] == flow_run_info.run_id
-        assert loaded_flow_run_info[0]["status"] == flow_run_info.status.value
-        assert loaded_flow_run_info[0]["inputs"]["image1"]["data:image/png;path"] == str(
-            Path(local_storage._run_infos_folder, "test.png")
-        )
-        assert loaded_flow_run_info[0]["output"]["output1"]["data:image/png;path"] == str(
-            Path(local_storage._run_infos_folder, "test.png")
-        )
-
-        res = local_storage.load_flow_run_info(1)
-        assert isinstance(res, FlowRunInfo)
-        assert res.run_id == flow_run_info.run_id
+        assert isinstance(loaded_flow_run_info, FlowRunInfo)
+        assert loaded_flow_run_info.run_id == flow_run_info.run_id
+        assert loaded_flow_run_info.status == flow_run_info.status
+        assert isinstance(loaded_flow_run_info.inputs["image1"], Image)
+        assert isinstance(loaded_flow_run_info.output["output1"], Image)

--- a/src/promptflow/tests/executor/unittests/storage/test_local_storage_operations.py
+++ b/src/promptflow/tests/executor/unittests/storage/test_local_storage_operations.py
@@ -91,6 +91,8 @@ class TestLocalStorageOperations:
         assert isinstance(loaded_node_run_info[0].inputs["image1"], Image)
         assert isinstance(loaded_node_run_info[0].output["output1"], Image)
 
+        assert local_storage.load_node_run_info_for_line(2) == []
+
     def test_load_flow_run_info(self, local_storage, flow_run_info):
         local_storage.persist_flow_run(flow_run_info)
         loaded_flow_run_info = local_storage.load_flow_run_info(1)
@@ -100,3 +102,5 @@ class TestLocalStorageOperations:
         assert loaded_flow_run_info.status == flow_run_info.status
         assert isinstance(loaded_flow_run_info.inputs["image1"], Image)
         assert isinstance(loaded_flow_run_info.output["output1"], Image)
+
+        assert local_storage.load_flow_run_info(2) is None


### PR DESCRIPTION
# Description

Load image to memory in 1load_flow_run_info` and `load_node_run_info_for_line` API of `LocalStorageOperations`.
So that the resume feature can work for image scenario.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
