### PR TITLE
[Tracing] Remove dependence of tracing on jinja2

### DIFF
--- a/src/promptflow/promptflow/tracing/_utils.py
+++ b/src/promptflow/promptflow/tracing/_utils.py
@@ -59,6 +59,8 @@ def serialize(value: object, remove_null: bool = False, serialization_funcs: Dic
 
 def get_input_names_for_prompt_template(template_str):
     try:
+        # We need to parse jinja template only when the promptflow is installed and run flow with PromptTemplate
+        # type input, so using try-catch to avoid the dependency of jinja2 when it's not needed.
         from jinja2 import Environment, meta
 
         input_names = []

--- a/src/promptflow/promptflow/tracing/_utils.py
+++ b/src/promptflow/promptflow/tracing/_utils.py
@@ -2,7 +2,6 @@ import re
 from dataclasses import fields, is_dataclass
 from datetime import datetime
 from enum import Enum
-from jinja2 import Environment, meta
 from typing import Callable, Dict
 
 from .contracts.generator_proxy import GeneratorProxy
@@ -59,18 +58,23 @@ def serialize(value: object, remove_null: bool = False, serialization_funcs: Dic
 
 
 def get_input_names_for_prompt_template(template_str):
-    input_names = []
-    env = Environment()
-    template = env.parse(template_str)
-    input_names.extend(sorted(meta.find_undeclared_variables(template), key=lambda x: template_str.find(x)))
+    try:
+        from jinja2 import Environment, meta
 
-    # currently we only support image type
-    pattern = r"\!\[(\s*image\s*)\]\(\{\{\s*([^{}]+)\s*\}\}\)"
-    matches = re.finditer(pattern, template_str)
-    for match in matches:
-        input_names.append(match.group(2).strip())
+        input_names = []
+        env = Environment()
+        template = env.parse(template_str)
+        input_names.extend(sorted(meta.find_undeclared_variables(template), key=lambda x: template_str.find(x)))
 
-    return input_names
+        # currently we only support image type
+        pattern = r"\!\[(\s*image\s*)\]\(\{\{\s*([^{}]+)\s*\}\}\)"
+        matches = re.finditer(pattern, template_str)
+        for match in matches:
+            input_names.append(match.group(2).strip())
+
+        return input_names
+    except ImportError:
+        return []
 
 
 def get_prompt_param_name_from_func(f):

--- a/src/promptflow/promptflow/tracing/_utils.py
+++ b/src/promptflow/promptflow/tracing/_utils.py
@@ -62,21 +62,21 @@ def get_input_names_for_prompt_template(template_str):
         # We need to parse jinja template only when the promptflow is installed and run flow with PromptTemplate
         # type input, so using try-catch to avoid the dependency of jinja2 when it's not needed.
         from jinja2 import Environment, meta
-
-        input_names = []
-        env = Environment()
-        template = env.parse(template_str)
-        input_names.extend(sorted(meta.find_undeclared_variables(template), key=lambda x: template_str.find(x)))
-
-        # currently we only support image type
-        pattern = r"\!\[(\s*image\s*)\]\(\{\{\s*([^{}]+)\s*\}\}\)"
-        matches = re.finditer(pattern, template_str)
-        for match in matches:
-            input_names.append(match.group(2).strip())
-
-        return input_names
     except ImportError:
         return []
+
+    input_names = []
+    env = Environment()
+    template = env.parse(template_str)
+    input_names.extend(sorted(meta.find_undeclared_variables(template), key=lambda x: template_str.find(x)))
+
+    # currently we only support image type
+    pattern = r"\!\[(\s*image\s*)\]\(\{\{\s*([^{}]+)\s*\}\}\)"
+    matches = re.finditer(pattern, template_str)
+    for match in matches:
+        input_names.append(match.group(2).strip())
+
+    return input_names
 
 
 def get_prompt_param_name_from_func(f):


### PR DESCRIPTION
# Description

Since the promptflow-tracing package should only depend on openai and opentelemetry, we should remove the dependence of tracing on jinja2.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
