### PR TITLE
[promptflow][bugfix] Sanitize `computeName` in submit request and enable related tests

### DIFF
--- a/src/promptflow/tests/_constants.py
+++ b/src/promptflow/tests/_constants.py
@@ -11,6 +11,6 @@ ENV_FILE = (PROMOTFLOW_ROOT / ".env").resolve().absolute().as_posix()
 DEFAULT_SUBSCRIPTION_ID = "96aede12-2f73-41cb-b983-6d11a904839b"
 DEFAULT_RESOURCE_GROUP_NAME = "promptflow"
 DEFAULT_WORKSPACE_NAME = "promptflow-eastus2euap"
-DEFAULT_COMPUTE_INSTANCE_NAME = "ci-lin-cpu-sp-canary"
+DEFAULT_COMPUTE_INSTANCE_NAME = "ci-lin-cpu-sp"
 DEFAULT_RUNTIME_NAME = "test-runtime-ci"
 DEFAULT_REGISTRY_NAME = "promptflow-preview"

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
@@ -1012,10 +1012,6 @@ class TestFlowRun:
             for file in expected_files:
                 assert Path(tmp_dir, run.name, file).exists()
 
-    @pytest.mark.skipif(
-        condition=not is_live(),
-        reason="Enable this after fixed sanitizer.",
-    )
     def test_run_with_compute_instance_session(
         self, pf: PFClient, compute_instance_name: str, randstr: Callable[[str], str]
     ):
@@ -1036,10 +1032,6 @@ class TestFlowRun:
         run = pf.stream(run)
         assert run.status == RunStatus.COMPLETED
 
-    @pytest.mark.skipif(
-        condition=not is_live(),
-        reason="Enable this after fixed sanitizer.",
-    )
     def test_run_with_compute_instance_session_yml(
         self, pf: PFClient, compute_instance_name: str, randstr: Callable[[str], str]
     ):

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/constants.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/constants.py
@@ -64,6 +64,7 @@ class SanitizedValues:
     FLOW_LINEAGE_ID = "0000000000000000000000000000000000000000000000000000000000000000"
     REGION = "fake-region"
     FLOW_ID = "00000000-0000-0000-0000-000000000000"
+    COMPUTE_NAME = "fake-compute"
     # trick: "unknown_user" is the value when client fails to get username
     #        use this value so that we don't do extra logic when replay
     USERNAME = "unknown_user"

--- a/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/recording_utilities/utils.py
@@ -206,6 +206,8 @@ def sanitize_pfs_request_body(body: str) -> str:
         body_dict["runtimeName"] = SanitizedValues.RUNTIME_NAME
     if "sessionId" in body_dict:
         body_dict["sessionId"] = SanitizedValues.SESSION_ID
+    if "computeName" in body_dict:
+        body_dict["computeName"] = SanitizedValues.COMPUTE_NAME
     if "flowLineageId" in body:
         body_dict["flowLineageId"] = SanitizedValues.FLOW_LINEAGE_ID
     if "flowDefinitionResourceId" in body_dict:

--- a/src/promptflow/tests/test_configs/recordings/test_run_operations_TestFlowRun_test_run_with_compute_instance_session.yaml
+++ b/src/promptflow/tests/test_configs/recordings/test_run_operations_TestFlowRun_test_run_with_compute_instance_session.yaml
@@ -457,7 +457,7 @@ interactions:
       "inputsMapping": {}, "connections": {}, "environmentVariables": {}, "runtimeName":
       "fake-runtime-name", "sessionId": "000000000000000000000000000000000000000000000000",
       "sessionSetupMode": "SystemWait", "flowLineageId": "0000000000000000000000000000000000000000000000000000000000000000",
-      "runDisplayNameGenerationType": "UserProvidedMacro", "computeName": "wanhan1"}'
+      "runDisplayNameGenerationType": "UserProvidedMacro", "computeName": "fake-compute"}'
     headers:
       Accept:
       - application/json

--- a/src/promptflow/tests/test_configs/recordings/test_run_operations_TestFlowRun_test_run_with_compute_instance_session_yml.yaml
+++ b/src/promptflow/tests/test_configs/recordings/test_run_operations_TestFlowRun_test_run_with_compute_instance_session_yml.yaml
@@ -457,7 +457,7 @@ interactions:
       "inputsMapping": {"key": "${data.key}"}, "connections": {}, "environmentVariables":
       {}, "runtimeName": "fake-runtime-name", "sessionId": "000000000000000000000000000000000000000000000000",
       "sessionSetupMode": "SystemWait", "flowLineageId": "0000000000000000000000000000000000000000000000000000000000000000",
-      "runDisplayNameGenerationType": "UserProvidedMacro", "computeName": "wanhan1"}'
+      "runDisplayNameGenerationType": "UserProvidedMacro", "computeName": "fake-compute"}'
     headers:
       Accept:
       - application/json


### PR DESCRIPTION
# Description

When SDK tries to submit run to Azure, the request body may contain a field `computeName`, this need to be sanitized during record/replay - this PR targets to do this and enable related skipped tests.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
