### PR TITLE
Add created_by info to cosmosDB's trace

### DIFF
--- a/src/promptflow/promptflow/_sdk/_service/app.py
+++ b/src/promptflow/promptflow/_sdk/_service/app.py
@@ -88,12 +88,17 @@ def create_app():
                 import jwt
                 from azure.identity import DefaultAzureCredential
 
-                default_credential = DefaultAzureCredential().get_token("https://management.azure.com/.default")
-                decoded_info = jwt.decode(default_credential.token, options={"verify_signature": False})
+                from promptflow.azure._utils.general import get_arm_token
+
+                default_credential = DefaultAzureCredential()
+
+                token = get_arm_token(credential=default_credential)
+                decoded_token = jwt.decode(token, options={"verify_signature": False})
+                user_object_id, user_tenant_id = decoded_token["oid"], decoded_token["tid"]
                 CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE.update(
                     {
-                        "object_id": decoded_info.get("oid", ""),
-                        "tenant_id": decoded_info.get("tid", ""),
+                        "object_id": user_object_id,
+                        "tenant_id": user_tenant_id,
                     }
                 )
             except Exception as e:

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/span.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/span.py
@@ -23,8 +23,9 @@ class Span:
     resource: dict = None
     id: str = None
     partition_key: str = None
+    created_by: dict = None
 
-    def __init__(self, span: SpanEntity) -> None:
+    def __init__(self, span: SpanEntity, created_by: dict) -> None:
         self.name = span.name
         self.context = span._content[SpanFieldName.CONTEXT]
         self.kind = span._content[SpanFieldName.KIND]
@@ -38,6 +39,7 @@ class Span:
         self.resource = span._content[SpanFieldName.RESOURCE]
         self.partition_key = span.session_id
         self.id = span.span_id
+        self.created_by = created_by
 
     def persist(self, client):
         if self.id is None or self.partition_key is None or self.resource is None:

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/summary.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/summary.py
@@ -29,6 +29,7 @@ class SummaryLine:
     latency: float
     name: str
     kind: str
+    created_by: typing.Dict
     cumulative_token_count: typing.Optional[typing.Dict[str, int]]
     evaluations: typing.Dict = field(default_factory=dict)
     # Only for batch run
@@ -49,6 +50,7 @@ class LineEvaluation:
     trace_id: str
     root_span_id: str
     display_name: str
+    created_by: typing.Dict
     flow_id: str = None
     # Only for batch run
     batch_run_id: str = None
@@ -58,8 +60,9 @@ class LineEvaluation:
 
 
 class Summary:
-    def __init__(self, span: Span) -> None:
+    def __init__(self, span: Span, created_by: typing.Dict) -> None:
         self.span = span
+        self.created_by = created_by
 
     def persist(self, client):
         if self.span.parent_span_id:
@@ -131,6 +134,7 @@ class Summary:
             name=self.span.name,
             kind=attributes[SpanAttributeFieldName.SPAN_TYPE],
             cumulative_token_count=cumulative_token_count,
+            created_by=self.created_by,
         )
         if SpanAttributeFieldName.LINE_RUN_ID in attributes:
             item.line_run_id = attributes[SpanAttributeFieldName.LINE_RUN_ID]
@@ -150,6 +154,7 @@ class Summary:
             root_span_id=self.span.span_id,
             outputs=json_loads_parse_const_as_str(attributes[SpanAttributeFieldName.OUTPUT]),
             display_name=name,
+            created_by=self.created_by,
         )
         if SpanAttributeFieldName.REFERENCED_LINE_RUN_ID in attributes:
             # Query to get item id from line run id.

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
@@ -6,6 +6,8 @@ from promptflow.azure._storage.cosmosdb.span import Span
 
 @pytest.mark.unittest
 class TestSpan:
+    FAKE_CREATED_BY = {"oid": "fake_oid"}
+
     def test_to_dict(self):
         span = Span(
             SpanEntity(
@@ -25,7 +27,8 @@ class TestSpan:
                 resource={},
                 span_type=None,
                 session_id=None,
-            )
+            ),
+            created_by=self.FAKE_CREATED_BY,
         )
         assert span.to_dict() == {
             "name": "test",
@@ -38,6 +41,7 @@ class TestSpan:
                 "span_id": "0x9ded7ce65d5f7775",
             },
             "id": "0x9ded7ce65d5f7775",
+            "created_by": {"oid": "fake_oid"},
         }
 
         span = Span(
@@ -58,7 +62,8 @@ class TestSpan:
                 resource={},
                 span_type=None,
                 session_id="test_session_id",
-            )
+            ),
+            created_by=self.FAKE_CREATED_BY,
         )
         assert span.to_dict() == {
             "name": "test",
@@ -74,4 +79,5 @@ class TestSpan:
             },
             "id": "0x9ded7ce65d5f7775",
             "partition_key": "test_session_id",
+            "created_by": {"oid": "fake_oid"},
         }

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
@@ -10,6 +10,8 @@ from promptflow.azure._storage.cosmosdb.summary import LineEvaluation, Summary, 
 
 
 class TestSummary:
+    FAKE_CREATED_BY = {"oid": "fake_oid"}
+
     @pytest.fixture(autouse=True)
     def setup_data(self):
         test_span = Span(
@@ -30,7 +32,7 @@ class TestSummary:
             run="test_run",
             experiment="test_experiment",
         )
-        self.summary = Summary(test_span)
+        self.summary = Summary(test_span, self.FAKE_CREATED_BY)
         app = Flask(__name__)
         with app.app_context():
             yield
@@ -113,6 +115,7 @@ class TestSummary:
             root_span_id=self.summary.span.span_id,
             outputs={"output_key": "output_value"},
             display_name=self.summary.span.name,
+            created_by=self.FAKE_CREATED_BY,
         )
         expected_patch_operations = [
             {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
@@ -160,6 +163,7 @@ class TestSummary:
             root_span_id=self.summary.span.span_id,
             outputs={"output_key": "output_value"},
             display_name=self.summary.span.name,
+            created_by=self.FAKE_CREATED_BY,
         )
 
         expected_patch_operations = [
@@ -205,6 +209,7 @@ class TestSummary:
             latency=60.0,
             name=self.summary.span.name,
             kind="promptflow.TraceType.Flow",
+            created_by=self.FAKE_CREATED_BY,
             cumulative_token_count={
                 "completion": 10,
                 "prompt": 5,
@@ -247,6 +252,7 @@ class TestSummary:
             status="OK",
             latency=60.0,
             name=self.summary.span.name,
+            created_by=self.FAKE_CREATED_BY,
             kind="promptflow.TraceType.Flow",
             cumulative_token_count={
                 "completion": 10,


### PR DESCRIPTION
# Description

For portal trace, we use one link to show all flow test's traces from same workspace.
Customer must need some way to filter between themselves and others.
So, we add `created_by` here to enable UI add corresponding feature later.

Example:
![image](https://github.com/microsoft/promptflow/assets/17527303/406d890f-ccbc-4532-8e8b-86b84701e957)


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
