### PR TITLE
fix: runs and logs won't respect PF_HOME_DIRECTORY

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - [SDK/CLI] Support `AzureOpenAIConnection.from_env` and `OpenAIConnection.from_env`. Reach more details [here](https://microsoft.github.io/promptflow/how-to-guides/manage-connections.html#load-from-environment-variables).
 
+### Bugs Fixed
+
+- [SDK/CLI] environment variable `PF_HOME_DIRECTORY` doesn't work for run details & logs.
+
 ## 1.6.0 (2024.03.01)
 
 ### Features Added

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -10,6 +10,8 @@ from pathlib import Path
 LOGGER_NAME = "promptflow"
 
 PROMPT_FLOW_HOME_DIR_ENV_VAR = "PF_HOME_DIRECTORY"
+# Please avoid using PROMPT_FLOW_DIR_NAME directly for home directory, "Path.home() / PROMPT_FLOW_DIR_NAME" e.g.
+# Use HOME_PROMPT_FLOW_DIR instead
 PROMPT_FLOW_DIR_NAME = ".promptflow"
 
 

--- a/src/promptflow/promptflow/_sdk/entities/_experiment.py
+++ b/src/promptflow/promptflow/_sdk/entities/_experiment.py
@@ -14,8 +14,8 @@ from marshmallow import Schema
 
 from promptflow._sdk._constants import (
     BASE_PATH_CONTEXT_KEY,
+    HOME_PROMPT_FLOW_DIR,
     PARAMS_OVERRIDE_KEY,
-    PROMPT_FLOW_DIR_NAME,
     PROMPT_FLOW_EXP_DIR_NAME,
     ExperimentNodeType,
     ExperimentStatus,
@@ -295,7 +295,7 @@ class Experiment(ExperimentTemplate):
         self.last_start_time = kwargs.get("last_start_time", None)
         self.last_end_time = kwargs.get("last_end_time", None)
         self.is_archived = kwargs.get("is_archived", False)
-        self._output_dir = Path.home() / PROMPT_FLOW_DIR_NAME / PROMPT_FLOW_EXP_DIR_NAME / self.name
+        self._output_dir = HOME_PROMPT_FLOW_DIR / PROMPT_FLOW_EXP_DIR_NAME / self.name
         super().__init__(nodes, name=self.name, data=data, inputs=inputs, **kwargs)
 
     @classmethod

--- a/src/promptflow/promptflow/_sdk/entities/_run.py
+++ b/src/promptflow/promptflow/_sdk/entities/_run.py
@@ -19,8 +19,8 @@ from promptflow._sdk._constants import (
     DEFAULT_VARIANT,
     FLOW_DIRECTORY_MACRO_IN_CONFIG,
     FLOW_RESOURCE_ID_PREFIX,
+    HOME_PROMPT_FLOW_DIR,
     PARAMS_OVERRIDE_KEY,
-    PROMPT_FLOW_DIR_NAME,
     REGISTRY_URI_PREFIX,
     REMOTE_URI_PREFIX,
     RUN_MACRO,
@@ -666,7 +666,7 @@ class Run(YAMLTranslatableMixin):
         config = config or Configuration.get_instance()
         path = config.get_run_output_path()
         if path is None:
-            path = Path.home() / PROMPT_FLOW_DIR_NAME / ".runs"
+            path = HOME_PROMPT_FLOW_DIR / ".runs"
         else:
             try:
                 flow_posix_path = self.flow.resolve().as_posix()
@@ -677,7 +677,7 @@ class Run(YAMLTranslatableMixin):
                     raise Exception(f"{FLOW_DIRECTORY_MACRO_IN_CONFIG!r} is not a valid value.")
                 path.mkdir(parents=True, exist_ok=True)
             except Exception:  # pylint: disable=broad-except
-                path = Path.home() / PROMPT_FLOW_DIR_NAME / ".runs"
+                path = HOME_PROMPT_FLOW_DIR / ".runs"
                 warning_message = (
                     "Got unexpected error when parsing specified output path: "
                     f"{config.get_run_output_path()!r}; "

--- a/src/promptflow/promptflow/azure/operations/_run_operations.py
+++ b/src/promptflow/promptflow/azure/operations/_run_operations.py
@@ -30,10 +30,10 @@ from azure.ai.ml.operations._operation_orchestrator import OperationOrchestrator
 
 from promptflow._constants import LANGUAGE_KEY, FlowLanguage
 from promptflow._sdk._constants import (
+    HOME_PROMPT_FLOW_DIR,
     LINE_NUMBER,
     MAX_RUN_LIST_RESULTS,
     MAX_SHOW_DETAILS_RESULTS,
-    PROMPT_FLOW_DIR_NAME,
     PROMPT_FLOW_RUNS_DIR_NAME,
     REGISTRY_URI_PREFIX,
     VIS_PORTAL_URL_TMPL,
@@ -931,7 +931,7 @@ class RunOperations(WorkspaceTelemetryMixin, _ScopeDependentOperations):
         # process the output path
         if output is None:
             # default to be "~/.promptflow/.runs" folder
-            output_directory = Path.home() / PROMPT_FLOW_DIR_NAME / PROMPT_FLOW_RUNS_DIR_NAME
+            output_directory = HOME_PROMPT_FLOW_DIR / PROMPT_FLOW_RUNS_DIR_NAME
         else:
             output_directory = Path(output)
 


### PR DESCRIPTION
# Description

This pull request primarily focuses on modifying the way the home directory is accessed in the `promptflow` package. Instead of directly using `PROMPT_FLOW_DIR_NAME`, the code now uses `HOME_PROMPT_FLOW_DIR`. This change has been applied across multiple files and methods to maintain consistency and improve the code's readability and maintainability.

Here are the most important changes:

Changes to `src/promptflow/promptflow/_sdk/_constants.py`:
* Added a comment to discourage the direct use of `PROMPT_FLOW_DIR_NAME` for the home directory and recommended the use of `HOME_PROMPT_FLOW_DIR` instead.

Changes to `src/promptflow/promptflow/_sdk/entities/_experiment.py`:
* Replaced `PROMPT_FLOW_DIR_NAME` with `HOME_PROMPT_FLOW_DIR` in the import statement.
* Modified the `_output_dir` attribute in the `__init__` method to use `HOME_PROMPT_FLOW_DIR` instead of `PROMPT_FLOW_DIR_NAME`.

Changes to `src/promptflow/promptflow/_sdk/entities/_run.py`:
* Replaced `PROMPT_FLOW_DIR_NAME` with `HOME_PROMPT_FLOW_DIR` in the import statement.
* Updated the `_generate_output_path` method to use `HOME_PROMPT_FLOW_DIR` instead of `PROMPT_FLOW_DIR_NAME`. [[1]](diffhunk://#diff-14f4d7a1d9b077c7b749230a92628782f990e1fc7cb741b20ff894f868327020L669-R669) [[2]](diffhunk://#diff-14f4d7a1d9b077c7b749230a92628782f990e1fc7cb741b20ff894f868327020L680-R680)

Changes to `src/promptflow/promptflow/azure/operations/_run_operations.py`:
* Replaced `PROMPT_FLOW_DIR_NAME` with `HOME_PROMPT_FLOW_DIR` in the import statement.
* Modified the `_validate_for_run_download` method to use `HOME_PROMPT_FLOW_DIR` instead of `PROMPT_FLOW_DIR_NAME`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
