### PR TITLE
Create running placeholder item in LineSummary table

### DIFF
--- a/src/promptflow/promptflow/_constants.py
+++ b/src/promptflow/promptflow/_constants.py
@@ -76,6 +76,7 @@ STREAMING_ANIMATION_TIME = 0.01
 OTEL_RESOURCE_SERVICE_NAME = "promptflow"
 DEFAULT_SPAN_TYPE = "default"
 RUNNING_LINE_RUN_STATUS = "Running"
+OK_LINE_RUN_STATUS = "Ok"
 
 
 class TraceEnvironmentVariableName:

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/summary.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/summary.py
@@ -6,7 +6,6 @@ from dataclasses import asdict, dataclass, field
 
 from azure.cosmos import ContainerProxy
 from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosResourceNotFoundError
-from flask import current_app
 
 from promptflow._constants import (
     OK_LINE_RUN_STATUS,
@@ -192,7 +191,7 @@ class Summary:
                 break
             except InsertEvaluationsRetriableException as e:
                 if attempt == 2:  # If this is the last attempt, ignore and just return
-                    current_app.logger.error(f"Error while inserting evaluation: {e}")
+                    self.logger.error(f"Error while inserting evaluation: {e}")
                     return
                 time.sleep(1)
 

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
@@ -2,11 +2,17 @@ from dataclasses import asdict
 from unittest import mock
 
 import pytest
+from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosResourceNotFoundError
 from flask import Flask
 
-from promptflow._constants import SpanAttributeFieldName, SpanFieldName
+from promptflow._constants import OK_LINE_RUN_STATUS, SpanAttributeFieldName, SpanFieldName
 from promptflow._sdk.entities._trace import Span
-from promptflow.azure._storage.cosmosdb.summary import LineEvaluation, Summary, SummaryLine
+from promptflow.azure._storage.cosmosdb.summary import (
+    InsertEvaluationsRetriableException,
+    LineEvaluation,
+    Summary,
+    SummaryLine,
+)
 
 
 @pytest.mark.unittest
@@ -22,7 +28,7 @@ class TestSummary:
             kind="client",
             start_time="2022-01-01T00:00:00Z",
             end_time="2022-01-01T00:01:00Z",
-            status={"status_code": "OK"},
+            status={"status_code": OK_LINE_RUN_STATUS},
             attributes={"key1": "value1", "key2": "value2"},
             resource={"type": "resource_type", "name": "resource_name"},
             span_type="custom",
@@ -40,54 +46,56 @@ class TestSummary:
             yield
 
     def test_non_root_span_does_not_persist(self):
-        with mock.patch.object(self.summary, "_persist_line_run") as mock_persist_line_run, mock.patch.object(
-            self.summary, "_insert_evaluation"
-        ) as mock_insert_evaluation:
-            mock_client = mock.Mock()
-            self.summary.span.parent_span_id = "parent_span_id"
-            self.summary.persist(mock_client)
-            mock_persist_line_run.assert_not_called()
-            mock_insert_evaluation.assert_not_called()
+        mock_client = mock.Mock()
+        self.summary.span.parent_span_id = "parent_span_id"
 
-    def test_aggregate_run_does_not_persist(self):
-        with mock.patch.object(self.summary, "_persist_line_run") as mock_persist_line_run, mock.patch.object(
-            self.summary, "_insert_evaluation"
-        ) as mock_insert_evaluation:
-            mock_client = mock.Mock()
-            self.summary.span.parent_span_id = None
-            attributes = self.summary.span._content[SpanFieldName.ATTRIBUTES]
-            attributes.pop(SpanAttributeFieldName.LINE_RUN_ID, None)
-            attributes.pop(SpanAttributeFieldName.BATCH_RUN_ID, None)
+        with mock.patch.multiple(
+            self.summary,
+            _persist_running_item=mock.DEFAULT,
+            _persist_line_run=mock.DEFAULT,
+            _insert_evaluation_with_retry=mock.DEFAULT,
+        ) as values:
             self.summary.persist(mock_client)
-            mock_persist_line_run.assert_called_once()
-            mock_insert_evaluation.assert_not_called()
+            values["_persist_running_item"].assert_called_once()
+            values["_persist_line_run"].assert_not_called()
+            values["_insert_evaluation_with_retry"].assert_not_called()
 
-    def test_non_evaluation_span_persists_as_main_run(self):
-        with mock.patch.object(self.summary, "_persist_line_run") as mock_persist_line_run, mock.patch.object(
-            self.summary, "_insert_evaluation"
-        ) as mock_insert_evaluation:
-            mock_client = mock.Mock()
-            self.summary.span.parent_span_id = None
-            self.summary.span._content[SpanFieldName.ATTRIBUTES][SpanAttributeFieldName.LINE_RUN_ID] = "line_run_id"
+    def test_root_span_persist_main_line(self):
+        mock_client = mock.Mock()
+        self.summary.span.parent_span_id = None
+        attributes = self.summary.span._content[SpanFieldName.ATTRIBUTES]
+        attributes.pop(SpanAttributeFieldName.LINE_RUN_ID, None)
+        attributes.pop(SpanAttributeFieldName.BATCH_RUN_ID, None)
+        with mock.patch.multiple(
+            self.summary,
+            _persist_running_item=mock.DEFAULT,
+            _persist_line_run=mock.DEFAULT,
+            _insert_evaluation_with_retry=mock.DEFAULT,
+        ) as values:
             self.summary.persist(mock_client)
-            mock_persist_line_run.assert_called_once()
-            mock_insert_evaluation.assert_not_called()
+            values["_persist_running_item"].assert_not_called()
+            values["_persist_line_run"].assert_called_once()
+            values["_insert_evaluation_with_retry"].assert_not_called()
 
-    def test_non_evaluation_span_persists_with_referenced_line_run_id(self):
-        with mock.patch.object(self.summary, "_persist_line_run") as mock_persist_line_run, mock.patch.object(
-            self.summary, "_insert_evaluation"
-        ) as mock_insert_evaluation:
-            mock_client = mock.Mock()
-            self.summary.span.parent_span_id = None
-            self.summary.span._content[SpanFieldName.ATTRIBUTES][SpanAttributeFieldName.LINE_RUN_ID] = "line_run_id"
-            self.summary.span._content[SpanFieldName.ATTRIBUTES][
-                SpanAttributeFieldName.REFERENCED_LINE_RUN_ID
-            ] = "main_line_run_id"
+    def test_root_evaluation_span_insert(self):
+        mock_client = mock.Mock()
+        self.summary.span.parent_span_id = None
+        self.summary.span._content[SpanFieldName.ATTRIBUTES][SpanAttributeFieldName.LINE_RUN_ID] = "line_run_id"
+        self.summary.span._content[SpanFieldName.ATTRIBUTES][
+            SpanAttributeFieldName.REFERENCED_LINE_RUN_ID
+        ] = "main_line_run_id"
+        with mock.patch.multiple(
+            self.summary,
+            _persist_running_item=mock.DEFAULT,
+            _persist_line_run=mock.DEFAULT,
+            _insert_evaluation_with_retry=mock.DEFAULT,
+        ) as values:
             self.summary.persist(mock_client)
-            mock_persist_line_run.assert_called_once()
-            mock_insert_evaluation.assert_called_once()
+            values["_persist_running_item"].assert_not_called()
+            values["_persist_line_run"].assert_called_once()
+            values["_insert_evaluation_with_retry"].assert_called_once()
 
-    def test_insert_evaluation_line_run_not_exist(self):
+    def test_insert_evaluation_not_found(self):
         client = mock.Mock()
         self.summary.span._content = {
             SpanFieldName.ATTRIBUTES: {
@@ -98,11 +106,28 @@ class TestSummary:
         }
 
         client.query_items.return_value = []
-        self.summary._insert_evaluation(client)
+        with pytest.raises(InsertEvaluationsRetriableException):
+            self.summary._insert_evaluation(client)
         client.query_items.assert_called_once()
         client.patch_item.assert_not_called()
 
-    def test_insert_evaluation_line_run_normal(self):
+    def test_insert_evaluation_not_finished(self):
+        client = mock.Mock()
+        self.summary.span._content = {
+            SpanFieldName.ATTRIBUTES: {
+                SpanAttributeFieldName.REFERENCED_LINE_RUN_ID: "referenced_line_run_id",
+                SpanAttributeFieldName.LINE_RUN_ID: "line_run_id",
+                SpanAttributeFieldName.OUTPUT: '{"output_key": "output_value"}',
+            }
+        }
+
+        client.query_items.return_value = [{"id": "main_id"}]
+        with pytest.raises(InsertEvaluationsRetriableException):
+            self.summary._insert_evaluation(client)
+        client.query_items.assert_called_once()
+        client.patch_item.assert_not_called()
+
+    def test_insert_evaluation_normal(self):
         client = mock.Mock()
         self.summary.span._content = {
             SpanFieldName.ATTRIBUTES: {
@@ -123,7 +148,7 @@ class TestSummary:
             {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
         ]
 
-        client.query_items.return_value = [{"id": "main_id"}]
+        client.query_items.return_value = [{"id": "main_id", "status": OK_LINE_RUN_STATUS}]
         self.summary._insert_evaluation(client)
         client.query_items.assert_called_once()
         client.patch_item.assert_called_once_with(
@@ -132,49 +157,85 @@ class TestSummary:
             patch_operations=expected_patch_operations,
         )
 
-    def test_insert_evaluation_batch_run_not_exist(self):
+    def test_insert_evaluation_query_line(self):
         client = mock.Mock()
         self.summary.span._content = {
             SpanFieldName.ATTRIBUTES: {
-                SpanAttributeFieldName.REFERENCED_BATCH_RUN_ID: "referenced_batch_run_id",
-                SpanAttributeFieldName.BATCH_RUN_ID: "batch_run_id",
-                SpanAttributeFieldName.LINE_NUMBER: "1",
+                SpanAttributeFieldName.REFERENCED_LINE_RUN_ID: "referenced_line_run_id",
+                SpanAttributeFieldName.LINE_RUN_ID: "line_run_id",
                 SpanAttributeFieldName.OUTPUT: '{"output_key": "output_value"}',
             }
         }
-
-        client.query_items.return_value = []
+        client.query_items.return_value = [{"id": "main_id", "status": OK_LINE_RUN_STATUS}]
         self.summary._insert_evaluation(client)
-        client.query_items.assert_called_once()
-        client.patch_item.assert_not_called()
+        client.query_items.assert_called_once_with(
+            query=(
+                "SELECT * FROM c WHERE "
+                "c.line_run_id = @line_run_id AND c.batch_run_id = @batch_run_id AND c.line_number = @line_number"
+            ),
+            parameters=[
+                {"name": "@line_run_id", "value": "referenced_line_run_id"},
+                {"name": "@batch_run_id", "value": None},
+                {"name": "@line_number", "value": None},
+            ],
+            partition_key="test_session_id",
+        )
 
-    def test_insert_evaluation_batch_run_normal(self):
-        client = mock.Mock()
-        self.summary.span._content = {
-            SpanFieldName.ATTRIBUTES: {
-                SpanAttributeFieldName.REFERENCED_BATCH_RUN_ID: "referenced_batch_run_id",
-                SpanAttributeFieldName.BATCH_RUN_ID: "batch_run_id",
-                SpanAttributeFieldName.LINE_NUMBER: "1",
-                SpanAttributeFieldName.OUTPUT: '{"output_key": "output_value"}',
-            }
-        }
         expected_item = LineEvaluation(
-            batch_run_id="batch_run_id",
-            line_number="1",
+            line_run_id="line_run_id",
             trace_id=self.summary.span.trace_id,
             root_span_id=self.summary.span.span_id,
             outputs={"output_key": "output_value"},
             name=self.summary.span.name,
             created_by=self.FAKE_CREATED_BY,
         )
-
         expected_patch_operations = [
             {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
         ]
+        client.patch_item.assert_called_once_with(
+            item="main_id",
+            partition_key="test_session_id",
+            patch_operations=expected_patch_operations,
+        )
 
-        client.query_items.return_value = [{"id": "main_id"}]
+    def test_insert_evaluation_query_batch_run(self):
+        client = mock.Mock()
+        self.summary.span._content = {
+            SpanFieldName.ATTRIBUTES: {
+                SpanAttributeFieldName.REFERENCED_BATCH_RUN_ID: "referenced_batch_run_id",
+                SpanAttributeFieldName.BATCH_RUN_ID: "batch_run_id",
+                SpanAttributeFieldName.LINE_NUMBER: 1,
+                SpanAttributeFieldName.OUTPUT: '{"output_key": "output_value"}',
+            }
+        }
+        client.query_items.return_value = [{"id": "main_id", "status": OK_LINE_RUN_STATUS}]
+
         self.summary._insert_evaluation(client)
-        client.query_items.assert_called_once()
+        client.query_items.assert_called_once_with(
+            query=(
+                "SELECT * FROM c WHERE "
+                "c.line_run_id = @line_run_id AND c.batch_run_id = @batch_run_id AND c.line_number = @line_number"
+            ),
+            parameters=[
+                {"name": "@line_run_id", "value": None},
+                {"name": "@batch_run_id", "value": "referenced_batch_run_id"},
+                {"name": "@line_number", "value": 1},
+            ],
+            partition_key="test_session_id",
+        )
+
+        expected_item = LineEvaluation(
+            batch_run_id="batch_run_id",
+            line_number=1,
+            trace_id=self.summary.span.trace_id,
+            root_span_id=self.summary.span.span_id,
+            outputs={"output_key": "output_value"},
+            name=self.summary.span.name,
+            created_by=self.FAKE_CREATED_BY,
+        )
+        expected_patch_operations = [
+            {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
+        ]
         client.patch_item.assert_called_once_with(
             item="main_id",
             partition_key="test_session_id",
@@ -207,7 +268,7 @@ class TestSummary:
             outputs={"output_key": "output_value"},
             start_time="2022-01-01T00:00:00Z",
             end_time="2022-01-01T00:01:00Z",
-            status="OK",
+            status=OK_LINE_RUN_STATUS,
             latency=60.0,
             name=self.summary.span.name,
             kind="promptflow.TraceType.Flow",
@@ -219,9 +280,8 @@ class TestSummary:
             },
         )
 
-        with mock.patch.object(client, "create_item") as mock_create_item:
-            self.summary._persist_line_run(client)
-            mock_create_item.assert_called_once_with(body=asdict(expected_item))
+        self.summary._persist_line_run(client)
+        client.upsert_item.assert_called_once_with(body=asdict(expected_item))
 
     def test_persist_batch_run(self):
         client = mock.Mock()
@@ -251,7 +311,7 @@ class TestSummary:
             outputs={"output_key": "output_value"},
             start_time="2022-01-01T00:00:00Z",
             end_time="2022-01-01T00:01:00Z",
-            status="OK",
+            status=OK_LINE_RUN_STATUS,
             latency=60.0,
             name=self.summary.span.name,
             created_by=self.FAKE_CREATED_BY,
@@ -263,6 +323,63 @@ class TestSummary:
             },
         )
 
-        with mock.patch.object(client, "create_item") as mock_create_item:
-            self.summary._persist_line_run(client)
-            mock_create_item.assert_called_once_with(body=asdict(expected_item))
+        self.summary._persist_line_run(client)
+        client.upsert_item.assert_called_once_with(body=asdict(expected_item))
+
+    def test_insert_evaluation_with_retry_success(self):
+        client = mock.Mock()
+        with mock.patch.object(self.summary, "_insert_evaluation") as mock_insert_evaluation:
+            self.summary._insert_evaluation_with_retry(client)
+            mock_insert_evaluation.assert_called_once_with(client)
+
+    def test_insert_evaluation_with_retry_exception(self):
+        client = mock.Mock()
+        with mock.patch.object(self.summary, "_insert_evaluation") as mock_insert_evaluation:
+            mock_insert_evaluation.side_effect = InsertEvaluationsRetriableException()
+            with mock.patch("time.sleep") as mock_sleep:
+                self.summary._insert_evaluation_with_retry(client)
+                mock_insert_evaluation.assert_called_with(client)
+                assert mock_insert_evaluation.call_count == 3
+                assert mock_sleep.call_count == 2
+
+    def test_insert_evaluation_with_non_retry_exception(self):
+        client = mock.Mock()
+        with mock.patch.object(self.summary, "_insert_evaluation") as mock_insert_evaluation:
+            mock_insert_evaluation.side_effect = Exception()
+            with pytest.raises(Exception):
+                self.summary._insert_evaluation_with_retry(client)
+            assert mock_insert_evaluation.call_count == 1
+
+    def test_persist_running_item_create_item(self):
+        client = mock.Mock()
+        client.read_item.side_effect = CosmosResourceNotFoundError
+
+        self.summary._persist_running_item(client)
+
+        client.read_item.assert_called_once_with(self.summary.span.trace_id, self.summary.span.session_id)
+        client.create_item.assert_called_once()
+
+    def test_persist_running_item_create_item_conflict_error(self):
+        client = mock.Mock()
+        client.read_item.side_effect = CosmosResourceNotFoundError
+        client.create_item.side_effect = CosmosResourceExistsError
+
+        self.summary._persist_running_item(client)
+
+        client.read_item.assert_called_once_with(self.summary.span.trace_id, self.summary.span.session_id)
+        client.create_item.assert_called_once()
+
+    def test_persist_running_item_item_already_exists(self):
+        client = mock.Mock()
+        item = SummaryLine(
+            id=self.summary.span.trace_id,
+            partition_key=self.summary.span.session_id,
+            session_id=self.summary.span.session_id,
+            trace_id=self.summary.span.trace_id,
+        )
+        client.read_item.return_value = item
+
+        self.summary._persist_running_item(client)
+
+        client.read_item.assert_called_once_with(item.id, item.partition_key)
+        client.create_item.assert_not_called()


### PR DESCRIPTION
# Description
Create a running placeholder item in LineSummary table.
Then if line run needs to execute a long time, customer could see it in advance in UI.
![image](https://github.com/microsoft/promptflow/assets/17527303/5f768dd1-6a55-448b-80b1-ab0345af24a6)
![image](https://github.com/microsoft/promptflow/assets/17527303/da77ae9e-d1a2-443b-9214-a3c59e3710b5)

This PR also add special logic for inserting evaluations. We only insert it after find the main flow is `Ok`.
Because when main flow is finished, we need to invoke upsert_item, which will override existing `evaluations`.
Only insert evaluations when main flow is `Ok` could avoid missing data.


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
