### PR TITLE
Persist as main flow in LineSummary when span don't have id (for eager mode/arbitrary script)

### DIFF
--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
@@ -55,7 +55,7 @@ class TestSummary:
             attributes.pop(SpanAttributeFieldName.LINE_RUN_ID, None)
             attributes.pop(SpanAttributeFieldName.BATCH_RUN_ID, None)
             self.summary.persist(mock_client)
-            mock_persist_line_run.assert_not_called()
+            mock_persist_line_run.assert_called_once()
             mock_insert_evaluation.assert_not_called()
 
     def test_non_evaluation_span_persists_as_main_run(self):
@@ -112,6 +112,7 @@ class TestSummary:
             trace_id=self.summary.span.trace_id,
             root_span_id=self.summary.span.span_id,
             outputs={"output_key": "output_value"},
+            display_name=self.summary.span.name,
         )
         expected_patch_operations = [
             {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
@@ -158,6 +159,7 @@ class TestSummary:
             trace_id=self.summary.span.trace_id,
             root_span_id=self.summary.span.span_id,
             outputs={"output_key": "output_value"},
+            display_name=self.summary.span.name,
         )
 
         expected_patch_operations = [


### PR DESCRIPTION
# Description

For aggregate node/eager flow/arbitrary script, they don't have line run id/batch run id in span.
And we don't have a way to separate them from each other.

For cosmosDB table, we want to persist them as main flow item in `LineSummary` table.
But don't need to patch them as one item in `evaluations`


For example:
![image](https://github.com/microsoft/promptflow/assets/17527303/a2edda12-08d6-4bdd-96ea-58ac42e70eab)


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
