### PR TITLE
Init sys.stdout and sys.stderr to avoid exception when started in detach mode.

### DIFF
--- a/src/promptflow/promptflow/_sdk/_service/app.py
+++ b/src/promptflow/promptflow/_sdk/_service/app.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 import logging
+import os
+import sys
 import time
 from logging.handlers import RotatingFileHandler
 
@@ -20,6 +22,13 @@ from promptflow._sdk._service.apis.telemetry import api as telemetry_api
 from promptflow._sdk._service.apis.ui import api as ui_api
 from promptflow._sdk._service.utils.utils import FormattedException
 from promptflow._sdk._utils import get_promptflow_sdk_version, read_write_by_user
+
+# For the process started in detach mode, stdout/stderr will be none.
+# To avoid exception to stdout/stderr calls in the dependency package, point stdout/stderr to devnull.
+if sys.stdout is None:
+    sys.stdout = open(os.devnull, "w")
+if sys.stderr is None:
+    sys.stderr = sys.stdout
 
 
 def heartbeat():

--- a/src/promptflow/promptflow/_sdk/_service/app.py
+++ b/src/promptflow/promptflow/_sdk/_service/app.py
@@ -2,8 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 import logging
-import os
-import sys
 import time
 from logging.handlers import RotatingFileHandler
 
@@ -21,14 +19,9 @@ from promptflow._sdk._service.apis.span import api as span_api
 from promptflow._sdk._service.apis.telemetry import api as telemetry_api
 from promptflow._sdk._service.apis.ui import api as ui_api
 from promptflow._sdk._service.utils.utils import FormattedException
-from promptflow._sdk._utils import get_promptflow_sdk_version, read_write_by_user
+from promptflow._sdk._utils import get_promptflow_sdk_version, overwrite_null_std_logger, read_write_by_user
 
-# For the process started in detach mode, stdout/stderr will be none.
-# To avoid exception to stdout/stderr calls in the dependency package, point stdout/stderr to devnull.
-if sys.stdout is None:
-    sys.stdout = open(os.devnull, "w")
-if sys.stderr is None:
-    sys.stderr = sys.stdout
+overwrite_null_std_logger()
 
 
 def heartbeat():

--- a/src/promptflow/promptflow/_sdk/_submitter/experiment_orchestrator.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/experiment_orchestrator.py
@@ -20,13 +20,6 @@ from typing import Union
 
 import psutil
 
-# For the process started in detach mode, stdout/std error will be none.
-# To avoid exception to stdout/stderr calls in the dependency package, point stdout/stderr to devnull.
-if sys.stdout is None:
-    sys.stdout = open(os.devnull, "w")
-if sys.stderr is None:
-    sys.stderr = sys.stdout
-
 from promptflow._sdk._constants import (
     PF_TRACE_CONTEXT,
     PROMPT_FLOW_DIR_NAME,
@@ -56,6 +49,7 @@ from promptflow._sdk._submitter.utils import (
     _stop_orchestrator_process,
     _windows_stop_handler,
 )
+from promptflow._sdk._utils import overwrite_null_std_logger
 from promptflow._sdk.entities import Run
 from promptflow._sdk.entities._experiment import Experiment, ExperimentTemplate
 from promptflow._sdk.entities._flow import ProtectedFlow
@@ -68,6 +62,7 @@ from promptflow.contracts.run_info import Status
 from promptflow.contracts.run_mode import RunMode
 from promptflow.exceptions import ErrorTarget, UserErrorException
 
+overwrite_null_std_logger()
 logger = LoggerFactory.get_logger(name=__name__)
 
 

--- a/src/promptflow/promptflow/_sdk/_utils.py
+++ b/src/promptflow/promptflow/_sdk/_utils.py
@@ -1204,3 +1204,12 @@ def extract_workspace_triad_from_trace_provider(trace_provider: str) -> AzureMLW
     resource_group_name = match.group(3)
     workspace_name = match.group(5)
     return AzureMLWorkspaceTriad(subscription_id, resource_group_name, workspace_name)
+
+
+def overwrite_null_std_logger():
+    # For the process started in detach mode, stdout/stderr will be none.
+    # To avoid exception to stdout/stderr calls in the dependency package, point stdout/stderr to devnull.
+    if sys.stdout is None:
+        sys.stdout = open(os.devnull, "w")
+    if sys.stderr is None:
+        sys.stderr = sys.stdout


### PR DESCRIPTION
# Description

For the process started in detach mode like local pfs, stdout/stderr will be none([doc](https://docs.python.org/2/library/subprocess.html#subprocess.Popen.stdin)).
To avoid exception to stdout/stderr calls in the dependency package, point stdout/stderr to devnull.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
