### PR TITLE
[Internal] Init Span/LineSummary client in parallel

### DIFF
--- a/src/promptflow/promptflow/_sdk/_service/apis/collector.py
+++ b/src/promptflow/promptflow/_sdk/_service/apis/collector.py
@@ -9,6 +9,7 @@
 
 import json
 import traceback
+from datetime import datetime
 
 from flask import current_app, request
 from google.protobuf.json_format import MessageToJson
@@ -59,32 +60,52 @@ def trace_collector():
 
 
 def _try_write_trace_to_cosmosdb(all_spans):
-    current_app.logger.info(f"Start writing trace to cosmosdb, total spans count: {len(all_spans)}.")
+    if not all_spans:
+        return
     try:
+        span_resource = all_spans[0]._content.get(SpanFieldName.RESOURCE, {})
+        resource_attributes = span_resource.get(SpanResourceFieldName.ATTRIBUTES, {})
+        subscription_id = resource_attributes.get(SpanResourceAttributesFieldName.SUBSCRIPTION_ID, None)
+        resource_group_name = resource_attributes.get(SpanResourceAttributesFieldName.RESOURCE_GROUP_NAME, None)
+        workspace_name = resource_attributes.get(SpanResourceAttributesFieldName.WORKSPACE_NAME, None)
+        if subscription_id is None or resource_group_name is None or workspace_name is None:
+            current_app.logger.debug("Cannot find workspace info in span resource, skip writing trace to cosmosdb.")
+            return
+
+        current_app.logger.info(f"Start writing trace to cosmosdb, total spans count: {len(all_spans)}.")
+        start_time = datetime.now()
+        from promptflow._sdk._service.app import CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE
+        from promptflow.azure._storage.cosmosdb.client import get_client
+        from promptflow.azure._storage.cosmosdb.span import Span as SpanCosmosDB
+        from promptflow.azure._storage.cosmosdb.summary import Summary
+
+        # Load span and summary clients first time may slow.
+        # So, we load 2 client in parallel for warm up.
+        span_thread = ThreadWithContextVars(
+            target=get_client, args=(CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name)
+        )
+        span_thread.start()
+
+        get_client(CosmosDBContainerName.LINE_SUMMARY, subscription_id, resource_group_name, workspace_name)
+
+        span_thread.join()
+
         for span in all_spans:
-            span_resource = span._content.get(SpanFieldName.RESOURCE, {})
-            resource_attributes = span_resource.get(SpanResourceFieldName.ATTRIBUTES, {})
-            subscription_id = resource_attributes.get(SpanResourceAttributesFieldName.SUBSCRIPTION_ID, None)
-            resource_group_name = resource_attributes.get(SpanResourceAttributesFieldName.RESOURCE_GROUP_NAME, None)
-            workspace_name = resource_attributes.get(SpanResourceAttributesFieldName.WORKSPACE_NAME, None)
-            if subscription_id is None or resource_group_name is None or workspace_name is None:
-                current_app.logger.debug("Cannot find workspace info in span resource, skip writing trace to cosmosdb.")
-                return
-            from promptflow._sdk._service.app import CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE
-            from promptflow.azure._storage.cosmosdb.client import get_client
-            from promptflow.azure._storage.cosmosdb.span import Span as SpanCosmosDB
-            from promptflow.azure._storage.cosmosdb.summary import Summary
-
             span_client = get_client(CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name)
-            line_summary_client = get_client(
-                CosmosDBContainerName.LINE_SUMMARY, subscription_id, resource_group_name, workspace_name
+            result = SpanCosmosDB(span, CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE).persist(span_client)
+            # None means the span already exists, then we don't need to persist the summary also.
+            if result is not None:
+                line_summary_client = get_client(
+                    CosmosDBContainerName.LINE_SUMMARY, subscription_id, resource_group_name, workspace_name
+                )
+                Summary(span, CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE).persist(line_summary_client)
+        current_app.logger.info(
+            (
+                f"Finish writing trace to cosmosdb, total spans count: {len(all_spans)}."
+                f" Duration {datetime.now() - start_time}."
             )
+        )
 
-            if line_summary_client and span_client:
-                result = SpanCosmosDB(span, CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE).persist(span_client)
-                # None means the span already exists, then we don't need to persist the summary also.
-                if result is not None:
-                    Summary(span, CREATED_BY_FOR_LOCAL_TO_CLOUD_TRACE).persist(line_summary_client)
     except Exception as e:
         stack_trace = traceback.format_exc()
         current_app.logger.error(f"Failed to write trace to cosmosdb: {e}, stack trace is {stack_trace}")

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_cosmosdb.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_cosmosdb.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from promptflow.azure._storage.cosmosdb.client import _get_client_from_map, client_map
+from promptflow.azure._storage.cosmosdb.client import _get_client_from_map, _get_container_lock, client_map
 
 
 @pytest.mark.unittest
@@ -19,3 +19,9 @@ class TestCosmosDB:
             "client": "test",
         }
         assert _get_client_from_map("test") == "test"
+
+    def test_get_container_lock(self):
+        container_lock = _get_container_lock("test")
+        assert container_lock is not None
+        assert _get_container_lock("test2") != container_lock
+        assert _get_container_lock("test") == container_lock


### PR DESCRIPTION
# Description

Currently, first call to _try_write_trace_to_cosmosdb may take long time. 

In this PR, we init two client in parallel to speed up the init. This will reduce 10s to 20s of the init time.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
