### PR TITLE
Fix docs cli example to give the promised run details table output

### DIFF
--- a/docs/how-to-guides/manage-runs.md
+++ b/docs/how-to-guides/manage-runs.md
@@ -154,7 +154,7 @@ print(run)
 Get run details with TABLE format.
 
 ```bash
-pf run show --name <run-name>
+pf run show-details --name <run-name>
 ```
 
 ![img](../media/how-to-guides/run_show_details.png)


### PR DESCRIPTION
# Description
Existing docs give wrong command line at this url; user expects to get tabular output, but command shown gives json output: https://microsoft.github.io/promptflow/how-to-guides/manage-runs.html#show-run-metrics

ISSUE: https://github.com/microsoft/promptflow/issues/2299

The 

TEST PLAN:
updated md file renders in vscode, copy & paste of corrected command line works when a real run name is used.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.** (N/A)
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x ] Pull request includes test coverage for the included changes. (N/A)
