### PR TITLE
Write collection container for portal trace

### DIFF
--- a/src/promptflow/promptflow/_constants.py
+++ b/src/promptflow/promptflow/_constants.py
@@ -103,6 +103,7 @@ OK_LINE_RUN_STATUS = "Ok"
 class TraceEnvironmentVariableName:
     EXPERIMENT = "PF_TRACE_EXPERIMENT"
     SESSION_ID = "PF_TRACE_SESSION_ID"
+    COLLECTION_ID = "PF_TRACE_COLLECTION_ID"
     SUBSCRIPTION_ID = "PF_TRACE_SUBSCRIPTION_ID"
     RESOURCE_GROUP_NAME = "PF_TRACE_RESOURCE_GROUP_NAME"
     WORKSPACE_NAME = "PF_TRACE_WORKSPACE_NAME"
@@ -111,6 +112,7 @@ class TraceEnvironmentVariableName:
 class CosmosDBContainerName:
     SPAN = "Span"
     LINE_SUMMARY = "LineSummary"
+    COLLECTION = "Collection"
 
 
 class SpanFieldName:
@@ -165,6 +167,7 @@ class SpanAttributeFieldName:
 class SpanResourceAttributesFieldName:
     SERVICE_NAME = "service.name"
     SESSION_ID = "session.id"
+    COLLECTION_ID = "collection.id"
     EXPERIMENT_NAME = "experiment.name"
     # local to cloud
     SUBSCRIPTION_ID = "subscription.id"

--- a/src/promptflow/promptflow/_internal/__init__.py
+++ b/src/promptflow/promptflow/_internal/__init__.py
@@ -40,7 +40,7 @@ from promptflow._core.tools_manager import (
     register_connections,
     retrieve_tool_func_result,
 )
