### PR TITLE
[Fundamental] stop record and warn to upgrade pydantic in record/replay mode

### DIFF
--- a/docs/dev/replay-e2e-test.md
+++ b/docs/dev/replay-e2e-test.md
@@ -10,6 +10,7 @@
 After cloning the full repo and setting up the proper test environment following [dev_setup.md](./dev_setup.md), run the following command in the root directory of the repo:
 
 1. If you have changed/affected tests in __sdk_cli_test__ : Copy or rename the file [dev-connections.json.example](../../src/promptflow/dev-connections.json.example) to `connections.json` in the same folder.
+   * There are some python package version requirements for running the replay/record tests. It needs pydantic >= 2.0.0.
 2. In your Python environment, set the environment variable `PROMPT_FLOW_TEST_MODE` to `'replay'` and run the test(s).
 
 These tests should work properly without any real connection settings.

--- a/src/promptflow/tests/sdk_cli_test/conftest.py
+++ b/src/promptflow/tests/sdk_cli_test/conftest.py
@@ -23,6 +23,7 @@ from promptflow.executor._process_manager import create_spawned_fork_process_man
 
 from .recording_utilities import (
     RecordStorage,
+    check_pydantic_v2,
     delete_count_lock_file,
     inject_async_with_recording,
     inject_sync_with_recording,
@@ -255,6 +256,7 @@ def setup_recording_injection_if_enabled():
             patcher.start()
 
     if is_replay() or is_record():
+        check_pydantic_v2()
         file_path = RECORDINGS_TEST_CONFIGS_ROOT / "node_cache.shelve"
         RecordStorage.get_instance(file_path)
 

--- a/src/promptflow/tests/sdk_cli_test/recording_utilities/__init__.py
+++ b/src/promptflow/tests/sdk_cli_test/recording_utilities/__init__.py
@@ -5,6 +5,7 @@ from .record_storage import (
     RecordFileMissingException,
     RecordItemMissingException,
     RecordStorage,
+    check_pydantic_v2,
     is_live,
     is_record,
     is_replay,
@@ -24,4 +25,5 @@ __all__ = [
     "is_record",
     "is_replay",
     "delete_count_lock_file",
+    "check_pydantic_v2",
 ]

--- a/src/promptflow/tests/sdk_cli_test/recording_utilities/record_storage.py
+++ b/src/promptflow/tests/sdk_cli_test/recording_utilities/record_storage.py
@@ -32,6 +32,16 @@ def is_live() -> bool:
     return get_test_mode_from_environ() == RecordMode.LIVE
 
 
+def check_pydantic_v2():
+    try:
+        from importlib.metadata import version
+
+        if version("pydantic") < "2.0.0":
+            raise ImportError("pydantic version is less than 2. Recording cannot work properly after commit.")
+    except ImportError:
+        raise ImportError("pydantic is not installed, this is required component for openai recording.")
+
+
 class RecordItemMissingException(PromptflowException):
     """Exception raised when record item missing."""
 

--- a/src/promptflow/tests/sdk_cli_test/recording_utilities/record_storage.py
+++ b/src/promptflow/tests/sdk_cli_test/recording_utilities/record_storage.py
@@ -37,7 +37,7 @@ def check_pydantic_v2():
         from importlib.metadata import version
 
         if version("pydantic") < "2.0.0":
-            raise ImportError("pydantic version is less than 2. Recording cannot work properly after commit.")
+            raise ImportError("pydantic version is less than 2.0.0. Recording cannot work properly.")
     except ImportError:
         raise ImportError("pydantic is not installed, this is required component for openai recording.")
 


### PR DESCRIPTION
# Description

Pydantic model is key items recorded in local recording mode.
By the way, the pipeline is using pydantic > 2  when running tests.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
