### PR TITLE
[Executor] Line process to wait for otel exporter

### DIFF
--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -43,6 +43,8 @@ from promptflow.executor._script_executor import ScriptExecutor
 from promptflow.executor.flow_executor import DEFAULT_CONCURRENCY_BULK, FlowExecutor
 from promptflow.storage import AbstractRunStorage
 
+TERMINATE_SIGNAL = "terminate"
+
 
 def signal_handler(signum, frame):
     signame = signal.Signals(signum).name
@@ -364,16 +366,13 @@ class LineExecutionProcessPool:
         # If the while loop exits due to batch run timeout, we should set is_timeout to True if we didn't set it before.
         self._is_timeout = self._is_timeout or self._batch_timeout_expired(batch_start_time)
 
-        # wait 10 seconds to ensure the spans are exported before the process is killed
-        # otherwise there will be some missing spans for lines
-        # TODO (Task 2950080): make line process wait for spans flush
-        from promptflow._trace._start_trace import _is_tracer_provider_configured
-
-        if _is_tracer_provider_configured():
-            time.sleep(10)
+        if not self._is_timeout:
+            input_queue.put(TERMINATE_SIGNAL)
+            time.sleep(1)
 
         # End the process when the batch timeout is exceeded or when all lines have been executed.
         self._processes_manager.end_process(index)
+
         # In fork mode, the main process and the sub spawn process communicate through _process_info.
         # We need to ensure the process has been killed before returning. Otherwise, it may cause
         # the main process have exited but the spawn process is still alive.
