### PR TITLE
fix: always release resources in chat ui for csharp

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_constants.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_constants.py
@@ -9,10 +9,11 @@ from pathlib import Path
 
 from promptflow._constants import (
     CONNECTION_SCRUBBED_VALUE,
+    CONNECTION_SCRUBBED_VALUE_NO_CHANGE,
     PROMPT_FLOW_DIR_NAME,
     ConnectionAuthMode,
     ConnectionType,
-    CustomStrongTypeConnectionConfigs, CONNECTION_SCRUBBED_VALUE_NO_CHANGE,
+    CustomStrongTypeConnectionConfigs,
 )
 
 LOGGER_NAME = "promptflow"
@@ -476,6 +477,11 @@ class IdentityKeys(str, Enum):
     USER_IDENTITY = "user_identity"
     RESOURCE_ID = "resource_id"
     CLIENT_ID = "client_id"
+
+
+class OSType:
+    WINDOWS = "Windows"
+    LINUX = "Linux"
 
 
 # Note: Keep these for backward compatibility

--- a/src/promptflow-devkit/promptflow/_sdk/_service/apis/flow.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/apis/flow.py
@@ -89,6 +89,8 @@ class FlowTest(Resource):
                 node=node,
                 experiment=experiment,
                 output_path=output_path,
+                allow_generator_output=False,
+                stream_output=False,
             )
         finally:
             if remove_dir:

--- a/src/promptflow-devkit/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_submitter/test_submitter.py
@@ -283,8 +283,9 @@ class TestSubmitter:
                 try:
                     yield self
                 finally:
+                    # TODO: this is dangerous as we may not release resources
                     if self.executor_proxy:
-                        async_run_allowing_running_loop(self.executor_proxy.destroy_if_all_generators_exhausted)
+                        async_run_allowing_running_loop(self.executor_proxy.destroy)
 
             self._within_init_context = False
 

--- a/src/promptflow-devkit/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_submitter/test_submitter.py
@@ -29,13 +29,6 @@ from promptflow.exceptions import UserErrorException
 from promptflow.executor._result import LineResult
 from promptflow.storage._run_storage import DefaultRunStorage
 
-from ..._constants import LINE_NUMBER_KEY, FlowLanguage
-from ..._core._errors import NotSupported
-from ..._utils.async_utils import async_run_allowing_running_loop
-from ..._utils.dataclass_serializer import convert_eager_flow_output_to_dict
-from ..._utils.flow_utils import dump_flow_result
-from ..._utils.logger_utils import get_cli_sdk_logger
-from ...batch import APIBasedExecutorProxy, CSharpExecutorProxy
 from .._configuration import Configuration
 from ..entities._flow import FlexFlow
 from .utils import (

--- a/src/promptflow-devkit/promptflow/_sdk/_submitter/test_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_submitter/test_submitter.py
@@ -29,6 +29,12 @@ from promptflow.exceptions import UserErrorException
 from promptflow.executor._result import LineResult
 from promptflow.storage._run_storage import DefaultRunStorage
 
+from ..._constants import LINE_NUMBER_KEY, FlowLanguage
+from ..._core._errors import NotSupported
+from ..._utils.async_utils import async_run_allowing_running_loop
+from ..._utils.dataclass_serializer import convert_eager_flow_output_to_dict
+from ..._utils.flow_utils import dump_flow_result
+from ..._utils.logger_utils import get_cli_sdk_logger
 from ...batch import APIBasedExecutorProxy, CSharpExecutorProxy
 from .._configuration import Configuration
 from ..entities._flow import FlexFlow
@@ -86,11 +92,11 @@ class TestSubmitter:
         self._target_node = None
         self._storage = None
         self._enable_stream_output = None
-        self._executor_proxy: Optional[APIBasedExecutorProxy] = None
+        self._executor_proxy = None
         self._within_init_context = False
 
     @property
-    def executor_proxy(self) -> APIBasedExecutorProxy:
+    def executor_proxy(self):
         self._raise_if_not_within_init_context()
         return self._executor_proxy
 
@@ -268,22 +274,19 @@ class TestSubmitter:
                     sub_dir=output_sub / "intermediate",
                 )
 
