### PR TITLE
Add separate log for each line in batch run.

### DIFF
--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -15,7 +15,7 @@
   - CLI: Support `pfazure run create --resume-from <original-run-name>` to create a run resume from another run.
   - SDK: Support `pf.run(resume_from=<original-run-name>)` to create a run resume from another run.
 
-- [Executor] Added per-line logging for batch runs, stored under the `flow_logs` folder.
+- [Batch] Added per-line logging for batch runs, stored under the `flow_logs` folder.
 - [SDK/CLI] Support `AzureOpenAIConnection.from_env` and `OpenAIConnection.from_env`. Reach more details [here](https://microsoft.github.io/promptflow/how-to-guides/manage-connections.html#load-from-environment-variables).
 
 ### Bugs Fixed

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -15,6 +15,7 @@
   - CLI: Support `pfazure run create --resume-from <original-run-name>` to create a run resume from another run.
   - SDK: Support `pf.run(resume_from=<original-run-name>)` to create a run resume from another run.
 
+- [Executor] Added per-line logging for batch runs, stored under the `flow_logs` folder.
 - [SDK/CLI] Support `AzureOpenAIConnection.from_env` and `OpenAIConnection.from_env`. Reach more details [here](https://microsoft.github.io/promptflow/how-to-guides/manage-connections.html#load-from-environment-variables).
 
 ### Bugs Fixed

--- a/src/promptflow/promptflow/_constants.py
+++ b/src/promptflow/promptflow/_constants.py
@@ -44,6 +44,8 @@ FLOW_TOOLS_JSON = "flow.tools.json"
 
 # Constants related to execution
 LINE_NUMBER_KEY = "line_number"  # Using the same key with portal.
+# Fill zero to the left of line number to make it 9 digits. This is to make sure the line number file name is sortable.
+LINE_NUMBER_WIDTH = 9
 LINE_TIMEOUT_SEC = 600
 
 # Environment variables

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -288,6 +288,7 @@ class LocalStorageFilenames:
     DETAIL = "detail.json"
     METRICS = "metrics.json"
     LOG = "logs.txt"
+    FLOW_LOGS_FOLDER = "flow_logs"
     EXCEPTION = "error.json"
     META = "meta.json"
 

--- a/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py
@@ -88,6 +88,7 @@ class LoggerOperations(LogContext):
             run_mode=self.run_mode,
             credential_list=self.credential_list,
             stream=self.stream,
+            flow_logs_folder=self.flow_logs_folder,
         )
 
     def __enter__(self):
@@ -95,6 +96,8 @@ class LoggerOperations(LogContext):
         log_path.parent.mkdir(parents=True, exist_ok=True)
         if self.run_mode == RunMode.Batch:
             log_path.touch(exist_ok=True)
+            line_folder_path = Path(self.flow_logs_folder)
+            line_folder_path.mkdir(parents=True, exist_ok=True)
         else:
             if log_path.exists():
                 # for non batch run, clean up previous log content
@@ -196,7 +199,10 @@ class LocalStorageOperations(AbstractBatchRunStorage):
         self.path = prepare_folder(self._run._output_path)
 
         self.logger = LoggerOperations(
-            file_path=self.path / LocalStorageFilenames.LOG, stream=stream, run_mode=run_mode
+            file_path=self.path / LocalStorageFilenames.LOG,
+            stream=stream,
+            run_mode=run_mode,
+            flow_logs_folder=self.path / LocalStorageFilenames.FLOW_LOGS_FOLDER,
         )
         # snapshot
         self._snapshot_folder_path = prepare_folder(self.path / LocalStorageFilenames.SNAPSHOT_FOLDER)

--- a/src/promptflow/promptflow/_utils/logger_utils.py
+++ b/src/promptflow/promptflow/_utils/logger_utils.py
@@ -15,7 +15,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import List, Optional
 
-from promptflow._constants import PF_LOGGING_LEVEL
+from promptflow._constants import LINE_NUMBER_WIDTH, PF_LOGGING_LEVEL
 from promptflow._utils.credential_scrubber import CredentialScrubber
 from promptflow._utils.exception_utils import ExceptionPresenter
 from promptflow.contracts.run_mode import RunMode
@@ -225,7 +225,6 @@ class LogContext:
 
     file_path: str  # Log file path.
     run_mode: Optional[RunMode] = RunMode.Test
-    LINE_NUMBER_WIDTH = 9
     credential_list: Optional[List[str]] = None  # These credentials will be scrubbed in logs.
     input_logger: logging.Logger = None  # If set, then context will also be set for input_logger.
     flow_logs_folder: Optional[str] = None  # Used in batch mode to specify the folder for flow logs.
@@ -294,8 +293,8 @@ class LogContext:
             return
         from pathlib import Path
 
-        filename = f"{str(self.line_number).zfill(self.LINE_NUMBER_WIDTH)}.log"
-        path = Path(self.flow_logs_folder) / filename
+        file_name = f"{str(self.line_number).zfill(LINE_NUMBER_WIDTH)}.log"
+        path = Path(self.flow_logs_folder) / file_name
         for logger in self._get_batch_run_flow_loggers_list():
             handler = LineFileHandlerConcurrentWrapper()
             handler.handler = FileHandler(path)

--- a/src/promptflow/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow/promptflow/executor/_line_execution_process_pool.py
@@ -741,6 +741,7 @@ def _exec_line_for_queue(
         try:
             data = input_queue.get(timeout=1)
             if data == ProcessPoolConstants.TERMINATE_SIGNAL:
+                # Set logger context for terminate signal without line_number.
                 with log_context_initialization_func() if log_context_initialization_func else nullcontext():
                     bulk_logger.info(f"The process [{os.getpid()}] has received a terminate signal.")
                     # Add try catch in case of shutdown method is not implemented in the tracer provider.

--- a/src/promptflow/tests/executor/e2etests/test_logs.py
+++ b/src/promptflow/tests/executor/e2etests/test_logs.py
@@ -4,7 +4,7 @@ from tempfile import mkdtemp
 
 import pytest
 
-from promptflow._constants import OUTPUT_FILE_NAME
+from promptflow._constants import LINE_NUMBER_WIDTH, OUTPUT_FILE_NAME
 from promptflow._utils.logger_utils import LogContext
 from promptflow.batch import BatchEngine
 from promptflow.batch._result import BatchResult
@@ -221,7 +221,8 @@ class TestExecutorLogs:
             )
             nlines = len(get_bulk_inputs_from_jsonl(flow_folder))
             for i in range(nlines):
-                flow_log_file = Path(bulk_run_flow_logs_folder) / f"{i}.log"
+                file_name = f"{str(i).zfill(LINE_NUMBER_WIDTH)}.log"
+                flow_log_file = Path(bulk_run_flow_logs_folder) / file_name
                 assert flow_log_file.is_file()
                 log_content = load_content(flow_log_file)
                 # Assert flow log file contains expected logs

--- a/src/promptflow/tests/executor/e2etests/test_logs.py
+++ b/src/promptflow/tests/executor/e2etests/test_logs.py
@@ -14,6 +14,7 @@ from promptflow.executor import FlowExecutor
 
 from ..utils import (
     get_batch_inputs_line,
+    get_bulk_inputs_from_jsonl,
     get_flow_folder,
     get_flow_inputs_file,
     get_yaml_file,
@@ -204,6 +205,29 @@ class TestExecutorLogs:
                 assert isinstance(output, dict)
                 assert "line_number" in output, f"line_number is not in {i}th output {output}"
                 assert output["line_number"] == i, f"line_number is not correct in {i}th output {output}"
+
+    def test_batch_run_flow_logs(self, dev_connections):
+        flow_folder = "print_input_flow"
+        logs_directory = Path(mkdtemp())
+        bulk_run_log_path = str(logs_directory / "test_bulk_run.log")
+        bulk_run_flow_logs_folder = str(logs_directory / "test_bulk_run_flow_logs_folder")
+        Path(bulk_run_flow_logs_folder).mkdir()
+        with LogContext(bulk_run_log_path, run_mode=RunMode.Batch, flow_logs_folder=bulk_run_flow_logs_folder):
+            submit_batch_run(
+                flow_folder,
+                inputs_mapping={"text": "${data.text}"},
+                connections=dev_connections,
+                input_file_name="inputs.jsonl",
+            )
+            nlines = len(get_bulk_inputs_from_jsonl(flow_folder))
+            for i in range(nlines):
+                flow_log_file = Path(bulk_run_flow_logs_folder) / f"{i}.log"
+                assert flow_log_file.is_file()
+                log_content = load_content(flow_log_file)
+                # Assert flow log file contains expected logs
+                assert "execution          WARNING" in log_content
+                assert "execution.flow     INFO" in log_content
+                assert f"in line {i} (index starts from 0)" in log_content
 
     def test_activate_config_log(self):
         logs_directory = Path(mkdtemp())


### PR DESCRIPTION
Open another PR
There is one can't resolve conversation in original PR
https://github.com/microsoft/promptflow/pull/2323
![image](https://github.com/microsoft/promptflow/assets/17527303/3982ec63-90cb-479f-abcf-244fc82d23db)


# Description
Add separate log for each line in batch run. Which could improve user experience for debugging failed lines.
In future, it could also be useful to check eager flow's customer print content.

Local batch run flow logs folder example:
![image](https://github.com/microsoft/promptflow/assets/17527303/239d5b08-457d-49a2-b0d1-2d7c94c0b8ce)
Use fixed length file name to keep right order, then it could be easier to check.

Implementation:
There are 3 loggers in executor ("execution"\"execution.flow"\"execution.bulk")
They all have handler list to write log.
Such as `FileHandlerConcurrentWrapper` and `StreamHandler`.
`FileHandlerConcurrentWrapper` is wrapper for `FileHandler`.
Before this PR, we use `FileHandlerConcurrentWrapper` to write bulk run's log content to same file.
In this PR, we create a new `FileHandlerConcurrentWrapper` for "execution" and "execution.flow", to write their log content to different file according to line number.

So, for each line execution, we should set log context after getting `line_number` info. This part of logic is implemented by changing invocation of `log_context_initialization_func`

This pull request introduces changes to the logging mechanism in the PromptFlow SDK, specifically for batch runs. The changes allow for line-specific logging in batch runs, with each line's log stored in a separate file in a specified folder. The `LocalStorageFilenames` class and `LoggerOperations` class have been modified to accommodate the new `line_log_folder` attribute. A new class, `LineFileHandlerConcurrentWrapper`, has been introduced to ensure thread safety when writing to different log files in different contexts. The `get_logger` function now adds an instance of this new class to the logger. The `LogContext` class has been extended with `line_log_folder` and `line_number` attributes. The `_set_log_path` method in `LogContext` has been modified to set the path for the line log file if the run mode is `Batch`. Finally, the `_exec_line_for_queue` function in the `LineExecutionProcessPool` class has been updated to set the logger context for each line execution.




Main changes:

Updates to logging:

* [`src/promptflow/promptflow/_sdk/_constants.py`](diffhunk://#diff-9ffef684cefef289f51e58b0aff1cd6cfa42363ace309d07f36dfe6559c5b84dR287): Added `LINE_LOG_FOLDER` to `LocalStorageFilenames` class.
* [`src/promptflow/promptflow/_sdk/operations/_local_storage_operations.py`](diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719R91-R100): Added `line_log_folder` attribute to `get_initializer` method and `LoggerOperations` class. [[1]](diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719R91-R100) [[2]](diffhunk://#diff-1a5c2463c2ef997c5203a6b2e77b247d812961b7a6df5f0f45c02579b6656719L199-R205)
* [`src/promptflow/promptflow/_utils/logger_utils.py`](diffhunk://#diff-4cf50231dfaf296f999ac6c39e74c09399635d8aed56e609d5fdee0e63574b87R171-R182): Introduced `LineFileHandlerConcurrentWrapper` class for thread safety, added it to the `get_logger` function, and added `line_log_folder` and `line_number` attributes to `LogContext` class. Modified `_set_log_path` method to set the path for line log file in batch mode. [[1]](diffhunk://#diff-4cf50231dfaf296f999ac6c39e74c09399635d8aed56e609d5fdee0e63574b87R171-R182) [[2]](diffhunk://#diff-4cf50231dfaf296f999ac6c39e74c09399635d8aed56e609d5fdee0e63574b87R199) [[3]](diffhunk://#diff-4cf50231dfaf296f999ac6c39e74c09399635d8aed56e609d5fdee0e63574b87R233-R242) [[4]](diffhunk://#diff-4cf50231dfaf296f999ac6c39e74c09399635d8aed56e609d5fdee0e63574b87R294-R304) [[5]](diffhunk://#diff-4cf50231dfaf296f999ac6c39e74c09399635d8aed56e609d5fdee0e63574b87R336-R340)
* [`src/promptflow/promptflow/executor/_line_execution_process_pool.py`](diffhunk://#diff-c14422c33faa9e44145738152120929455da4e4f05d4fc7b59158423fa609bc1L636-R636): Updated `_exec_line_for_queue` function to set logger context for each line execution. [[1]](diffhunk://#diff-c14422c33faa9e44145738152120929455da4e4f05d4fc7b59158423fa609bc1L636-R636) [[2]](diffhunk://#diff-c14422c33faa9e44145738152120929455da4e4f05d4fc7b59158423fa609bc1R680-R692)

Minor changes:

* [`src/promptflow/promptflow/executor/_line_execution_process_pool.py`](diffhunk://#diff-c14422c33faa9e44145738152120929455da4e4f05d4fc7b59158423fa609bc1L19-R19): Imported `Callable` from `typing`.



# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
