### PR TITLE
[Internal] Remove useless log in tracing

### DIFF
--- a/src/promptflow/promptflow/tracing/_tracer.py
+++ b/src/promptflow/promptflow/tracing/_tracer.py
@@ -31,8 +31,6 @@ class Tracer(ThreadLocalSingleton):
     def start_tracing(cls, run_id, node_name: Optional[str] = None):
         current_run_id = cls.current_run_id()
         if current_run_id is not None:
-            msg = f"Try to start tracing for run {run_id} but {current_run_id} is already active."
-            logging.warning(msg)
             return
         tracer = cls(run_id, node_name)
         tracer._activate_in_context()


### PR DESCRIPTION
# Description

This pull request includes a minor change to the `start_tracing` method in the `src/promptflow/promptflow/tracing/_tracer.py` file. The change removes a warning log message that was previously triggered when attempting to start tracing for a run while another run is already active.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
