### PR TITLE
[Internal] Align the extras_require with azure promptflow

### DIFF
--- a/src/promptflow/setup.py
+++ b/src/promptflow/setup.py
@@ -80,9 +80,9 @@ setup(
     extras_require={
         "azure": [
             "azure-core>=1.26.4,<2.0.0",
-            "azure-storage-blob[aio]>=12.13.0,<13.0.0",  # add [aio] for async run download feature
+            "azure-storage-blob[aio]>=12.17.0,<13.0.0",  # add [aio] for async run download feature
             "azure-identity>=1.12.0,<2.0.0",
-            "azure-ai-ml>=1.11.0,<2.0.0",
+            "azure-ai-ml>=1.14.0,<2.0.0",
             "pyjwt>=2.4.0,<3.0.0",  # requirement of control plane SDK
             "azure-cosmos>=4.5.1,<5.0.0",  # used to upload trace to cloud
         ],
@@ -90,7 +90,7 @@ setup(
         "azureml-serving": [
             # AzureML connection dependencies
             "azure-identity>=1.12.0,<2.0.0",
-            "azure-ai-ml>=1.11.0,<2.0.0",
+            "azure-ai-ml>=1.14.0,<2.0.0",
             # MDC dependencies for monitoring
             "azureml-ai-monitoring>=0.1.0b3,<1.0.0",
         ],


### PR DESCRIPTION
# Description

Upgrade some azure deps to align the deps with promptflow runtime. And then runtime can remove some self define deps version.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
