### PR TITLE
[Executor] Remove resume_from_run_output_dir

### DIFF
--- a/src/promptflow/promptflow/batch/_batch_engine.py
+++ b/src/promptflow/promptflow/batch/_batch_engine.py
@@ -197,9 +197,9 @@ class BatchEngine:
                     run_id = run_id or str(uuid.uuid4())
 
                     previous_run_results = None
-                    if resume_from_run_storage and resume_from_run_output_dir:
+                    if resume_from_run_storage:
                         previous_run_results = self._copy_previous_run_result(
-                            resume_from_run_storage, resume_from_run_output_dir, batch_inputs, output_dir, run_id
+                            resume_from_run_storage, batch_inputs, output_dir, run_id
                         )
 
                     # run flow in batch mode
@@ -231,13 +231,11 @@ class BatchEngine:
     def _copy_previous_run_result(
         self,
         resume_from_run_storage: AbstractBatchRunStorage,
-        resume_from_run_output_dir: Path,
         batch_inputs: List,
         output_dir: Path,
         run_id: str,
     ) -> List[LineResult]:
-        """Duplicate the previous debug_info from resume_from_run_storage and output from resume_from_run_output_dir
-        to the storage of new run,
+        """Duplicate the previous debug_info from resume_from_run_storage to the storage of new run,
         return the list of previous line results for the usage of aggregation and summarization.
         """
         try:


### PR DESCRIPTION
# Description

Since we switch to load previous_run_output from debug_info instead of output file, the resume_from_output_dir is not used in the resume process. This PR removes it from _copy_previous_run_result.
To maintain consistency with runtime and not introducing breaking change, we keep it in the batch_engine.run param list.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
