### PR TITLE
Add assistant_defintion type into schema for local tool meta gen

### DIFF
--- a/src/promptflow/promptflow/_sdk/data/tool.schema.json
+++ b/src/promptflow/promptflow/_sdk/data/tool.schema.json
@@ -217,7 +217,7 @@
         "FormRecognizerConnection",
         "FilePath",
         "Image",
-        "assistant_definition"
+        "AssistantDefinition"
       ],
       "enum": [
         "int",

--- a/src/promptflow/promptflow/_sdk/data/tool.schema.json
+++ b/src/promptflow/promptflow/_sdk/data/tool.schema.json
@@ -216,7 +216,8 @@
         "FunctionStr",
         "FormRecognizerConnection",
         "FilePath",
-        "Image"
+        "Image",
+        "assistant_definition"
       ],
       "enum": [
         "int",
@@ -243,7 +244,8 @@
         "function_str",
         "FormRecognizerConnection",
         "file_path",
-        "image"
+        "image",
+        "assistant_definition"
       ]
     },
     "AzureOpenAIModelCapabilities": {


### PR DESCRIPTION
# Description

Type validation logic enabled by https://github.com/microsoft/promptflow/pull/2041 for extension.
assistant_definition is missing there which failed the assistant sample.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
