### PR TITLE
[Bugfix] Do not add otlp exporter if the env is not set to avoid the default http endpoint.

### DIFF
--- a/src/promptflow/promptflow/_sdk/_tracing.py
+++ b/src/promptflow/promptflow/_sdk/_tracing.py
@@ -216,8 +216,10 @@ def setup_exporter_to_pfs() -> None:
     tracer_provider = TracerProvider(resource=res)
     # get OTLP endpoint from environment
     endpoint = os.getenv(OTEL_EXPORTER_OTLP_ENDPOINT)
-    otlp_span_exporter = OTLPSpanExporter(endpoint=endpoint)
-    tracer_provider.add_span_processor(BatchSpanProcessor(otlp_span_exporter))
+    if endpoint is not None:
+        # create OTLP span exporter if endpoint is set
+        otlp_span_exporter = OTLPSpanExporter(endpoint=endpoint)
+        tracer_provider.add_span_processor(BatchSpanProcessor(otlp_span_exporter))
     # set tracer provider
     if _is_tracer_provider_set():
         _force_set_tracer_provider(tracer_provider)


### PR DESCRIPTION
# Description

Do not add otlp exporter when the environment is not set.
Currently we will initialize an exporter with `endpoint=None`, then we will call a default http endpoint.
However we need to avoid this.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
