### PR TITLE
Shutdown span processor when end process to guarantee span is exported

### DIFF
--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -707,15 +707,16 @@ def exec_line_for_queue(executor_creation_func, input_queue: Queue, output_queue
         try:
             data = input_queue.get(timeout=1)
             if data == TERMINATE_SIGNAL:
+                # Add try catch in case of shutdown method is not implemented in the tracer provider.
                 try:
                     import opentelemetry.trace as otel_trace
 
-                    # Meet span missing issue when end process normally.
-                    # Shutdown the span processor to flush the remaining spans.
-                    # The span processor is created for each process, so it's ok to shutdown it here.
-                    otel_trace.get_tracer_provider()._active_span_processor.shutdown()
+                    # Meet span missing issue when end process normally (even add wait() when end it).
+                    # Shutdown the tracer provider to flush the remaining spans.
+                    # The tracer provider is created for each process, so it's ok to shutdown it here.
+                    otel_trace.get_tracer_provider().shutdown()
                 except Exception as e:
-                    bulk_logger.warning(f"Error occurred while shutting down span processor: {e}")
+                    bulk_logger.warning(f"Error occurred while shutting down tracer provider: {e}")
 
                 # If found the terminate signal, exit the process.
                 break

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -707,6 +707,16 @@ def exec_line_for_queue(executor_creation_func, input_queue: Queue, output_queue
         try:
             data = input_queue.get(timeout=1)
             if data == TERMINATE_SIGNAL:
+                try:
+                    import opentelemetry.trace as otel_trace
+
+                    # Meet span missing issue when end process normally.
+                    # Shutdown the span processor to flush the remaining spans.
+                    # The span processor is created for each process, so it's ok to shutdown it here.
+                    otel_trace.get_tracer_provider()._active_span_processor.shutdown()
+                except Exception as e:
+                    bulk_logger.warning(f"Error occurred while shutting down span processor: {e}")
+
                 # If found the terminate signal, exit the process.
                 break
             inputs, line_number, run_id, line_timeout_sec = data


### PR DESCRIPTION
# Description

Meet span missing issue for batch run. Which means:
1. Span exporter doesn't submit request to local PFS at all
2. Span exporter may just submit part of spans for one line in request
3. Span exporter may just submit one line's span but ignore other lines


There is a previous PR to fix same issue: https://github.com/microsoft/promptflow/pull/2103
In this PR, shutdown span processor manually to fix the issue. (Will flush all the waiting spans)
Keep the 10 seconds wait from previous PR to guarantee Exporter could receive response from local PFS.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
