### PR TITLE
Tune prompt to avoid question with `in this context/in given code/in table`

### DIFF
--- a/examples/gen_test_data/gen_test_data/generate_test_data_flow/generate_question_prompt.jinja2
+++ b/examples/gen_test_data/gen_test_data/generate_test_data_flow/generate_question_prompt.jinja2
@@ -8,6 +8,7 @@ Your task is to formulate a question from given context satisfying the rules giv
 4.The question should not contains phrases like 'provided context' in the question.
 5.The question should not contain any links.
 6.The question should not contain more than 20 words, use abbreviation wherever possible.
+7.The question should be a question asked by the hypothetical user without any given context
 
 # user:
 context:

--- a/examples/gen_test_data/gen_test_data/generate_test_data_flow/generate_question_prompt.jinja2
+++ b/examples/gen_test_data/gen_test_data/generate_test_data_flow/generate_question_prompt.jinja2
@@ -5,10 +5,10 @@ Your task is to formulate a question from given context satisfying the rules giv
 1.The question should better be framed from the overall context, serving as a general question, rather than just framed from some details.
 2.The question should be specific and answerable from the given context.
 3.The question must be reasonable and must be understood and responded by humans.
-4.The question should not contains phrases like 'provided context' in the question.
-5.The question should not contain any links.
-6.The question should not contain more than 20 words, use abbreviation wherever possible.
-7.The question should be a question asked by the hypothetical user without any given context
+4.The question should not contains phrases like 'provided' or 'given' in the question.
+5.The question should be a question asked by the hypothetical user without any given context
+6.The question should not contain any links.
+7.The question should not contain more than 20 words, use abbreviation wherever possible.
 
 # user:
 context:

--- a/examples/gen_test_data/gen_test_data/generate_test_data_flow/generate_question_prompt.jinja2
+++ b/examples/gen_test_data/gen_test_data/generate_test_data_flow/generate_question_prompt.jinja2
@@ -5,8 +5,8 @@ Your task is to formulate a question from given context satisfying the rules giv
 1.The question should better be framed from the overall context, serving as a general question, rather than just framed from some details.
 2.The question should be specific and answerable from the given context.
 3.The question must be reasonable and must be understood and responded by humans.
-4.The question should not contains phrases like 'provided' or 'given' in the question.
-5.The question should be a question asked by the hypothetical user without any given context
+4.The question should not contain phrases like 'provided' or 'given' in the question.
+5.The question should be a question asked by the hypothetical user without any given context.
 6.The question should not contain any links.
 7.The question should not contain more than 20 words, use abbreviation wherever possible.
 


### PR DESCRIPTION
# Description
For some text chunks, compare the questions before and after modification. Use the model "gpt-4-1106-preview". Each text chunk run 5 to 10 times continuously to verify the results.

### QA 1
**before question:** `What is the purpose of the condition_output in the given pipeline code?`
**before answer:** `The purpose of the condition_output in the given pipeline code is to selectively return one of two inputs based on a condition that is evaluated at runtime. If the condition evaluates to True, condition_output will return the first input (input_a), otherwise, it will return the second input (input_b). This allows for dynamic control of the data flow within the pipeline, depending on the results of previous tasks or workflow inputs.`
**after question:** `How does the condition_output function decide which input to return?`
**after answer:** `The condition_output function decides which input to return based on the result of a boolean condition. If the condition evaluates to True, it returns input_a; if the condition evaluates to False, it returns input_b.`

### QA 2
**before question:** `What are macros used for in the context of scheduling services?`
**before answer:** `Macros are used in scheduling services to manipulate timestamps in various ways, such as adding days, hours, minutes, or seconds to a timestamp, converting time zones, extracting specific parts of a date like the day of the year, month, or week, finding the start of a month, day, or hour, formatting a timestamp into a string, and adding or subtracting time units from a timestamp. These operations help in dynamically setting the times when scheduled tasks should run or in processing time-related data within the tasks.`
**after question:** `What are the supported macros for manipulating timestamps in a schedule service?`
**after answer:** `The supported macros for manipulating timestamps in a schedule service are:\n\n- `trigger_time`: Time when schedule service triggered the pipeline.\n- `add_days`: Add a number of days to a timestamp.\n- `add_hours`: Add a number of hours to a timestamp.\n- `add_minutes`: Add a number of minutes to a timestamp.\n- `add_seconds`: Add a number of seconds to a timestamp.\n- `convert_time_zone`: Convert a timestamp from the source time zone to the target time zone.\n- `day_of_year`: Return the day of the year from a timestamp.\n- `day_of_month`: Return the day of the month from a timestamp.\n- `day_of_week`: Return the day of the week from a timestamp.\n- `start_of_month`: Return the start of the month for a timestamp.\n- `start_of_day`: Return the start of the day for a timestamp.\n- `start_of_hour`: Return the start of the hour for a timestamp.\n- `format_date_time`: Return the timestamp as a string in optional format.\n- `add_to_time`: Add a number of time units to a timestamp.\n- `substract_from_time`: Subtract a number of time units from a timestamp.`

### QA 3
**before question:** `What does \"JOB_HEARTBEAT_TIMEOUT_SECONDS\" indicate in the context of job monitoring?`
**before answer:** `\"JOB_HEARTBEAT_TIMEOUT_SECONDS\" represents the amount of time you are willing to allow a job to run without any indication of progress before considering the resources used as wasted due to a potential hang. It is not meant to be a strict limit on the expected duration of an epoch but rather a threshold to detect and alert on job hangs without causing false positives.`
**after question:** `How should the JOB_HEARTBEAT_TIMEOUT_SECONDS be set in relation to epoch duration to avoid false alerts?`
**after answer:** `JOB_HEARTBEAT_TIMEOUT_SECONDS should be set longer than the expected duration of an epoch to prevent false positive alerts. It should be a measure of the amount of compute resources you are willing to lose while a hang goes undetected, rather than a tight limit on your epoch's expected time.`

### QA 4
**before question:** `What types are supported for parallel-for output in the given mapping table?`
**before answer:** `The supported parallel-for output types are:\n\n- mltable\n- string`
**after question:** `What types are supported for parallel-for output in Azure ML pipelines?`
**after answer:** `The supported types for parallel-for output in Azure ML pipelines are mltable and string.`


### Test using docs: no 'in this context/in given code/in table' pattern anymore
![image](https://github.com/microsoft/promptflow/assets/75061414/098aa161-fa91-4555-a7d3-319dbf97ced3)



# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
