### PR TITLE
[Draft][Tracing] Modify openai span names

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_tracer.py
+++ b/src/promptflow-tracing/promptflow/tracing/_tracer.py
@@ -137,7 +137,7 @@ class Tracer(ThreadLocalSingleton):
 
 
 def _create_trace_from_function_call(
-    f, *, args=None, kwargs=None, args_to_ignore: Optional[List[str]] = None, trace_type=TraceType.FUNCTION
+    f, *, args=None, kwargs=None, args_to_ignore: Optional[List[str]] = None, trace_type=TraceType.FUNCTION, name=None,
 ):
     """
     Creates a trace object from a function call.
@@ -149,6 +149,7 @@ def _create_trace_from_function_call(
         args_to_ignore (Optional[List[str]], optional): A list of argument names to be ignored in the trace.
                                                         Defaults to None.
         trace_type (TraceType, optional): The type of the trace. Defaults to TraceType.FUNCTION.
+        name (str, optional): The name of the trace. Defaults to None.
 
     Returns:
         Trace: The created trace object.
@@ -176,16 +177,17 @@ def _create_trace_from_function_call(
     for key in args_to_ignore:
         all_kwargs.pop(key, None)
 
-    name = f.__qualname__
+    function = f.__qualname__
     if trace_type in [TraceType.LLM, TraceType.EMBEDDING] and f.__module__:
-        name = f"{f.__module__}.{name}"
+        function = f"{f.__module__}.{function}"
 
     return Trace(
-        name=name,
+        name=name or function,  # Use the function name as the trace name if not provided
         type=trace_type,
         start_time=datetime.utcnow().timestamp(),
         inputs=all_kwargs,
         children=[],
+        function=function,
     )
 
 

--- a/src/promptflow-tracing/promptflow/tracing/contracts/trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/contracts/trace.py
@@ -52,3 +52,4 @@ class Trace:
     node_name: Optional[str] = None  # The node name of the trace, used for flow level trace
     parent_id: str = ""  # The parent trace id of the trace
     id: str = ""  # The trace id
+    function: str = ""  # The function name of the trace

--- a/src/promptflow-tracing/tests/e2etests/simple_functions.py
+++ b/src/promptflow-tracing/tests/e2etests/simple_functions.py
@@ -38,7 +38,7 @@ def greetings(user_id):
 
 @trace
 async def dummy_llm(prompt: str, model: str):
-    asyncio.sleep(0.5)
+    await asyncio.sleep(0.5)
     return "dummy_output"
 
 

--- a/src/promptflow-tracing/tests/e2etests/test_tracing.py
+++ b/src/promptflow-tracing/tests/e2etests/test_tracing.py
@@ -148,17 +148,18 @@ class TestTracing:
         self.validate_openai_tokens(span_list)
         for span in span_list:
             if span.attributes.get("function", "") in EMBEDDING_FUNCTION_NAMES:
-                assert "ada" in span.attributes.get("llm.response.model", "")
+                msg = f"Span attributes is not expected: {span.attributes}"
+                assert "ada" in span.attributes.get("llm.response.model", ""), msg
                 embeddings = span.attributes.get("embedding.embeddings", "")
-                assert "embedding.vector" in embeddings
-                assert "embedding.text" in embeddings
+                assert "embedding.vector" in embeddings, msg
+                assert "embedding.text" in embeddings, msg
                 if isinstance(inputs["input"], list):
                     # If the input is a token array, which is list of int, the attribute should contains
                     # the length of the token array '<len(token_array) dimensional token>'.
-                    assert "dimensional token" in embeddings
+                    assert "dimensional token" in embeddings, msg
                 else:
                     # If the input is a string, the attribute should contains the original input string.
-                    assert inputs["input"] in embeddings
+                    assert inputs["input"] in embeddings, msg
 
     def test_otel_trace_with_multiple_functions(self):
         execute_function_in_subprocess(self.assert_otel_traces_with_multiple_functions)

--- a/src/promptflow-tracing/tests/unittests/test_openai_injector.py
+++ b/src/promptflow-tracing/tests/unittests/test_openai_injector.py
@@ -18,6 +18,8 @@ from promptflow.tracing._integrations._openai_injector import (
     inject_operation_headers,
     inject_sync,
     recover_openai_api,
+    _legacy_openai_apis,
+    _openai_apis,
 )
 from promptflow.tracing._operation_context import OperationContext
 from promptflow.tracing._tracer import Tracer
@@ -276,43 +278,27 @@ async def test_openai_generator_proxy_async():
     "is_legacy, expected_apis_with_injectors",
     [
         (
-            True,
+            False,
             [
                 (
-                    (
-                        ("openai", "Completion", "create", TraceType.LLM),
-                        ("openai", "ChatCompletion", "create", TraceType.LLM),
-                        ("openai", "Embedding", "create", TraceType.EMBEDDING),
-                    ),
+                    _openai_apis()[0],
                     inject_sync,
                 ),
                 (
-                    (
-                        ("openai", "Completion", "acreate", TraceType.LLM),
-                        ("openai", "ChatCompletion", "acreate", TraceType.LLM),
-                        ("openai", "Embedding", "acreate", TraceType.EMBEDDING),
-                    ),
+                    _openai_apis()[1],
                     inject_async,
                 ),
             ],
         ),
         (
-            False,
+            True,
             [
                 (
-                    (
-                        ("openai.resources.chat", "Completions", "create", TraceType.LLM),
-                        ("openai.resources", "Completions", "create", TraceType.LLM),
-                        ("openai.resources", "Embeddings", "create", TraceType.EMBEDDING),
-                    ),
+                    _legacy_openai_apis()[0],
                     inject_sync,
                 ),
                 (
-                    (
-                        ("openai.resources.chat", "AsyncCompletions", "create", TraceType.LLM),
-                        ("openai.resources", "AsyncCompletions", "create", TraceType.LLM),
-                        ("openai.resources", "AsyncEmbeddings", "create", TraceType.EMBEDDING),
-                    ),
+                    _legacy_openai_apis()[1],
                     inject_async,
                 ),
             ],
@@ -331,13 +317,13 @@ def test_api_list(is_legacy, expected_apis_with_injectors):
     "apis_with_injectors, expected_output, expected_logs",
     [
         (
-            [((("MockModule", "MockAPI", "create", TraceType.LLM),), inject_sync)],
-            [(MockAPI, "create", TraceType.LLM, inject_sync)],
+            [((("MockModule", "MockAPI", "create", TraceType.LLM, "Mock.create"),), inject_sync)],
+            [(MockAPI, "create", TraceType.LLM, inject_sync, "Mock.create")],
             [],
         ),
         (
-            [((("MockModule", "MockAPI", "create", TraceType.LLM),), inject_async)],
-            [(MockAPI, "create", TraceType.LLM, inject_async)],
+            [((("MockModule", "MockAPI", "create", TraceType.LLM, "Mock.acreate"),), inject_async)],
+            [(MockAPI, "create", TraceType.LLM, inject_async, "Mock.acreate")],
             [],
         ),
     ],
@@ -349,21 +335,32 @@ def test_generate_api_and_injector(apis_with_injectors, expected_output, expecte
             # Run the generator and collect the output
             result = list(_generate_api_and_injector(apis_with_injectors))
 
-        # Check if the result matches the expected output
-        assert result == expected_output
-
         # Check if the logs match the expected logs
         assert len(caplog.records) == len(expected_logs)
         for record, expected_message in zip(caplog.records, expected_logs):
             assert expected_message in record.message
+
+        # Check if the result matches the expected output
+        assert result == expected_output
 
     mock_import_module.assert_called_with("MockModule")
 
 
 def test_generate_api_and_injector_attribute_error_logging(caplog):
     apis = [
-        ((("NonExistentModule", "NonExistentAPI", "create", TraceType.LLM),), MagicMock()),
-        ((("MockModuleMissingMethod", "MockAPIMissingMethod", "missing_method", "missing_trace_type"),), MagicMock()),
+        ((("NonExistentModule", "NonExistentAPI", "create", TraceType.LLM, "create"),), MagicMock()),
+        (
+            (
+                (
+                    "MockModuleMissingMethod",
+                    "MockAPIMissingMethod",
+                    "missing_method",
+                    "missing_trace_type",
+                    "missing_name",
+                ),
+            ),
+            MagicMock(),
+        ),
     ]
 
     # Set up the side effect for the mock
@@ -407,7 +404,7 @@ def test_inject_and_recover_openai_api():
         pass
 
     # Real injector function that adds an _original attribute
-    def injector(f, trace_type):
+    def injector(f, trace_type, name):
         def wrapper_fun(*args, **kwargs):
             return f(*args, **kwargs)
 
@@ -425,8 +422,8 @@ def test_inject_and_recover_openai_api():
     with patch(
         "promptflow.tracing._integrations._openai_injector.available_openai_apis_and_injectors",
         return_value=[
-            (FakeAPIWithoutOriginal, "create", TraceType.LLM, injector),
-            (FakeAPIWithOriginal, "create", TraceType.LLM, injector),
+            (FakeAPIWithoutOriginal, "create", TraceType.LLM, injector, "create"),
+            (FakeAPIWithOriginal, "create", TraceType.LLM, injector, "create"),
         ],
     ):
         # Call the function to inject the APIs

--- a/src/promptflow-tracing/tests/unittests/test_trace.py
+++ b/src/promptflow-tracing/tests/unittests/test_trace.py
@@ -70,8 +70,8 @@ class MockUsage:
 
 
 class MockTrace:
-    def __init__(self, name, type):
-        self.name = name
+    def __init__(self, function, type):
+        self.function = function
         self.type = type
 
 


### PR DESCRIPTION
# Description

Rename openai spans since openai.resources.chat.Completions.create is too long.

This pull request primarily introduces changes to the tracing functionality in the `promptflow` application. The changes allow for more flexibility and control over the naming of traces, particularly for asynchronous and synchronous functions. The key changes can be grouped into two categories: modifications to the function definitions and adjustments to the function calls.

Modifications to function definitions:

* [`src/promptflow-tracing/promptflow/tracing/_trace.py`](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcL272-R276): Both the `_traced_async` and `_traced_sync` functions were modified to include an optional `name` parameter. This allows for custom naming of the traces. If no name is provided, the function's name is used as the trace name. [[1]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcL272-R276) [[2]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcL322-R334)

Adjustments to function calls:

* [`src/promptflow-tracing/promptflow/tracing/_integrations/_openai_injector.py`](diffhunk://#diff-01b30cb37ac2a91b223014785c6bc7efe007a66efcb97a0dbb36442a94c2054bL24-R33): Several function calls were adjusted to include the new `name` parameter. This includes the `inject_function_async`, `inject_function_sync`, `inject_async`, and `inject_sync` functions. The `name` parameter was also added to the tuples in the `_openai_api_list` function, which are used to generate the API and injector. [[1]](diffhunk://#diff-01b30cb37ac2a91b223014785c6bc7efe007a66efcb97a0dbb36442a94c2054bL24-R33) [[2]](diffhunk://#diff-01b30cb37ac2a91b223014785c6bc7efe007a66efcb97a0dbb36442a94c2054bL93-R103) [[3]](diffhunk://#diff-01b30cb37ac2a91b223014785c6bc7efe007a66efcb97a0dbb36442a94c2054bL112-R132) [[4]](diffhunk://#diff-01b30cb37ac2a91b223014785c6bc7efe007a66efcb97a0dbb36442a94c2054bL141-R146) [[5]](diffhunk://#diff-01b30cb37ac2a91b223014785c6bc7efe007a66efcb97a0dbb36442a94c2054bL179-R182)

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