-from promptflow._sdk._constants import LOCAL_MGMT_DB_PATH
+from promptflow._sdk._constants import LOCAL_MGMT_DB_PATH, CreatedByFieldName
 from promptflow._sdk._service.apis.collector import trace_collector
 from promptflow._sdk._utils import (
     get_used_connection_names_from_environment_variables,

--- a/src/promptflow/promptflow/_sdk/_constants.py
+++ b/src/promptflow/promptflow/_sdk/_constants.py
@@ -459,6 +459,12 @@ class LineRunFieldName:
     EVALUATIONS = "evaluations"
 
 
+class CreatedByFieldName:
+    OBJECT_ID = "object_id"
+    TENANT_ID = "tenant_id"
+    NAME = "name"
+
+
 class ChatGroupSpeakOrder(str, Enum):
     SEQUENTIAL = "sequential"
     LLM = "llm"

--- a/src/promptflow/promptflow/_sdk/_service/apis/collector.py
+++ b/src/promptflow/promptflow/_sdk/_service/apis/collector.py
@@ -77,12 +77,14 @@ def trace_collector(
 
         if cloud_trace_only:
             # If we only trace to cloud, we should make sure the data writing is success before return.
-            _try_write_trace_to_cosmosdb(all_spans, get_created_by_info_with_cache, logger, credential)
+            _try_write_trace_to_cosmosdb(
+                all_spans, get_created_by_info_with_cache, logger, credential, is_cloud_trace=True
+            )
         else:
             # Create a new thread to write trace to cosmosdb to avoid blocking the main thread
             ThreadWithContextVars(
                 target=_try_write_trace_to_cosmosdb,
-                args=(all_spans, get_created_by_info_with_cache, logger, credential),
+                args=(all_spans, get_created_by_info_with_cache, logger, credential, False),
             ).start()
         return "Traces received", 200
 
@@ -92,12 +94,17 @@ def trace_collector(
 
 
 def _try_write_trace_to_cosmosdb(
-    all_spans, get_created_by_info_with_cache: Callable, logger: logging.Logger, credential: Optional[object] = None
+    all_spans,
+    get_created_by_info_with_cache: Callable,
+    logger: logging.Logger,
+    credential: Optional[object] = None,
+    is_cloud_trace: bool = False,
 ):
     if not all_spans:
         return
     try:
-        span_resource = all_spans[0]._content.get(SpanFieldName.RESOURCE, {})
+        first_span = all_spans[0]
+        span_resource = first_span._content.get(SpanFieldName.RESOURCE, {})
         resource_attributes = span_resource.get(SpanResourceFieldName.ATTRIBUTES, {})
         subscription_id = resource_attributes.get(SpanResourceAttributesFieldName.SUBSCRIPTION_ID, None)
         resource_group_name = resource_attributes.get(SpanResourceAttributesFieldName.RESOURCE_GROUP_NAME, None)
@@ -109,16 +116,23 @@ def _try_write_trace_to_cosmosdb(
         logger.info(f"Start writing trace to cosmosdb, total spans count: {len(all_spans)}.")
         start_time = datetime.now()
         from promptflow.azure._storage.cosmosdb.client import get_client
+        from promptflow.azure._storage.cosmosdb.collection import CollectionCosmosDB
         from promptflow.azure._storage.cosmosdb.span import Span as SpanCosmosDB
         from promptflow.azure._storage.cosmosdb.summary import Summary
 
         # Load span and summary clients first time may slow.
-        # So, we load 2 client in parallel for warm up.
+        # So, we load clients in parallel for warm up.
         span_client_thread = ThreadWithContextVars(
             target=get_client,
             args=(CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name, credential),
         )
         span_client_thread.start()
+
+        collection_client_thread = ThreadWithContextVars(
+            target=get_client,
+            args=(CosmosDBContainerName.COLLECTION, subscription_id, resource_group_name, workspace_name, credential),
+        )
+        collection_client_thread.start()
 
         # Load created_by info first time may slow. So, we load it in parallel for warm up.
         created_by_thread = ThreadWithContextVars(target=get_created_by_info_with_cache)
@@ -128,13 +142,26 @@ def _try_write_trace_to_cosmosdb(
 
         span_client_thread.join()
         created_by_thread.join()
+        collection_client_thread.join()
 
         created_by = get_created_by_info_with_cache()
+
+        collection_client = get_client(
+            CosmosDBContainerName.COLLECTION, subscription_id, resource_group_name, workspace_name, credential
+        )
+
+        collection_db = CollectionCosmosDB(first_span, is_cloud_trace, created_by)
+        collection_db.create_collection_if_not_exist(collection_client)
+        collection_id = collection_db.collection_id
 
         for span in all_spans:
             span_client = get_client(
                 CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name, credential
             )
+            if not is_cloud_trace:
+                # Update collection id in Span for local trace.
+                resource_attributes = span._content[SpanFieldName.RESOURCE][SpanResourceFieldName.ATTRIBUTES]
+                resource_attributes[SpanResourceAttributesFieldName.COLLECTION_ID] = collection_id
             result = SpanCosmosDB(span, created_by).persist(span_client)
             # None means the span already exists, then we don't need to persist the summary also.
             if result is not None:
@@ -145,7 +172,8 @@ def _try_write_trace_to_cosmosdb(
                     workspace_name,
                     credential,
                 )
-                Summary(span, created_by, logger).persist(line_summary_client)
+                Summary(span, collection_id, created_by, logger).persist(line_summary_client)
+        collection_db.update_collection_updated_at_info(collection_client)
         logger.info(
             (
                 f"Finish writing trace to cosmosdb, total spans count: {len(all_spans)}."

--- a/src/promptflow/promptflow/_sdk/_service/apis/collector.py
+++ b/src/promptflow/promptflow/_sdk/_service/apis/collector.py
@@ -158,11 +158,7 @@ def _try_write_trace_to_cosmosdb(
             span_client = get_client(
                 CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name, credential
             )
-            if not is_cloud_trace:
-                # Update collection id in Span for local trace.
-                resource_attributes = span._content[SpanFieldName.RESOURCE][SpanResourceFieldName.ATTRIBUTES]
-                resource_attributes[SpanResourceAttributesFieldName.COLLECTION_ID] = collection_id
-            result = SpanCosmosDB(span, created_by).persist(span_client)
+            result = SpanCosmosDB(span, collection_id, created_by).persist(span_client)
             # None means the span already exists, then we don't need to persist the summary also.
             if result is not None:
                 line_summary_client = get_client(

--- a/src/promptflow/promptflow/_sdk/_tracing.py
+++ b/src/promptflow/promptflow/_sdk/_tracing.py
@@ -203,7 +203,7 @@ def setup_exporter_to_pfs() -> None:
     # get resource attributes from environment
     # TODO: Rename session_id, local trace should hide id and name.
     # For local trace, collection is the only identifier for name and id
-    # For cloud trace, we use collection is name and collection_id for id
+    # For cloud trace, we use collection as name and collection_id for id
     session_id = os.getenv(TraceEnvironmentVariableName.SESSION_ID, None)
     # Only used for runtime
     collection_id = os.getenv(TraceEnvironmentVariableName.COLLECTION_ID, None)

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/collection.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/collection.py
@@ -1,0 +1,82 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict
+
+from azure.cosmos import ContainerProxy
+
+from promptflow._constants import SpanAttributeFieldName, SpanFieldName, SpanResourceAttributesFieldName
+from promptflow._sdk._constants import CreatedByFieldName
+from promptflow._sdk.entities._trace import Span
+from promptflow.azure._storage.cosmosdb.cosmosdb_utils import safe_create_cosmosdb_item
+
+
+@dataclass
+class Collection:
+    id: str  # Collection id for cosmosDB query, usually hide from customer
+    partition_key: str
+    name: str  # Display name for customer facing UI
+    created_at: int
+    updated_at: int
+    created_by: Dict[str, Any]
+    location: int
+
+
+class LocationType(int, Enum):
+    LOCAL = 0
+    CLOUD = 1
+
+
+def generate_collection_id_by_name_and_created_by(name: str, created_by: Dict[str, Any]) -> str:
+    return f"{name}_{created_by[CreatedByFieldName.OBJECT_ID]}"
+
+
+class CollectionCosmosDB:
+    def __init__(self, span: Span, is_cloud_trace: bool, created_by: Dict[str, Any]):
+        self.span = span
+        self.created_by = created_by
+        self.collection_name = span.session_id
+        self.location = LocationType.CLOUD if is_cloud_trace else LocationType.LOCAL
+        resource_attributes = span._content.get(SpanFieldName.RESOURCE, None)
+        self.collection_id = (
+            resource_attributes[SpanResourceAttributesFieldName.COLLECTION_ID]
+            if is_cloud_trace
+            else generate_collection_id_by_name_and_created_by(self.collection_name, created_by)
+        )
+
+    def create_collection_if_not_exist(self, client: ContainerProxy):
+        span_attributes = self.span._content[SpanFieldName.ATTRIBUTES]
+        # For batch run, ignore collection operation
+        if SpanAttributeFieldName.BATCH_RUN_ID in span_attributes:
+            return
+
+        item = Collection(
+            id=self.collection_id,
+            partition_key=self.collection_id,
+            name=self.collection_name,
+            created_at=int(time.time()),
+            updated_at=int(time.time()),
+            created_by=self.created_by,
+            location=self.location,
+        )
+        safe_create_cosmosdb_item(client, item)
+        # Update name if customer change flow display name
+        patch_operations = [{"op": "replace", "path": "/name", "value": self.collection_name}]
+        return client.patch_item(
+            item=self.collection_id, partition_key=self.collection_id, patch_operations=patch_operations
+        )
+
+    def update_collection_updated_at_info(self, client: ContainerProxy):
+        span_attributes = self.span._content[SpanFieldName.ATTRIBUTES]
+        # For batch run, ignore collection operation
+        if SpanAttributeFieldName.BATCH_RUN_ID in span_attributes:
+            return
+
+        patch_operations = [{"op": "replace", "path": "/updated_at", "value": int(time.time())}]
+        return client.patch_item(
+            item=self.collection_id, partition_key=self.collection_id, patch_operations=patch_operations
+        )

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/cosmosdb_utils.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/cosmosdb_utils.py
@@ -9,7 +9,7 @@ def safe_create_cosmosdb_item(client: ContainerProxy, dataclass_item):
         # Attempt to read the item using its ID and partition key
         client.read_item(item=dataclass_item.id, partition_key=dataclass_item.partition_key)
     except CosmosResourceNotFoundError:
-        # Only create when for not exist situation.
+        # Only create for not exist situation.
         try:
             client.create_item(body=asdict(dataclass_item))
         except CosmosResourceExistsError:

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/cosmosdb_utils.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/cosmosdb_utils.py
@@ -1,0 +1,17 @@
+from dataclasses import asdict
+
+from azure.cosmos import ContainerProxy
+from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosResourceNotFoundError
+
+
+def safe_create_cosmosdb_item(client: ContainerProxy, dataclass_item):
+    try:
+        # Attempt to read the item using its ID and partition key
+        client.read_item(item=dataclass_item.id, partition_key=dataclass_item.partition_key)
+    except CosmosResourceNotFoundError:
+        # Only create when for not exist situation.
+        try:
+            client.create_item(body=asdict(dataclass_item))
+        except CosmosResourceExistsError:
+            # Ignore conflict error.
+            return

--- a/src/promptflow/promptflow/azure/_storage/cosmosdb/span.py
+++ b/src/promptflow/promptflow/azure/_storage/cosmosdb/span.py
@@ -23,9 +23,10 @@ class Span:
     resource: dict = None
     id: str = None
     partition_key: str = None
+    collection_id: str = None
     created_by: dict = None
 
-    def __init__(self, span: SpanEntity, created_by: dict) -> None:
+    def __init__(self, span: SpanEntity, collection_id: str, created_by: dict) -> None:
         self.name = span.name
         self.context = span._content[SpanFieldName.CONTEXT]
         self.kind = span._content[SpanFieldName.KIND]
@@ -38,6 +39,7 @@ class Span:
         self.links = span._content[SpanFieldName.LINKS]
         self.resource = span._content[SpanFieldName.RESOURCE]
         self.partition_key = span.session_id
+        self.collection_id = collection_id
         self.id = span.span_id
         self.created_by = created_by
 

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_collection.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_collection.py
@@ -40,7 +40,15 @@ class TestCollectionCosmosDB:
             self.collection.create_collection_if_not_exist(client)
             mock_safe_write.assert_called_once()
 
-    def test_create_collection_if_not_exist_batch_run(self):
+    def test_update_collection_updated_at(self):
+        client = mock.Mock()
+        self.span._content = {"attributes": {}, "resource": {"collection.id": "test_collection_id"}}
+
+        self.collection.update_collection_updated_at_info(client)
+
+        client.patch_item.assert_called_once()
+
+    def test_batch_run_operation(self):
         client = mock.Mock()
         self.span._content = {
             "attributes": {"batch_run_id": "test_batch_run_id"},
@@ -50,21 +58,6 @@ class TestCollectionCosmosDB:
         with mock.patch("promptflow.azure._storage.cosmosdb.summary.safe_create_cosmosdb_item") as mock_safe_write:
             self.collection.create_collection_if_not_exist(client)
             mock_safe_write.assert_not_called()
-
-    def test_update_collection_updated_at(self):
-        client = mock.Mock()
-        self.span._content = {"attributes": {}, "resource": {"collection.id": "test_collection_id"}}
-
-        self.collection.update_collection_updated_at_info(client)
-
-        client.patch_item.assert_called_once()
-
-    def test_batch_run_update_collection_updated_at(self):
-        client = mock.Mock()
-        self.span._content = {
-            "attributes": {"batch_run_id": "test_batch_run_id"},
-            "resource": {"collection.id": "test_collection_id"},
-        }
 
         self.collection.create_collection_if_not_exist(client)
         client.patch_item.assert_not_called()

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_collection.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_collection.py
@@ -1,0 +1,70 @@
+from unittest import mock
+
+import pytest
+
+from promptflow._sdk._constants import CreatedByFieldName
+from promptflow.azure._storage.cosmosdb.collection import CollectionCosmosDB
+
+
+@pytest.mark.unittest
+class TestCollectionCosmosDB:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.span = mock.Mock()
+        self.span.session_id = "test_collection_name"
+        self.span._content = {
+            "attributes": {},
+            "resource": {
+                "collection.id": "test_collection_id",
+            },
+        }
+        self.created_by = {CreatedByFieldName.OBJECT_ID: "test_user_id"}
+        self.collection = CollectionCosmosDB(self.span, True, self.created_by)
+
+    def test_collection_properties_cloud(self):
+        collection = CollectionCosmosDB(self.span, True, self.created_by)
+        assert collection.collection_name == "test_collection_name"
+        assert collection.collection_id == "test_collection_id"
+        assert collection.location == 1
+
+    def test_collection_properties_local(self):
+        collection = CollectionCosmosDB(self.span, False, self.created_by)
+        assert collection.collection_name == "test_collection_name"
+        # For local, use collection name and user id to generate collection id
+        assert collection.collection_id == "test_collection_name_test_user_id"
+        assert collection.location == 0
+
+    def test_create_collection_if_not_exist(self):
+        client = mock.Mock()
+        with mock.patch("promptflow.azure._storage.cosmosdb.collection.safe_create_cosmosdb_item") as mock_safe_write:
+            self.collection.create_collection_if_not_exist(client)
+            mock_safe_write.assert_called_once()
+
+    def test_create_collection_if_not_exist_batch_run(self):
+        client = mock.Mock()
+        self.span._content = {
+            "attributes": {"batch_run_id": "test_batch_run_id"},
+            "resource": {"collection.id": "test_collection_id"},
+        }
+
+        with mock.patch("promptflow.azure._storage.cosmosdb.summary.safe_create_cosmosdb_item") as mock_safe_write:
+            self.collection.create_collection_if_not_exist(client)
+            mock_safe_write.assert_not_called()
+
+    def test_update_collection_updated_at(self):
+        client = mock.Mock()
+        self.span._content = {"attributes": {}, "resource": {"collection.id": "test_collection_id"}}
+
+        self.collection.update_collection_updated_at_info(client)
+
+        client.patch_item.assert_called_once()
+
+    def test_batch_run_update_collection_updated_at(self):
+        client = mock.Mock()
+        self.span._content = {
+            "attributes": {"batch_run_id": "test_batch_run_id"},
+            "resource": {"collection.id": "test_collection_id"},
+        }
+
+        self.collection.create_collection_if_not_exist(client)
+        client.patch_item.assert_not_called()

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_cosmosdb_utils.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_cosmosdb_utils.py
@@ -1,0 +1,48 @@
+from dataclasses import dataclass
+from unittest import mock
+
+import pytest
+from azure.cosmos.exceptions import CosmosResourceExistsError, CosmosResourceNotFoundError
+
+from promptflow.azure._storage.cosmosdb.cosmosdb_utils import safe_create_cosmosdb_item
+
+
+@dataclass
+class Item:
+    id: str
+    partition_key: str
+
+
+@pytest.mark.unittest
+class TestCosmosDBUtils:
+    @pytest.fixture(autouse=True)
+    def setUp(self):
+        self.item = Item(id="id", partition_key="partition_key")
+
+    def test_safe_write_to_cosmosdb_normal(self):
+        client = mock.Mock()
+        client.read_item.side_effect = CosmosResourceNotFoundError
+
+        safe_create_cosmosdb_item(client, self.item)
+
+        client.read_item.assert_called_once_with(item=self.item.id, partition_key=self.item.partition_key)
+        client.create_item.assert_called_once()
+
+    def test_safe_write_to_cosmosdb_conflict(self):
+        client = mock.Mock()
+        client.read_item.side_effect = CosmosResourceNotFoundError
+        client.create_item.side_effect = CosmosResourceExistsError
+
+        safe_create_cosmosdb_item(client, self.item)
+
+        client.read_item.assert_called_once_with(item=self.item.id, partition_key=self.item.partition_key)
+        client.create_item.assert_called_once()
+
+    def test_safe_write_to_cosmosdb_already_exist(self):
+        client = mock.Mock()
+        client.read_item.return_value = self.item
+
+        safe_create_cosmosdb_item(client, self.item)
+
+        client.read_item.assert_called_once_with(item=self.item.id, partition_key=self.item.partition_key)
+        client.create_item.assert_not_called()

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
@@ -7,6 +7,7 @@ from promptflow.azure._storage.cosmosdb.span import Span
 @pytest.mark.unittest
 class TestSpan:
     FAKE_CREATED_BY = {"oid": "fake_oid"}
+    FAKE_COLLECTION_ID = "fake_collection_id"
 
     def test_to_dict(self):
         span = Span(
@@ -28,6 +29,7 @@ class TestSpan:
                 span_type=None,
                 session_id=None,
             ),
+            collection_id=self.FAKE_COLLECTION_ID,
             created_by=self.FAKE_CREATED_BY,
         )
         assert span.to_dict() == {
@@ -41,6 +43,7 @@ class TestSpan:
                 "span_id": "0x9ded7ce65d5f7775",
             },
             "id": "0x9ded7ce65d5f7775",
+            "collection_id": "fake_collection_id",
             "created_by": {"oid": "fake_oid"},
         }
 
@@ -63,6 +66,7 @@ class TestSpan:
                 span_type=None,
                 session_id="test_session_id",
             ),
+            collection_id=self.FAKE_COLLECTION_ID,
             created_by=self.FAKE_CREATED_BY,
         )
         assert span.to_dict() == {
@@ -79,5 +83,6 @@ class TestSpan:
             },
             "id": "0x9ded7ce65d5f7775",
             "partition_key": "test_session_id",
+            "collection_id": "fake_collection_id",
             "created_by": {"oid": "fake_oid"},
         }


### PR DESCRIPTION
# Description

We need a new concept (Collection/trace group) to save non-batch run's traces.
For batch run, UX could use info provided by RH to aggregate.
For non-batch run, we create a collection table to record info such as `created_by` and `updated_at`.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
