### PR TITLE
[internal][trace] Support `pf config set trace.provider` and print url for local to cloud

### DIFF
--- a/src/promptflow/promptflow/_cli/_utils.py
+++ b/src/promptflow/promptflow/_cli/_utils.py
@@ -9,7 +9,6 @@ import os
 import shutil
 import sys
 import traceback
-from collections import namedtuple
 from configparser import ConfigParser
 from functools import wraps
 from pathlib import Path
@@ -19,15 +18,13 @@ import pydash
 from dotenv import load_dotenv
 from tabulate import tabulate
 
-from promptflow._sdk._constants import CLIListOutputFormat, EnvironmentVariables
-from promptflow._sdk._telemetry import log_activity, ActivityType, get_telemetry_logger
-from promptflow._sdk._utils import print_yellow_warning, print_red_error
+from promptflow._sdk._constants import AzureMLWorkspaceTriad, CLIListOutputFormat, EnvironmentVariables
+from promptflow._sdk._telemetry import ActivityType, get_telemetry_logger, log_activity
+from promptflow._sdk._utils import print_red_error, print_yellow_warning
 from promptflow._utils.exception_utils import ExceptionPresenter
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow._utils.utils import is_in_ci_pipeline
-from promptflow.exceptions import ErrorTarget, UserErrorException, PromptflowException
-
-AzureMLWorkspaceTriad = namedtuple("AzureMLWorkspace", ["subscription_id", "resource_group_name", "workspace_name"])
+from promptflow.exceptions import ErrorTarget, PromptflowException, UserErrorException
 
 logger = get_cli_sdk_logger()
 
