### PR TITLE
[internal][bugfix] Fix empty result when query with eval run name

### DIFF
--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -465,3 +465,6 @@ class LineRunFieldName:
     KIND = "kind"
     CUMULATIVE_TOKEN_COUNT = "cumulative_token_count"
     EVALUATIONS = "evaluations"
+
+
+TRACE_LIST_DEFAULT_LIMIT = 1000

--- a/src/promptflow/promptflow/_sdk/_orm/trace.py
+++ b/src/promptflow/promptflow/_sdk/_orm/trace.py
@@ -65,9 +65,9 @@ class Span(Base):
                 stmt = stmt.filter(Span.session_id == session_id)
             if trace_ids is not None:
                 stmt = stmt.filter(Span.trace_id.in_(trace_ids))
+            stmt = stmt.order_by(text("json_extract(span.content, '$.start_time') asc"))
             if session_id is None and trace_ids is None:
                 stmt = stmt.limit(TRACE_LIST_DEFAULT_LIMIT)
-            stmt = stmt.order_by(text("json_extract(span.content, '$.start_time') asc"))
             return [span for span in stmt.all()]
 
     @staticmethod
@@ -115,12 +115,12 @@ class LineRun:
                 stmt = stmt.filter(Span.session_id == session_id)
             if experiments is not None:
                 stmt = stmt.filter(Span.experiment.in_(experiments))
-            if session_id is None and experiments is None:
-                stmt = stmt.limit(TRACE_LIST_DEFAULT_LIMIT)
             stmt = stmt.order_by(
                 Span.trace_id,
                 text("json_extract(span.content, '$.start_time') asc"),
             )
+            if session_id is None and experiments is None:
+                stmt = stmt.limit(TRACE_LIST_DEFAULT_LIMIT)
             line_runs = []
             current_spans: typing.List[Span] = []
             span: Span

--- a/src/promptflow/promptflow/_sdk/_orm/trace.py
+++ b/src/promptflow/promptflow/_sdk/_orm/trace.py
@@ -9,7 +9,7 @@ from sqlalchemy import TEXT, Column, Index, or_, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Query, declarative_base
 
-from promptflow._sdk._constants import SPAN_TABLENAME
+from promptflow._sdk._constants import SPAN_TABLENAME, TRACE_LIST_DEFAULT_LIMIT
 
 from .retry import sqlite_retry
 from .session import trace_mgmt_db_session
@@ -65,6 +65,8 @@ class Span(Base):
                 stmt = stmt.filter(Span.session_id == session_id)
             if trace_ids is not None:
                 stmt = stmt.filter(Span.trace_id.in_(trace_ids))
+            if session_id is None and trace_ids is None:
+                stmt = stmt.limit(TRACE_LIST_DEFAULT_LIMIT)
             stmt = stmt.order_by(text("json_extract(span.content, '$.start_time') asc"))
             return [span for span in stmt.all()]
 
@@ -113,6 +115,8 @@ class LineRun:
                 stmt = stmt.filter(Span.session_id == session_id)
             if experiments is not None:
                 stmt = stmt.filter(Span.experiment.in_(experiments))
+            if session_id is None and experiments is None:
+                stmt = stmt.limit(TRACE_LIST_DEFAULT_LIMIT)
             stmt = stmt.order_by(
                 Span.trace_id,
                 text("json_extract(span.content, '$.start_time') asc"),

--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -274,3 +274,30 @@ class LineRun:
             cumulative_token_count=main_line_run_data.cumulative_token_count,
             evaluations=evaluations,
         )
+
+    @staticmethod
+    def _from_run_and_spans(run: str, spans: typing.List[Span]) -> typing.Optional["LineRun"]:
+        main_line_run_data: _LineRunData = None
+        evaluations = dict()
+        for span in spans:
+            attributes = span._content[SpanFieldName.ATTRIBUTES]
+            batch_run_id = attributes[SpanAttributeFieldName.BATCH_RUN_ID]
+            if batch_run_id == run:
+                main_line_run_data = _LineRunData._from_root_span(span)
+            else:
+                evaluations[span.name] = _LineRunData._from_root_span(span)
+        return LineRun(
+            line_run_id=main_line_run_data.line_run_id,
+            trace_id=main_line_run_data.trace_id,
+            root_span_id=main_line_run_data.root_span_id,
+            inputs=main_line_run_data.inputs,
+            outputs=main_line_run_data.outputs,
+            start_time=main_line_run_data.start_time,
+            end_time=main_line_run_data.end_time,
+            status=main_line_run_data.status,
+            latency=main_line_run_data.latency,
+            name=main_line_run_data.display_name,
+            kind=main_line_run_data.kind,
+            cumulative_token_count=main_line_run_data.cumulative_token_count,
+            evaluations=evaluations,
+        )

--- a/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
@@ -104,6 +104,9 @@ class TraceOperations:
         grouped_spans = {run: dict() for run in runs}
         for span in map(Span._from_orm_object, orm_spans):
             attributes = span._content[SpanFieldName.ATTRIBUTES]
