### PR TITLE
[BugFix] set default values to workspace triad params of dynamic list tool func to avoid misleading errors

### DIFF
--- a/docs/how-to-guides/develop-a-tool/create-dynamic-list-tool-input.md
+++ b/docs/how-to-guides/develop-a-tool/create-dynamic-list-tool-input.md
@@ -125,7 +125,10 @@ pip install my-tools-package>=0.0.8
 ### I'm a tool author, and want to dynamically list Azure resources in my tool input. What should I pay attention to?
 1. Clarify azure workspace triple "subscription_id", "resource_group_name", "workspace_name" in the list function signature. System helps append workspace triple to function input parameters if they are in function signature. See [list_endpoint_names](https://github.com/microsoft/promptflow/blob/main/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py) as an example.
 ```python
-def list_endpoint_names(subscription_id, resource_group_name, workspace_name, prefix: str = "") -> List[Dict[str, str]]:
+def list_endpoint_names(subscription_id: str = None,
+                        resource_group_name: str = None, 
+                        workspace_name: str = None,
+                        prefix: str = "") -> List[Dict[str, str]]:
     """This is an example to show how to get Azure ML resource in tool input list function.
 
     :param subscription_id: Azure subscription id.
@@ -133,6 +136,10 @@ def list_endpoint_names(subscription_id, resource_group_name, workspace_name, pr
     :param workspace_name: Azure ML workspace name.
     :param prefix: prefix to add to each item.
     """
+    # return an empty list if workspace triad is ready.
+    if not subscription_id or not resource_group_name or not workspace_name:
+        return []
+
     from azure.ai.ml import MLClient
     from azure.identity import DefaultAzureCredential
 
@@ -185,4 +192,13 @@ If you are unable to see any options in a dynamic list tool input, you may see a
 If this occurs, follow these troubleshooting steps:
 
 - Note the exact error message shown. This provides details on why the dynamic list failed to populate.
+- Check the tool documentation for any prerequisites or special instructions. For example, if the dynamic list function requires Azure credentials, ensure you have installed azure dependencies, logged in and set the default workspace.
+  ```sh
+  pip install azure-ai-ml
+  ```
+  ```sh
+  az login
+  az account set --subscription <subscription_id>
+  az configure --defaults group=<resource_group_name> workspace=<workspace_name>
+  ```
 - Contact the tool author/support team and report the issue. Provide the error message so they can investigate the root cause. 

--- a/docs/how-to-guides/develop-a-tool/create-dynamic-list-tool-input.md
+++ b/docs/how-to-guides/develop-a-tool/create-dynamic-list-tool-input.md
@@ -136,7 +136,7 @@ def list_endpoint_names(subscription_id: str = None,
     :param workspace_name: Azure ML workspace name.
     :param prefix: prefix to add to each item.
     """
-    # return an empty list if workspace triad is ready.
+    # return an empty list if workspace triad is not available.
     if not subscription_id or not resource_group_name or not workspace_name:
         return []
 

--- a/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py
+++ b/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py
@@ -32,7 +32,7 @@ def my_list_func(prefix: str = "", size: int = 10, **kwargs) -> List[Dict[str, U
 
 
 def list_endpoint_names(subscription_id: str = None,
-                        resource_group_name: str = None, 
+                        resource_group_name: str = None,
                         workspace_name: str = None,
                         prefix: str = "") -> List[Dict[str, str]]:
     """This is an example to show how to get Azure ML resource in tool input list function.

--- a/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py
+++ b/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py
@@ -31,7 +31,10 @@ def my_list_func(prefix: str = "", size: int = 10, **kwargs) -> List[Dict[str, U
     return result
 
 
-def list_endpoint_names(subscription_id, resource_group_name, workspace_name, prefix: str = "") -> List[Dict[str, str]]:
+def list_endpoint_names(subscription_id: str = None,
+                        resource_group_name: str = None, 
+                        workspace_name: str = None,
+                        prefix: str = "") -> List[Dict[str, str]]:
     """This is an example to show how to get Azure ML resource in tool input list function.
 
     :param subscription_id: Azure subscription id.
@@ -39,6 +42,10 @@ def list_endpoint_names(subscription_id, resource_group_name, workspace_name, pr
     :param workspace_name: Azure ML workspace name.
     :param prefix: prefix to add to each item.
     """
+    # return an empty list if workspace triad is ready.
+    if not subscription_id or not resource_group_name or not workspace_name:
+        return []
+
     from azure.ai.ml import MLClient
     from azure.identity import DefaultAzureCredential
 

--- a/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py
+++ b/examples/tools/tool-package-quickstart/my_tool_package/tools/tool_with_dynamic_list_input.py
@@ -42,7 +42,7 @@ def list_endpoint_names(subscription_id: str = None,
     :param workspace_name: Azure ML workspace name.
     :param prefix: prefix to add to each item.
     """
-    # return an empty list if workspace triad is ready.
+    # return an empty list if workspace triad is not available.
     if not subscription_id or not resource_group_name or not workspace_name:
         return []
 

--- a/src/promptflow-tools/promptflow/tools/open_model_llm.py
+++ b/src/promptflow-tools/promptflow/tools/open_model_llm.py
@@ -521,11 +521,15 @@ def parse_endpoint_connection_type(endpoint_connection_name: str) -> Tuple[str, 
     return (endpoint_connection_details[0].lower(), endpoint_connection_details[1])
 
 
-def list_endpoint_names(subscription_id: str,
-                        resource_group_name: str,
-                        workspace_name: str,
+def list_endpoint_names(subscription_id: str = None,
+                        resource_group_name: str = None,
+                        workspace_name: str = None,
                         return_endpoint_url: bool = False,
                         force_refresh: bool = False) -> List[Dict[str, Union[str, int, float, list, Dict]]]:
+    # return an empty list if workspace triad is ready.
+    if not subscription_id or not resource_group_name or not workspace_name:
+        return []
+
     cache_file_path = None
     try:
         with tempfile.NamedTemporaryFile(delete=False) as temp_file:
@@ -598,10 +602,14 @@ Error:{e}""", file=sys.stdout)
     return list_of_endpoints
 
 
-def list_deployment_names(subscription_id: str,
-                          resource_group_name: str,
-                          workspace_name: str,
+def list_deployment_names(subscription_id: str = None,
+                          resource_group_name: str = None,
+                          workspace_name: str = None,
                           endpoint: str = None) -> List[Dict[str, Union[str, int, float, list, Dict]]]:
+    # return an empty list if workspace triad is ready.
+    if not subscription_id or not resource_group_name or not workspace_name:
+        return []
+
     deployment_default_list = [{
         "value": DEPLOYMENT_DEFAULT,
         "display_value": DEPLOYMENT_DEFAULT,

--- a/src/promptflow-tools/promptflow/tools/open_model_llm.py
+++ b/src/promptflow-tools/promptflow/tools/open_model_llm.py
@@ -526,7 +526,7 @@ def list_endpoint_names(subscription_id: str = None,
                         workspace_name: str = None,
                         return_endpoint_url: bool = False,
                         force_refresh: bool = False) -> List[Dict[str, Union[str, int, float, list, Dict]]]:
-    # return an empty list if workspace triad is ready.
+    # return an empty list if workspace triad is not available.
     if not subscription_id or not resource_group_name or not workspace_name:
         return []
 
@@ -606,7 +606,7 @@ def list_deployment_names(subscription_id: str = None,
                           resource_group_name: str = None,
                           workspace_name: str = None,
                           endpoint: str = None) -> List[Dict[str, Union[str, int, float, list, Dict]]]:
-    # return an empty list if workspace triad is ready.
+    # return an empty list if workspace triad is not available.
     if not subscription_id or not resource_group_name or not workspace_name:
         return []
 


### PR DESCRIPTION
# Description
Issue: #2238 
![image](https://github.com/microsoft/promptflow/assets/49483542/4dca1102-dc41-4115-bb9d-b5ab49df6e73)

Fix: 
- if no workspace triad available, return empty list.
- set default values to workspace triad params of dynamic list tool func.

After fix:
![image](https://github.com/microsoft/promptflow/assets/49483542/1407ef1a-ec43-48d6-b132-0c0a4f0ada2d)


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
