### PR TITLE
[BugFix]Update list_deployment_names, check connection type

### DIFF
--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -94,6 +94,8 @@ def list_deployment_names(
     try:
         credential = _get_credential()
         try:
+            # Currently, the param 'connection' is str, not AzureOpenAIConnection type.
+            # Maybe SDK will update here to pass AzureOpenAIConnection later.
             if isinstance(connection, AzureOpenAIConnection):
                 name = connection.name
             else:

--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -95,14 +95,8 @@ def list_deployment_names(
         credential = _get_credential()
         try:
             # Currently, the param 'connection' is str, not AzureOpenAIConnection type.
-            # Maybe SDK will update here to pass AzureOpenAIConnection later.
-            if isinstance(connection, AzureOpenAIConnection):
-                name = connection.name
-            else:
-                name = connection
-
             conn = ArmConnectionOperations._build_connection_dict(
-                name=name,
+                name=connection,
                 subscription_id=subscription_id,
                 resource_group_name=resource_group_name,
                 workspace_name=workspace_name,

--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -77,7 +77,7 @@ def list_deployment_names(
     subscription_id,
     resource_group_name,
     workspace_name,
-    connection
+    connection = ""
 ) -> List[Dict[str, str]]:
     res = []
     try:

--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -77,7 +77,7 @@ def list_deployment_names(
     subscription_id,
     resource_group_name,
     workspace_name,
-    connection: AzureOpenAIConnection = None
+    connection
 ) -> List[Dict[str, str]]:
     res = []
     try:

--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -77,7 +77,7 @@ def list_deployment_names(
     subscription_id,
     resource_group_name,
     workspace_name,
-    connection = ""
+    connection=""
 ) -> List[Dict[str, str]]:
     res = []
     try:

--- a/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
+++ b/src/promptflow-tools/promptflow/tools/aoai_gpt4v.py
@@ -94,8 +94,13 @@ def list_deployment_names(
     try:
         credential = _get_credential()
         try:
+            if isinstance(connection, AzureOpenAIConnection):
+                name = connection.name
+            else:
+                name = connection
+
             conn = ArmConnectionOperations._build_connection_dict(
-                name=connection,
+                name=name,
                 subscription_id=subscription_id,
                 resource_group_name=resource_group_name,
                 workspace_name=workspace_name,

--- a/src/promptflow-tools/tests/test_aoai_gptv.py
+++ b/src/promptflow-tools/tests/test_aoai_gptv.py
@@ -102,24 +102,6 @@ def test_list_deployment_names_with_conn_error(monkeypatch):
     assert res == []
 
 
-def test_list_deployment_names_with_azure_openai_conn(monkeypatch):
-    from promptflow.azure.operations._arm_connection_operations import ArmConnectionOperations
-    from promptflow.connections import AzureOpenAIConnection
-
-    monkeypatch.setattr(
-        ArmConnectionOperations,
-        "_build_connection_dict",
-        mock_build_connection_dict_func1
-    )
-    res = list_deployment_names(
-        DEFAULT_SUBSCRIPTION_ID,
-        DEFAULT_RESOURCE_GROUP_NAME,
-        DEFAULT_WORKSPACE_NAME,
-        AzureOpenAIConnection("", "")
-    )
-    assert res == []
-
-
 def test_list_deployment_names_with_wrong_connection_id(monkeypatch):
     from promptflow.azure.operations._arm_connection_operations import ArmConnectionOperations
 

--- a/src/promptflow-tools/tests/test_aoai_gptv.py
+++ b/src/promptflow-tools/tests/test_aoai_gptv.py
@@ -43,10 +43,7 @@ def azure_openai_provider(azure_open_ai_connection) -> AzureOpenAI:
 def mock_build_connection_dict_func1(**kwargs):
     from promptflow.azure.operations._arm_connection_operations import OpenURLFailedUserError
 
-    if isinstance(kwargs['name'], str):
-        raise OpenURLFailedUserError
-    else:
-        return {"value" : {"resource_id": "abc"}}
+    raise OpenURLFailedUserError
 
 
 def mock_build_connection_dict_func2(**kwargs):

--- a/src/promptflow-tools/tests/test_aoai_gptv.py
+++ b/src/promptflow-tools/tests/test_aoai_gptv.py
@@ -43,7 +43,10 @@ def azure_openai_provider(azure_open_ai_connection) -> AzureOpenAI:
 def mock_build_connection_dict_func1(**kwargs):
     from promptflow.azure.operations._arm_connection_operations import OpenURLFailedUserError
 
-    raise OpenURLFailedUserError
+    if isinstance(kwargs['name'], str):
+        raise OpenURLFailedUserError
+    else:
+        return {"value" : {"resource_id": "abc"}}
 
 
 def mock_build_connection_dict_func2(**kwargs):
@@ -95,6 +98,24 @@ def test_list_deployment_names_with_conn_error(monkeypatch):
         DEFAULT_RESOURCE_GROUP_NAME,
         DEFAULT_WORKSPACE_NAME,
         DEFAULT_CONNECTION
+    )
+    assert res == []
+
+
+def test_list_deployment_names_with_azure_openai_conn(monkeypatch):
+    from promptflow.azure.operations._arm_connection_operations import ArmConnectionOperations
+    from promptflow.connections import AzureOpenAIConnection
+    
+    monkeypatch.setattr(
+        ArmConnectionOperations,
+        "_build_connection_dict",
+        mock_build_connection_dict_func1
+    )
+    res = list_deployment_names(
+        DEFAULT_SUBSCRIPTION_ID,
+        DEFAULT_RESOURCE_GROUP_NAME,
+        DEFAULT_WORKSPACE_NAME,
+        AzureOpenAIConnection("", "")
     )
     assert res == []
 

--- a/src/promptflow-tools/tests/test_aoai_gptv.py
+++ b/src/promptflow-tools/tests/test_aoai_gptv.py
@@ -105,7 +105,7 @@ def test_list_deployment_names_with_conn_error(monkeypatch):
 def test_list_deployment_names_with_azure_openai_conn(monkeypatch):
     from promptflow.azure.operations._arm_connection_operations import ArmConnectionOperations
     from promptflow.connections import AzureOpenAIConnection
-    
+
     monkeypatch.setattr(
         ArmConnectionOperations,
         "_build_connection_dict",


### PR DESCRIPTION
# Description
 Currently, the passed in connection is string, in list_deployment_names use it directly as name parameter.
Extension test:
![image](https://github.com/microsoft/promptflow/assets/20365062/1e512a37-fde1-4e7c-adf3-ec02758eaed9)
Portal test:
![image](https://github.com/microsoft/promptflow/assets/20365062/84dc3669-2c54-46aa-9e58-ca87fc73efe7)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