@@ -362,10 +359,10 @@ def cli_exception_and_telemetry_handler(func, activity_name, custom_dimensions=N
         try:
             telemetry_logger = get_telemetry_logger()
             with log_activity(
-                    telemetry_logger,
-                    activity_name,
-                    activity_type=ActivityType.PUBLICAPI,
-                    custom_dimensions=custom_dimensions,
+                telemetry_logger,
+                activity_name,
+                activity_type=ActivityType.PUBLICAPI,
+                custom_dimensions=custom_dimensions,
             ):
                 return func(*args, **kwargs)
         except Exception as e:

--- a/src/promptflow/promptflow/_constants.py
+++ b/src/promptflow/promptflow/_constants.py
@@ -69,6 +69,9 @@ DEFAULT_SPAN_TYPE = "default"
 class TraceEnvironmentVariableName:
     EXPERIMENT = "PF_TRACE_EXPERIMENT"
     SESSION_ID = "PF_TRACE_SESSION_ID"
+    SUBSCRIPTION_ID = "PF_TRACE_SUBSCRIPTION_ID"
+    RESOURCE_GROUP_NAME = "PF_TRACE_RESOURCE_GROUP_NAME"
+    WORKSPACE_NAME = "PF_TRACE_WORKSPACE_NAME"
 
 
 class SpanFieldName:
@@ -123,6 +126,10 @@ class SpanResourceAttributesFieldName:
     SERVICE_NAME = "service.name"
     SESSION_ID = "session.id"
     EXPERIMENT_NAME = "experiment.name"
+    # local to cloud
+    SUBSCRIPTION_ID = "subscription_id"
+    RESOURCE_GROUP_NAME = "resource_group_name"
+    WORKSPACE_NAME = "workspace_name"
     # batch run
     BATCH_RUN_ID = "batch_run_id"
     LINE_NUMBER = "line_number"

--- a/src/promptflow/promptflow/_constants.py
+++ b/src/promptflow/promptflow/_constants.py
@@ -127,9 +127,9 @@ class SpanResourceAttributesFieldName:
     SESSION_ID = "session.id"
     EXPERIMENT_NAME = "experiment.name"
     # local to cloud
-    SUBSCRIPTION_ID = "subscription_id"
-    RESOURCE_GROUP_NAME = "resource_group_name"
-    WORKSPACE_NAME = "workspace_name"
+    SUBSCRIPTION_ID = "subscription.id"
+    RESOURCE_GROUP_NAME = "resource_group.name"
+    WORKSPACE_NAME = "workspace.name"
     # batch run
     BATCH_RUN_ID = "batch_run_id"
     LINE_NUMBER = "line_number"

--- a/src/promptflow/promptflow/_sdk/_configuration.py
+++ b/src/promptflow/promptflow/_sdk/_configuration.py
@@ -17,11 +17,7 @@ from promptflow._sdk._constants import (
     SERVICE_CONFIG_FILE,
     ConnectionProvider,
 )
-from promptflow._sdk._utils import (
-    call_from_extension,
-    read_write_by_user,
-    gen_uuid_by_compute_info,
-)
+from promptflow._sdk._utils import call_from_extension, gen_uuid_by_compute_info, read_write_by_user
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow._utils.yaml_utils import dump_yaml, load_yaml
 from promptflow.exceptions import ErrorTarget, ValidationException
@@ -50,6 +46,7 @@ class Configuration(object):
     RUN_OUTPUT_PATH = "run.output_path"
     USER_AGENT = "user_agent"
     ENABLE_INTERNAL_FEATURES = "enable_internal_features"
+    TRACE_PROVIDER = "trace.provider"
     _instance = None
 
     def __init__(self, overrides=None):
@@ -169,6 +166,9 @@ class Configuration(object):
         """Get the current connection provider. Default to local if not configured."""
         provider = self.get_config(key=self.CONNECTION_PROVIDER)
         return self.resolve_connection_provider(provider, path=path)
+
+    def get_trace_provider(self) -> Optional[str]:
+        return self.get_config(key=self.TRACE_PROVIDER)
 
     @classmethod
     def resolve_connection_provider(cls, provider, path=None) -> Optional[str]:

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -1,7 +1,9 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+
 import os
+from collections import namedtuple
 from enum import Enum
 from pathlib import Path
 
@@ -130,6 +132,8 @@ TRACE_MGMT_DB_PATH = (HOME_PROMPT_FLOW_DIR / "trace.sqlite").resolve()
 TRACE_MGMT_DB_SESSION_ACQUIRE_LOCK_PATH = (HOME_PROMPT_FLOW_DIR / "trace.sqlite.lock").resolve()
 SPAN_TABLENAME = "span"
 PFS_MODEL_DATETIME_FORMAT = "iso8601"
+
+AzureMLWorkspaceTriad = namedtuple("AzureMLWorkspace", ["subscription_id", "resource_group_name", "workspace_name"])
 
 
 class CustomStrongTypeConnectionConfigs:

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -1196,7 +1196,7 @@ def extract_workspace_triad_from_trace_provider(trace_provider: str) -> AzureMLW
     match = re.match(AZURE_WORKSPACE_REGEX_FORMAT, trace_provider)
     if not match or len(match.groups()) != 5:
         raise ValueError(
-            "Malformed trace provider string, expected azureml:/subscriptions/<subscription_id>/"
+            "Malformed trace provider string, expected azureml://subscriptions/<subscription_id>/"
             "resourceGroups/<resource_group>/providers/Microsoft.MachineLearningServices/"
             f"workspaces/<workspace_name>, got {trace_provider}"
         )

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -36,6 +36,7 @@ from promptflow._constants import EXTENSION_UA, PF_NO_INTERACTIVE_LOGIN, PF_USER
 from promptflow._core.tool_meta_generator import generate_tool_meta_dict_by_file
 from promptflow._core.tools_manager import gen_dynamic_list, retrieve_tool_func_result
 from promptflow._sdk._constants import (
+    AZURE_WORKSPACE_REGEX_FORMAT,
     DAG_FILE_NAME,
     DEFAULT_ENCODING,
     FLOW_TOOLS_JSON,
@@ -53,6 +54,7 @@ from promptflow._sdk._constants import (
     REMOTE_URI_PREFIX,
     USE_VARIANTS,
     VARIANTS,
+    AzureMLWorkspaceTriad,
     CommonYamlFields,
     ConnectionProvider,
 )
@@ -1188,3 +1190,17 @@ def parse_otel_span_status_code(value: int) -> str:
         return "Ok"
     else:
         return "Error"
+
+
+def extract_workspace_triad_from_trace_provider(trace_provider: str) -> AzureMLWorkspaceTriad:
+    match = re.match(AZURE_WORKSPACE_REGEX_FORMAT, trace_provider)
+    if not match or len(match.groups()) != 5:
+        raise ValueError(
+            "Malformed trace provider string, expected azureml:/subscriptions/<subscription_id>/"
+            "resourceGroups/<resource_group>/providers/Microsoft.MachineLearningServices/"
+            f"workspaces/<workspace_name>, got {trace_provider}"
+        )
+    subscription_id = match.group(1)
+    resource_group_name = match.group(3)
+    workspace_name = match.group(5)
+    return AzureMLWorkspaceTriad(subscription_id, resource_group_name, workspace_name)

--- a/src/promptflow/promptflow/_sdk/operations/_local_azure_connection_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_azure_connection_operations.py
@@ -79,7 +79,7 @@ class LocalAzureConnectionOperations(WorkspaceTelemetryMixin):
         match = re.match(AZURE_WORKSPACE_REGEX_FORMAT, connection_provider)
         if not match or len(match.groups()) != 5:
             raise ValueError(
-                "Malformed connection provider string, expected azureml:/subscriptions/<subscription_id>/"
+                "Malformed connection provider string, expected azureml://subscriptions/<subscription_id>/"
                 "resourceGroups/<resource_group>/providers/Microsoft.MachineLearningServices/"
                 f"workspaces/<workspace_name>, got {connection_provider}"
             )

--- a/src/promptflow/promptflow/_trace/_start_trace.py
+++ b/src/promptflow/promptflow/_trace/_start_trace.py
@@ -87,7 +87,7 @@ def start_trace(*, session: typing.Optional[str] = None, **kwargs):
     if workspace_triad is not None:
         # if user has configured trace.provider, which indicates enabled local to cloud feature
         # print the url for cloud trace view
-        _trace_url_for_cloud(session_id=session_id)
+        _trace_url_for_cloud(session_id=session_id, workspace_triad=workspace_triad)
 
 
 def _start_pfs(pfs_port) -> None:
@@ -241,7 +241,7 @@ def _get_workspace_triad_from_config() -> typing.Optional[AzureMLWorkspaceTriad]
     return extract_workspace_triad_from_trace_provider(trace_provider)
 
 
-def _trace_url_for_cloud(session_id: str) -> None:
+def _trace_url_for_cloud(session_id: str, workspace_triad: AzureMLWorkspaceTriad) -> None:
     url_for_cloud = (
         f"https://int.ml.azure.com/prompts/trace/session/{session_id}"
         f"?wsid=/subscriptions/{workspace_triad.subscription_id}"

--- a/src/promptflow/promptflow/_trace/_start_trace.py
+++ b/src/promptflow/promptflow/_trace/_start_trace.py
@@ -73,7 +73,12 @@ def start_trace(*, session: typing.Optional[str] = None, **kwargs):
     workspace_triad = _get_workspace_triad_from_config()
 
     # init the global tracer with endpoint
-    _init_otel_trace_exporter(otlp_port=pfs_port, session_id=session_id, experiment=experiment)
+    _init_otel_trace_exporter(
+        otlp_port=pfs_port,
+        session_id=session_id,
+        experiment=experiment,
+        workspace_triad=workspace_triad,
+    )
     # print user the UI url
     ui_url = _determine_trace_url(
         pfs_port=pfs_port,


### PR DESCRIPTION
# Description

Support `pf config set trace.provider=azureml://subscriptions/<subscription_id>/resourceGroups/<resource_group>/providers/Microsoft.MachineLearningServices/workspaces/<workspace_name>` to configure local to cloud, and will record triad in `resource.attributes`:

![image](https://github.com/microsoft/promptflow/assets/38847871/29a49190-27e9-49eb-9f02-940050aa10b7)

If the user has enabled local to cloud feature, plus print an url for the UI link:

![image](https://github.com/microsoft/promptflow/assets/38847871/e52412fe-f0e4-41c4-9faf-ad235551a5ea)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