+            # aggregation node will not have `batch_run_id`, ignore
+            if SpanAttributeFieldName.BATCH_RUN_ID not in attributes:
+                continue
             batch_run_id = attributes[SpanAttributeFieldName.BATCH_RUN_ID]
             line_number = attributes[SpanAttributeFieldName.LINE_NUMBER]
             # check if it is an evaluation root span

--- a/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_trace_operations.py
@@ -30,10 +30,13 @@ class TraceOperations:
         runs: typing.Optional[typing.List[str]] = None,
         experiments: typing.Optional[typing.List[str]] = None,
     ) -> typing.List[LineRun]:
+        # separate query with runs
+        if runs is not None:
+            return self._list_line_runs_with_runs(runs)
+
         line_runs = []
         orm_spans_group_by_trace_id = ORMLineRun.list(
             session_id=session_id,
-            runs=runs,
             experiments=experiments,
         )
         # merge spans with same `line_run_id` or `referenced.line_run_id` (if exists)
@@ -90,5 +93,37 @@ class TraceOperations:
             spans = [Span._from_orm_object(orm_span) for orm_span in orm_spans]
             line_run = LineRun._from_spans(spans)
             if line_run is not None:
+                line_runs.append(line_run)
+        return line_runs
+
+    def _list_line_runs_with_runs(self, runs: typing.List[str]) -> typing.List[LineRun]:
+        orm_spans = ORMSpan.list_with_runs(runs)
+        # group root spans by lineage:
+        #   1. main + eval
+        #   2. eval
+        grouped_spans = {run: dict() for run in runs}
+        for span in map(Span._from_orm_object, orm_spans):
+            attributes = span._content[SpanFieldName.ATTRIBUTES]
+            batch_run_id = attributes[SpanAttributeFieldName.BATCH_RUN_ID]
+            line_number = attributes[SpanAttributeFieldName.LINE_NUMBER]
+            # check if it is an evaluation root span
+            if SpanAttributeFieldName.REFERENCED_BATCH_RUN_ID in attributes:
+                referenced_batch_run_id = attributes[SpanAttributeFieldName.REFERENCED_BATCH_RUN_ID]
+                if referenced_batch_run_id in runs:
+                    if line_number not in grouped_spans[referenced_batch_run_id]:
+                        grouped_spans[referenced_batch_run_id][line_number] = []
+                    grouped_spans[referenced_batch_run_id][line_number].append(span)
+                    continue
+            if line_number not in grouped_spans[batch_run_id]:
+                grouped_spans[batch_run_id][line_number] = []
+            grouped_spans[batch_run_id][line_number].append(span)
+        line_runs = []
+        for run in grouped_spans:
+            run_spans = grouped_spans[run]
+            if len(run_spans) == 0:
+                continue
+            for line_number in run_spans:
+                line_spans = run_spans[line_number]
+                line_run = LineRun._from_run_and_spans(run, line_spans)
                 line_runs.append(line_run)
         return line_runs

--- a/src/promptflow/tests/sdk_pfs_test/e2etests/test_trace.py
+++ b/src/promptflow/tests/sdk_pfs_test/e2etests/test_trace.py
@@ -99,3 +99,15 @@ class TestTrace:
         assert isinstance(output["NaN"], str) and output["NaN"] == "NaN"
         assert isinstance(output["Inf"], str) and output["Inf"] == "Infinity"
         assert isinstance(output["-Inf"], str) and output["-Inf"] == "-Infinity"
+
+    def test_list_evaluation_line_runs(self, pfs_op: PFSOperations, mock_session_id: str) -> None:
+        mock_batch_run_id = str(uuid.uuid4())
+        mock_referenced_batch_run_id = str(uuid.uuid4())
+        batch_run_attributes = {
+            SpanAttributeFieldName.BATCH_RUN_ID: mock_batch_run_id,
+            SpanAttributeFieldName.REFERENCED_BATCH_RUN_ID: mock_referenced_batch_run_id,
+            SpanAttributeFieldName.LINE_NUMBER: "0",
+        }
+        persist_a_span(session_id=mock_session_id, custom_attributes=batch_run_attributes)
+        line_runs = pfs_op.list_line_runs(runs=[mock_batch_run_id]).json
+        assert len(line_runs) == 1

--- a/src/promptflow/tests/sdk_pfs_test/utils.py
+++ b/src/promptflow/tests/sdk_pfs_test/utils.py
@@ -222,10 +222,12 @@ class PFSOperations:
 
     # trace APIs
     # LineRuns
-    def list_line_runs(self, *, session_id: Optional[str] = None):
+    def list_line_runs(self, *, session_id: Optional[str] = None, runs: Optional[List[str]] = None):
         query_string = {}
         if session_id is not None:
             query_string["session"] = session_id
+        if runs is not None:
+            query_string["run"] = ",".join(runs)
         response = self._client.get(
             f"{self.LINE_RUNS_PREFIX}/list",
             query_string=query_string,


### PR DESCRIPTION
# Description

- Fix empty result when query line runs with eval run name, by separating query run logic
- Limit 1000 for empty query parameter

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
