### PR TITLE
[tracing] Rename `display_name` to `name` in line run evaluations

### DIFF
--- a/src/promptflow/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow/promptflow/_sdk/entities/_trace.py
@@ -223,7 +223,8 @@ class _LineRunData:
     end_time: str
     status: str
     latency: float
-    display_name: str
+    name: str
+    display_name: str  # rename to `name`, keep this to avoid breaking before UX update
     kind: str
     cumulative_token_count: typing.Optional[typing.Dict[str, int]]
 
@@ -256,6 +257,7 @@ class _LineRunData:
             end_time=end_time.isoformat(),
             status=span._content[SpanFieldName.STATUS][SpanStatusFieldName.STATUS_CODE],
             latency=(end_time - start_time).total_seconds(),
+            name=span.name,
             display_name=span.name,
             kind=attributes.get(SpanAttributeFieldName.SPAN_TYPE, span.span_type),
             cumulative_token_count=cumulative_token_count,
@@ -314,7 +316,7 @@ class LineRun:
             end_time=main_line_run_data.end_time,
             status=main_line_run_data.status,
             latency=main_line_run_data.latency,
-            name=main_line_run_data.display_name,
+            name=main_line_run_data.name,
             kind=main_line_run_data.kind,
             cumulative_token_count=main_line_run_data.cumulative_token_count,
             evaluations=evaluations,


### PR DESCRIPTION
# Description

Rename this field to make UX easier to work with line run; will keep both `display_name` and `name` for now to avoid temp breaking, and will remove `display_name` once we get UX bundle updated.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
