### PR TITLE
Fix bug when collect package tools

### DIFF
--- a/docs/how-to-guides/develop-a-tool/create-and-use-tool-package.md
+++ b/docs/how-to-guides/develop-a-tool/create-and-use-tool-package.md
@@ -145,7 +145,7 @@ Alternatively, you can test your tool package using the script below to ensure t
           {'module': 'module_name', 'package': 'package_name', 'package_version': 'package_version', ...}
           """
           entry_points = importlib.metadata.entry_points()
-          if isinstance(entry_points, list):
+          if hasattr(entry_points, "select"):
               entry_points = entry_points.select(group=PACKAGE_TOOLS_ENTRY)
           else:
               entry_points = entry_points.get(PACKAGE_TOOLS_ENTRY, [])

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -72,7 +72,7 @@ def _get_entry_points_by_group(group):
     # which allows us to select entry points by group. In the previous versions, the entry_points() method
     # returns a dictionary-like object, we can use group name directly as a key.
     entry_points = importlib.metadata.entry_points()
-    if isinstance(entry_points, list):
+    if hasattr(entry_points, "select"):
         return entry_points.select(group=group)
     else:
         return entry_points.get(group, [])


### PR DESCRIPTION
# Description

This pull request includes changes to the `create-and-use-tool-package.md` and `tools_manager.py` files. The `collect_package_tools` failed in python 3.12, that's because in python 3.12 `importlib.metadata.entry_points()` is a tuple-like object, while in python 3.10 and 3.11 it is a dictionary-like object, but they both have a method `select` to filter group from the entry points, so we change to check if there is the attrubute `select`: `hasattr(entry_points, "select")`.

The changes involve updating the method of checking the type of `entry_points` from `isinstance(entry_points, list)` to `hasattr(entry_points, "select")`. This change is likely made to accommodate for different versions of the `importlib.metadata.entry_points()` method, which may return a different type of object depending on the version.

Changes:

* [`docs/how-to-guides/develop-a-tool/create-and-use-tool-package.md`](diffhunk://#diff-12fa67fdd2274d8437b9405f58cc33aa4c32685220ba8fbcc84a2fa0942e041dL148-R148): Updated the method of checking the type of `entry_points` to use `hasattr` instead of `isinstance`. This change ensures that the script can accommodate for different versions of the `importlib.metadata.entry_points()` method.
* [`src/promptflow/promptflow/_core/tools_manager.py`](diffhunk://#diff-f518149ddd2c66f8e68b168e37ca8f63513b9326fdb6483b9570284f32fad005L75-R75): Similar to the above change, the method of checking the type of `entry_points` was updated to use `hasattr` instead of `isinstance`. This change ensures that the `_get_entry_points_by_group` function can handle different types of `entry_points` objects.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
