### PR TITLE
[Internal][Executor] Use _kwargs to pass all common kwargs to SpawnedForkProcessManager instead of specifying them explicitly

### DIFF
--- a/src/promptflow/promptflow/executor/_process_manager.py
+++ b/src/promptflow/promptflow/executor/_process_manager.py
@@ -260,9 +260,10 @@ class ForkProcessManager(AbstractProcessManager):
 
     def __init__(self, control_signal_queue: Queue, flow_create_kwargs, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._kwargs = kwargs
         self._control_signal_queue = control_signal_queue
         self._flow_create_kwargs = flow_create_kwargs
+        # Use _kwargs to temporarily store all common kwargs and pass them to SpawnedForkProcessManager
+        self._kwargs = kwargs
 
     def start_processes(self):
         """


### PR DESCRIPTION
# Description

Use _kwargs to pass all common kwargs to SpawnedForkProcessManager instead of instead of specifying them explicitly.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
