### PR TITLE
[tracing][bugfix] Cleanup `referenced.batch_run_id` when submit run

### DIFF
--- a/src/promptflow/promptflow/_sdk/_submitter/run_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/run_submitter.py
@@ -62,13 +62,15 @@ class RunSubmitter:
         return required_run
 
     def _run_bulk(self, run: Run, stream=False, **kwargs):
-        attributes = kwargs.get("attributes", {})
+        attributes: dict = kwargs.get("attributes", {})
         # validate & resolve variant
         if run.variant:
             tuning_node, variant = parse_variant(run.variant)
         else:
             tuning_node, variant = None, None
 
+        # always pop reference.batch_run_id to avoid mis-inheritance
+        attributes.pop(ContextAttributeKey.REFERENCED_BATCH_RUN_ID, None)
         if run.run is not None:
             # Set for flow test against run and no experiment scenario
             if ContextAttributeKey.REFERENCED_BATCH_RUN_ID not in attributes:

--- a/src/promptflow/promptflow/_sdk/_submitter/run_submitter.py
+++ b/src/promptflow/promptflow/_sdk/_submitter/run_submitter.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Union
 
 from promptflow._constants import FlowLanguage
+from promptflow._core.operation_context import OperationContext
 from promptflow._sdk._constants import ContextAttributeKey, FlowRunProperties
 from promptflow._sdk._utils import parse_variant
 from promptflow._sdk.entities._flow import ProtectedFlow
@@ -69,8 +70,9 @@ class RunSubmitter:
         else:
             tuning_node, variant = None, None
 
-        # always pop reference.batch_run_id to avoid mis-inheritance
-        attributes.pop(ContextAttributeKey.REFERENCED_BATCH_RUN_ID, None)
+        # always remove reference.batch_run_id from operation context to avoid mis-inheritance
+        operation_context = OperationContext.get_instance()
+        operation_context._remove_otel_attributes(ContextAttributeKey.REFERENCED_BATCH_RUN_ID)
         if run.run is not None:
             # Set for flow test against run and no experiment scenario
             if ContextAttributeKey.REFERENCED_BATCH_RUN_ID not in attributes:


### PR DESCRIPTION
# Description

Always cleanup `referenced.batch_run_id` when submit a run, which can avoid mis-inheritance of run lineage.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
