### PR TITLE
[Internal] add hyper link to pf chatbot in pf docsite

### DIFF
--- a/scripts/docs/conf.py
+++ b/scripts/docs/conf.py
@@ -86,6 +86,11 @@ html_theme_options = {
             "url": "https://pypi.org/project/promptflow/",
             "icon": "fa-solid fa-box",
         },
+        {
+            "name": "Chat with copilot",
+            "url": "https://pfcopilot.azurewebsites.net/chat",
+            "icon": "fa-solid fa-message",
+        },
     ],
     "logo": {
         "text": "Prompt flow",


### PR DESCRIPTION
# Description

Add a hyper link point to promptflow chatbot in pf docsite.

![image](https://github.com/microsoft/promptflow/assets/9986857/ebaad79d-a8ee-4ea7-b2ec-24e61f66c758)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