-                # TODO: set up executor proxy for all languages
-                if self.flow.language == FlowLanguage.CSharp:
-                    self._executor_proxy = async_run_allowing_running_loop(
-                        CSharpExecutorProxy.create,
-                        self.flow.path,
-                        self.flow.code,
-                        connections=self._connections,
-                        storage=self._storage,
-                        log_path=log_path,
-                        enable_stream_output=stream_output,
-                    )
+                self._executor_proxy = ProxyFactory().create_executor_proxy(
+                    self.flow.path,
+                    self.flow.code,
+                    connections=self._connections,
+                    storage=self._storage,
+                    log_path=log_path,
+                    enable_stream_output=stream_output,
+                    language=self.flow.language,
+                )
 
                 try:
                     yield self
                 finally:
-                    # TODO: this is dangerous as we may not release resources
                     if self.executor_proxy:
                         async_run_allowing_running_loop(self.executor_proxy.destroy)
 

--- a/src/promptflow-devkit/promptflow/_sdk/entities/_flow/dag.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_flow/dag.py
@@ -146,6 +146,9 @@ class Flow(FlowBase):
         from promptflow._sdk._submitter import TestSubmitter
 
         if self.language == FlowLanguage.CSharp:
+            # TODO: we shouldn't use context manager here for stream_output, as resource need to be released
+            #  after the returned generator is fully consumed. If we use context manager here, the resource must be
+            #  released before the generator is consumed.
             with TestSubmitter(flow=self, flow_context=self.context).init(
                 stream_output=self.context.streaming
             ) as submitter:

--- a/src/promptflow-devkit/promptflow/_sdk/entities/_flow/dag.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_flow/dag.py
@@ -146,7 +146,7 @@ class Flow(FlowBase):
         from promptflow._sdk._submitter import TestSubmitter
 
         if self.language == FlowLanguage.CSharp:
-            # TODO: we shouldn't use context manager here for stream_output, as resource need to be released
+            # TODO 3033484: we shouldn't use context manager here for stream_output, as resource need to be released
             #  after the returned generator is fully consumed. If we use context manager here, the resource must be
             #  released before the generator is consumed.
             with TestSubmitter(flow=self, flow_context=self.context).init(

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
@@ -278,6 +278,9 @@ class FlowOperations(TelemetryMixin):
         :return: The result of flow or node
         :rtype: dict
         """
+        # TODO : it's not clear why we need this method, please help verify:
+        #  1. why we can't use test method directly
+        #  2. is _chat_with_ui still necessary
         experiment = kwargs.pop("experiment", None)
         if Configuration.get_instance().is_internal_features_enabled() and experiment:
             result = self.test(
@@ -286,6 +289,8 @@ class FlowOperations(TelemetryMixin):
                 environment_variables=environment_variables,
                 variant=variant,
                 node=node,
+                allow_generator_output=kwargs.pop("allow_generator_output", False),
+                stream_output=kwargs.pop("stream_output", False),
                 experiment=experiment,
                 output_path=output_path,
             )

--- a/src/promptflow-devkit/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/batch/_base_executor_proxy.py
@@ -229,8 +229,14 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
         On the other hand, the subprocess for execution service is not started in detach mode;
         it wll exit when parent process exit. So we simply skip the destruction here.
         """
-        if await self._all_generators_exhausted():
-            await self.destroy()
+
+        # TODO 3033484: update this after executor service support graceful shutdown
+        if not await self._all_generators_exhausted():
+            raise UnexpectedError(
+                message_format="The executor service is still handling a stream request "
+                "whose response is not fully consumed yet."
+            )
+        await self.destroy()
 
     # endregion
 
@@ -320,8 +326,6 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
         :type index: Optional[int]
         :param run_id: The id of the run.
         :type run_id: Optional[str]
-        :param enable_stream_output: Whether to enable the stream output.
-        :type enable_stream_output: bool
         :return: The line result.
         :rtype: LineResult
         """

--- a/src/promptflow-devkit/promptflow/batch/_base_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/batch/_base_executor_proxy.py
@@ -209,34 +209,13 @@ class APIBasedExecutorProxy(AbstractExecutorProxy):
         self._active_generator_count -= 1
 
     async def _all_generators_exhausted(self):
-        """For streaming output, we will return a generator for the output, and the execution service
-        should keep alive until the generator is exhausted.
+        """For streaming output in api-based executor proxy, we will return a generator for the output,
+        and the execution service should keep alive until the generator is exhausted.
 
         This method is to check if all generators are exhausted.
         """
         # the count should never be negative, but still check it here for safety
         return self._active_generator_count <= 0
-
-    async def destroy_if_all_generators_exhausted(self):
-        """
-        client.stream api in exec_line function won't pass all response one time.
-        For API-based streaming chat flow, if executor proxy is destroyed, it will kill service process
-        and connection will close. this will result in subsequent getting generator content failed.
-
-        Besides, external caller usually wait for the destruction of executor proxy before it can continue and iterate
-        the generator content, so we can't keep waiting here.
-
-        On the other hand, the subprocess for execution service is not started in detach mode;
-        it wll exit when parent process exit. So we simply skip the destruction here.
-        """
-
-        # TODO 3033484: update this after executor service support graceful shutdown
-        if not await self._all_generators_exhausted():
-            raise UnexpectedError(
-                message_format="The executor service is still handling a stream request "
-                "whose response is not fully consumed yet."
-            )
-        await self.destroy()
 
     # endregion
 

--- a/src/promptflow-devkit/promptflow/batch/_csharp_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/batch/_csharp_executor_proxy.py
@@ -1,6 +1,8 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+import platform
+import signal
 import socket
 import subprocess
 import uuid
@@ -8,6 +10,7 @@ from pathlib import Path
 from typing import NoReturn, Optional
 
 from promptflow._core._errors import UnexpectedError
+from promptflow._sdk._constants import OSType
 from promptflow._utils.flow_utils import is_flex_flow
 from promptflow.batch._csharp_base_executor_proxy import CSharpBaseExecutorProxy
 from promptflow.storage._run_storage import AbstractRunStorage
@@ -169,7 +172,12 @@ class CSharpExecutorProxy(CSharpBaseExecutorProxy):
         # process is not None, it means the executor service is started by the current executor proxy
         # and should be terminated when the executor proxy is destroyed if the service is still active
         if self._process and self._is_executor_active():
-            self._process.terminate()
+            if platform.system() == OSType.WINDOWS:
+                # send CTRL_C_EVENT to the process to gracefully terminate the service
+                self._process.send_signal(signal.CTRL_C_EVENT)
+            else:
+                # for Linux and MacOS, Popen.terminate() will send SIGTERM to the process
+                self._process.terminate()
             try:
                 self._process.wait(timeout=5)
             except subprocess.TimeoutExpired:


### PR DESCRIPTION
# Description

Although new chat UI doesn't support streaming for now, PFS will call flow operation with `stream_output` as `True`, which may bring some issues in resource release. In this PR, we avoid that.

Improvements to the `TestSubmitter`:

* [`src/promptflow/promptflow/_sdk/_submitter/test_submitter.py`](diffhunk://#diff-d9dd2c09a149b11eb54626edf065287eeb7b1a28e39719b8dd95377770f64138R287-R289): The `destroy_if_all_generators_exhausted` method has been replaced with the `destroy` method in the `TestSubmitter` class. This change is accompanied by a comment noting that the current implementation may not properly release resources.

Changes to the test submission process:

* [`src/promptflow/promptflow/_sdk/data/executable/main.py`](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cR14-L20): The `TestSubmitter` class is now used in the `submit` function to handle test submissions. This change simplifies the submission process by removing the need for the `run_flow` function. [[1]](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cR14-L20) [[2]](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cL74-R78) [[3]](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cL104-L123)

Codebase simplification:

* [`src/promptflow/promptflow/_sdk/data/executable/main.py`](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cL104-L123): The `invoker` global variable and the `run_flow` function have been removed, and a `resolve_flow_path` function has been added to handle the flow path resolution. [[1]](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cL104-L123) [[2]](diffhunk://#diff-c22ed7aec6ed0b5a5fde51716818d5695b917ab38cc385ee7e65390471fb723cR195-R212)
* [`src/promptflow/promptflow/_sdk/entities/_flow/dag.py`](diffhunk://#diff-fe4826ecd0e92a94a1769ec7376562b483dcb666b54acd0e6396d6262cbf5f2eR149-R151): A comment has been added to the `invoke` method in the `Flow` class, indicating that the use of a context manager for `stream_output` is not appropriate.
* [`src/promptflow/promptflow/batch/_base_executor_proxy.py`](diffhunk://#diff-44ac8eeb30a630bd24987e92f8bd5a180d57a3ad067db5d937561f21771e14c5L232-R238): The `destroy_if_all_generators_exhausted` method now raises an `UnexpectedError` if all generators are not exhausted, and the `enable_stream_output` parameter has been removed from the `exec_line` method. [[1]](diffhunk://#diff-44ac8eeb30a630bd24987e92f8bd5a180d57a3ad067db5d937561f21771e14c5L232-R238) [[2]](diffhunk://#diff-44ac8eeb30a630bd24987e92f8bd5a180d57a3ad067db5d937561f21771e14c5L323-L324)

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
