### PR TITLE
fix: broken flow_file when use default working_dir

### DIFF
--- a/src/promptflow/promptflow/contracts/flow.py
+++ b/src/promptflow/promptflow/contracts/flow.py
@@ -687,8 +687,9 @@ class Flow(FlowBase):
     def _parse_working_dir(cls, flow_file: Path, working_dir=None) -> Path:
         if working_dir is None:
             working_dir = Path(flow_file).resolve().parent
+            flow_file = Path(flow_file).name
         working_dir = Path(working_dir).absolute()
-        return working_dir
+        return flow_file, working_dir
 
     @classmethod
     def _update_working_dir(cls, working_dir: Path):
@@ -697,7 +698,7 @@ class Flow(FlowBase):
     @classmethod
     def from_yaml(cls, flow_file: Path, working_dir=None) -> "Flow":
         """Load flow from yaml file."""
-        working_dir = cls._parse_working_dir(flow_file, working_dir)
+        flow_file, working_dir = cls._parse_working_dir(flow_file, working_dir)
         with open(working_dir / flow_file, "r", encoding=DEFAULT_ENCODING) as fin:
             flow_dag = load_yaml(fin)
         flow_dag["name"] = flow_dag.get("name", _sanitize_python_variable_name(working_dir.stem))


### PR DESCRIPTION
when flow_file only specified, working_dir get set as flow_file.parent. However, working_dir / flow_file is not the valid path when flow_file is relative path of more than 2 depths. For example:
flow_file='./Flow-hello/flow.dag.yaml'
working_dir=None
working_dir='./Flow-hello/'.absolute()
working_dir / flow_file = './Flow-hello/Flow-hello/flow.dag.yaml'

# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
