### PR TITLE
Include dataclass output in flow meta

### DIFF
--- a/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_generate_tool_meta_utils.py
@@ -101,6 +101,7 @@ class TestToolMetaUtils:
         "flow_dir, entry_path, entry",
         [
             ("dummy_flow_with_trace", "flow_with_trace.py", "flow_with_trace:my_flow"),
+            ("flow_with_dataclass_output", "flow_with_dataclass.py", "flow_with_dataclass:my_flow"),
         ]
     )
     def test_generate_flow_meta(self, flow_dir, entry_path, entry):

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_dataclass_output/flow_with_dataclass.meta.json
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_dataclass_output/flow_with_dataclass.meta.json
@@ -1,0 +1,21 @@
+{
+    "function": "my_flow",
+    "entry": "flow_with_dataclass:my_flow",
+    "inputs": {
+        "text": {
+            "type": "string"
+        },
+        "models": {
+            "type": "list"
+        }
+    },
+    "outputs": {
+        "text": {
+            "type": "string"
+        },
+        "models": {
+            "type": "list"
+        }
+    },
+    "source": "flow_with_dataclass.py"
+}

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_dataclass_output/flow_with_dataclass.py
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_dataclass_output/flow_with_dataclass.py
@@ -7,5 +7,5 @@ class Data:
     models: list
 
 
-def my_flow(text: str = "default_text", models: list = ["default_model"]):
+def my_flow(text: str = "default_text", models: list = ["default_model"]) -> Data:
     return Data(text=text, models=models)


### PR DESCRIPTION
# Description

If the output of eager flow is a dataclass, we want to show the properties of the dataclass in the flow meta.

#### Example:
The definition of dataclass:
```
@dataclass
class Data:
    text: str
    models: list
```
Generated flow meta:
```
{
    "function": "my_flow",
    "entry": "flow_with_dataclass:my_flow",
    "inputs": {
        "text": {
            "type": "string"
        },
        "models": {
            "type": "list"
        }
    },
    "outputs": {
        "text": {
            "type": "string"
        },
        "models": {
            "type": "list"
        }
    },
    "source": "flow_with_dataclass.py"
}
```

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