@@ -707,7 +706,11 @@ def exec_line_for_queue(executor_creation_func, input_queue: Queue, output_queue
 
     while True:
         try:
-            inputs, line_number, run_id, line_timeout_sec = input_queue.get(timeout=1)
+            data = input_queue.get(timeout=1)
+            if data == TERMINATE_SIGNAL:
+                # If found the terminate signal, exit the process.
+                break
+            inputs, line_number, run_id, line_timeout_sec = data
             result = _exec_line(
                 executor=executor,
                 output_queue=output_queue,

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -368,7 +368,6 @@ class LineExecutionProcessPool:
 
         if not self._is_timeout:
             input_queue.put(TERMINATE_SIGNAL)
-            time.sleep(1)
 
         # End the process when the batch timeout is exceeded or when all lines have been executed.
         self._processes_manager.end_process(index)

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -14,6 +14,8 @@ from promptflow._utils.logger_utils import LogContext, bulk_logger
 from promptflow.executor._errors import SpawnedForkProcessManagerStartFailure
 from promptflow.executor.flow_executor import FlowExecutor
 
+TERMINATE_SIGNAL = "terminate"
+
 
 @dataclass
 class ProcessInfo:

--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -14,8 +14,6 @@ from promptflow._utils.logger_utils import LogContext, bulk_logger
 from promptflow.executor._errors import SpawnedForkProcessManagerStartFailure
 from promptflow.executor.flow_executor import FlowExecutor
 
-TERMINATE_SIGNAL = "terminate"
-
 
 @dataclass
 class ProcessInfo:
@@ -176,19 +174,29 @@ class SpawnProcessManager(AbstractProcessManager):
         :param i: Index of the process to terminate.
         :type i: int
         """
+        warning_msg = (
+            "Unexpected error occurred while end process for index {i} and process id {pid}. "
+            "Exception: {e}"
+        )
         try:
             pid = self._process_info[i].process_id
             process = psutil.Process(pid)
-            process.terminate()
-            process.wait()
-            self._process_info.pop(i)
+            # The subprocess will get terminate signal from input queue, so we need to wait for the process to exit.
+            # If the process is still running after 10 seconds, it will raise psutil.TimeoutExpired exception.
+            process.wait(timeout=10)
         except psutil.NoSuchProcess:
-            bulk_logger.warning(f"Process {pid} had been terminated")
+            bulk_logger.warning(f"Process {pid} had been terminated.")
+        except psutil.TimeoutExpired:
+            try:
+                # If the process is still running after waiting 10 seconds, terminate it.
+                process.terminate()
+                process.wait()
+            except Exception as e:
+                bulk_logger.warning(warning_msg.format(i=i, pid=pid, e=e))
         except Exception as e:
-            bulk_logger.warning(
-                f"Unexpected error occurred while end process for index {i} and process id {process.pid}. "
-                f"Exception: {e}"
-            )
+            bulk_logger.warning(warning_msg.format(i=i, pid=pid, e=e))
+        finally:
+            self._process_info.pop(i)
 
     def ensure_healthy(self):
         """
@@ -358,19 +366,29 @@ class SpawnedForkProcessManager(AbstractProcessManager):
         :param i: Index of the process to terminate.
         :type i: int
         """
+        warning_msg = (
+            "Unexpected error occurred while end process for index {i} and process id {pid}. "
+            "Exception: {e}"
+        )
         try:
             pid = self._process_info[i].process_id
             process = psutil.Process(pid)
-            process.terminate()
-            process.wait()
-            self._process_info.pop(i)
+            # The subprocess will get terminate signal from input queue, so we need to wait for the process to exit.
+            # If the process is still running after 10 seconds, it will raise psutil.TimeoutExpired exception.
+            process.wait(timeout=10)
         except psutil.NoSuchProcess:
-            bulk_logger.warning(f"Process {pid} had been terminated")
+            bulk_logger.warning(f"Process {pid} had been terminated.")
+        except psutil.TimeoutExpired:
+            try:
+                # If the process is still running after waiting 10 seconds, terminate it.
+                process.terminate()
+                process.wait()
+            except Exception as e:
+                bulk_logger.warning(warning_msg.format(i=i, pid=pid, e=e))
         except Exception as e:
-            bulk_logger.warning(
-                f"Unexpected error occurred while end process for index {i} and process id {process.pid}. "
-                f"Exception: {e}"
-            )
+            bulk_logger.warning(warning_msg.format(i=i, pid=pid, e=e))
+        finally:
+            self._process_info.pop(i)
 
     def restart_process(self, i):
         """


### PR DESCRIPTION
# Description

This pull request primarily focuses on improving the process termination and monitoring in the `promptflow` package. Previously the subprocess always run a dead cycle, and it relies on the call `process.terminate()` to kill the subprocess, it caused that the exporter of `opentelemetry` cannot shutdown properly. in this PR, we send the terminate signal to the subprocess and it will break out of the loop, and we will wait it to be ended in the monitor thread. 

The changes are mainly in two files: `src/promptflow/promptflow/executor/_line_execution_process_pool.py` and `src/promptflow/promptflow/executor/_process_manager.py`. The most significant changes include the introduction of a `TERMINATE_SIGNAL` for process termination, modifications to the `_monitor_workers_and_process_tasks_in_thread` and `exec_line_for_queue` functions to handle this signal, and updates to the `end_process` method in the `_process_manager.py` file to wait for the process to exit before termination.

Here are the key changes:

Changes in `src/promptflow/promptflow/executor/_line_execution_process_pool.py`:

* Introduced a `TERMINATE_SIGNAL` constant to signal process termination.
* Modified the `_monitor_workers_and_process_tasks_in_thread` function to put the `TERMINATE_SIGNAL` in the `input_queue` if the process is not in a timeout state.
* Updated the `exec_line_for_queue` function to break the loop and exit the process if the `TERMINATE_SIGNAL` is found in the `input_queue`.

Changes in `src/promptflow/promptflow/executor/_process_manager.py`:

* Updated the `end_process` method to wait for a process to exit after receiving the `TERMINATE_SIGNAL`. If the process is still running after 10 seconds, it is terminated. The method now also handles the `psutil.NoSuchProcess` and `psutil.TimeoutExpired` exceptions. [[1]](diffhunk://#diff-fb203fa9d75078068758d8934fd7711b63934b15faa6cee7c3c4d16ab3347258R180-R201) [[2]](diffhunk://#diff-fb203fa9d75078068758d8934fd7711b63934b15faa6cee7c3c4d16ab3347258R374-R395)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
