### PR TITLE
Write trace to cosmosDB in separate thread to avoid making whole request timeout.

### DIFF
--- a/src/promptflow/promptflow/_sdk/_service/apis/collector.py
+++ b/src/promptflow/promptflow/_sdk/_service/apis/collector.py
@@ -21,6 +21,7 @@ from promptflow._constants import (
 )
 from promptflow._sdk._utils import parse_kv_from_pb_attribute
 from promptflow._sdk.entities._trace import Span
+from promptflow._utils.thread_utils import ThreadWithContextVars
 
 
 def trace_collector():
@@ -29,6 +30,7 @@ def trace_collector():
     if "application/x-protobuf" in content_type:
         traces_request = ExportTraceServiceRequest()
         traces_request.ParseFromString(request.data)
+        all_spans = []
         for resource_span in traces_request.resource_spans:
             resource_attributes = dict()
             for attribute in resource_span.resource.attributes:
@@ -44,7 +46,10 @@ def trace_collector():
                     # TODO: persist with batch
                     span = Span._from_protobuf_object(span, resource=resource)
                     span._persist()
-                    _try_write_trace_to_cosmosdb(span)
+                    all_spans.append(span)
+
+        # Create a new thread to write trace to cosmosdb to avoid blocking the main thread
+        ThreadWithContextVars(target=_try_write_trace_to_cosmosdb, args=(all_spans,)).start()
         return "Traces received", 200
 
     # JSON protobuf encoding
@@ -52,26 +57,32 @@ def trace_collector():
         raise NotImplementedError
 
 
-def _try_write_trace_to_cosmosdb(span: Span):
-    span_resource = span._content.get(SpanFieldName.RESOURCE, {})
-    resource_attributes = span_resource.get(SpanResourceFieldName.ATTRIBUTES, {})
-    subscription_id = resource_attributes.get(SpanResourceAttributesFieldName.SUBSCRIPTION_ID, None)
-    resource_group_name = resource_attributes.get(SpanResourceAttributesFieldName.RESOURCE_GROUP_NAME, None)
-    workspace_name = resource_attributes.get(SpanResourceAttributesFieldName.WORKSPACE_NAME, None)
-    if subscription_id is None or resource_group_name is None or workspace_name is None:
-        current_app.logger.debug("Cannot find workspace info in span resource, skip writing trace to cosmosdb.")
+def _try_write_trace_to_cosmosdb(all_spans):
+    current_app.logger.info(f"Start writing trace to cosmosdb, total spans count: {len(all_spans)}.")
+    try:
+        for span in all_spans:
+            span_resource = span._content.get(SpanFieldName.RESOURCE, {})
+            resource_attributes = span_resource.get(SpanResourceFieldName.ATTRIBUTES, {})
+            subscription_id = resource_attributes.get(SpanResourceAttributesFieldName.SUBSCRIPTION_ID, None)
+            resource_group_name = resource_attributes.get(SpanResourceAttributesFieldName.RESOURCE_GROUP_NAME, None)
+            workspace_name = resource_attributes.get(SpanResourceAttributesFieldName.WORKSPACE_NAME, None)
+            if subscription_id is None or resource_group_name is None or workspace_name is None:
+                current_app.logger.debug("Cannot find workspace info in span resource, skip writing trace to cosmosdb.")
+                return
+            from promptflow.azure._storage.cosmosdb.client import get_client
+            from promptflow.azure._storage.cosmosdb.span import Span as SpanCosmosDB
+            from promptflow.azure._storage.cosmosdb.summary import Summary
+
+            span_client = get_client(CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name)
+            line_summary_client = get_client(
+                CosmosDBContainerName.LINE_SUMMARY, subscription_id, resource_group_name, workspace_name
+            )
+
+            if line_summary_client and span_client:
+                result = SpanCosmosDB(span).persist(span_client)
+                # None means the span already exists, then we don't need to persist the summary also.
+                if result is not None:
+                    Summary(span).persist(line_summary_client)
+    except Exception as e:
+        current_app.logger.error(f"Failed to write trace to cosmosdb: {e}")
         return
-    from promptflow.azure._storage.cosmosdb.client import get_client
-    from promptflow.azure._storage.cosmosdb.span import Span as SpanCosmosDB
-    from promptflow.azure._storage.cosmosdb.summary import Summary
-
-    span_client = get_client(CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name)
-    line_summary_client = get_client(
-        CosmosDBContainerName.LINE_SUMMARY, subscription_id, resource_group_name, workspace_name
-    )
-
-    if line_summary_client and span_client:
-        result = SpanCosmosDB(span).persist(span_client)
-        # None means the span already exists, then we don't need to persist the summary also.
-        if result is not None:
-            Summary(span).persist(line_summary_client)


### PR DESCRIPTION
# Description

CosmosDB's init could be time-consuming.
Move this operation to worker thread to avoid making whole request timeout.

We may could further improve it by avoid using one same `_thread_lock` for all clients.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
