### PR TITLE
[Internal] Support Union connections for register_apis

### DIFF
--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -10,7 +10,7 @@ import traceback
 import types
 from functools import partial
 from pathlib import Path
-from typing import Callable, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Callable, Dict, List, Mapping, Optional, Tuple, Union, get_origin, get_args
 
 from promptflow._core._errors import (
     InputTypeMismatch,
@@ -459,6 +459,17 @@ connections = {}
 connection_type_to_api_mapping = {}
 
 
+def get_all_supported_types(param_annotation) -> list:
+    origin = get_origin(param_annotation)
+    if origin != Union:
+        types.append(param_annotation.__name__)
+    else:
+        for arg in get_args(param_annotation):
+            types.append(arg.__name__)
+
+    return types
+
+
 def _register(provider_cls, collection, type):
     from promptflow._core.tool import ToolProvider
 
@@ -474,14 +485,17 @@ def _register(provider_cls, collection, type):
             module_logger.debug(f"Registered {name} as a builtin function")
     # Get the connection type - provider name mapping for execution use
     # Tools/Providers related connection must have been imported
+    api_name = provider_cls.__name__
     for param in initialize_inputs.values():
         if not param.annotation:
             continue
-        annotation_type_name = param.annotation.__name__
-        if annotation_type_name in connections:
-            api_name = provider_cls.__name__
-            module_logger.debug(f"Add connection type {annotation_type_name} to api {api_name} mapping")
-            connection_type_to_api_mapping[annotation_type_name] = api_name
+        types = get_all_supported_types(param.annotation)
+        for type in types:
+            if type in connections:
+                module_logger.debug(f"Add connection type {type} to api {api_name} mapping")
+                connection_type_to_api_mapping[type] = api_name
+                should_break = True
+        if should_break:
             break
 
 

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -460,6 +460,7 @@ connection_type_to_api_mapping = {}
 
 
 def get_all_supported_types(param_annotation) -> list:
+    types = []
     origin = get_origin(param_annotation)
     if origin != Union:
         types.append(param_annotation.__name__)

--- a/src/promptflow/promptflow/_core/tools_manager.py
+++ b/src/promptflow/promptflow/_core/tools_manager.py
@@ -487,6 +487,7 @@ def _register(provider_cls, collection, type):
     # Get the connection type - provider name mapping for execution use
     # Tools/Providers related connection must have been imported
     api_name = provider_cls.__name__
+    should_break = False
     for param in initialize_inputs.values():
         if not param.annotation:
             continue

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -384,7 +384,7 @@ class TestToolsManager:
         from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
 
         class MockAI1(ToolProvider):
-            def __init__(self, connection: Union[OpenAIConnection, ServerlessConnection]):
+            def __init__(self, input: str, connection: Union[OpenAIConnection, ServerlessConnection]):
                 super().__init__()
 
         class MockAI2(ToolProvider):

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -381,17 +381,20 @@ class TestToolsManager:
             from typing import Union
             from promptflow._core.tools_manager import register_apis, connection_type_to_api_mapping
             from promptflow._core.tool import ToolProvider
-            from promptflow.connections import OpenAIConnection, ServerlessConnection
+            from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
 
-            class MockAI(ToolProvider):
+            class MockAI1(ToolProvider):
                 def __init__(self, connection: Union[OpenAIConnection, ServerlessConnection]):
                     super().__init__()
 
-            register_apis(MockAI)
+            class MockAI2(ToolProvider):
+                def __init__(self, connection: AzureOpenAIConnection):
+                    super().__init__()
 
-            assert len(connection_type_to_api_mapping) == 2
-            assert "OpenAIConnection" in connection_type_to_api_mapping, "OpenAIConnection is not in connection_type_to_api_mapping"
-            assert "ServerlessConnection" in connection_type_to_api_mapping, "ServerlessConnection is not in connection_type_to_api_mapping"
+            register_apis(MockAI1)
+            register_apis(MockAI2)
+
+            assert len(connection_type_to_api_mapping) == 3
 
 
 @pytest.mark.unittest

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -377,6 +377,22 @@ class TestToolsManager:
             _retrieve_tool_func_result(func_call_scenario, {"func_path": func_path, "func_kwargs": func_kwargs})
         assert expected in str(e.value)
 
+    def test_register_apis(self):
+            from typing import Union
+            from promptflow._core.tools_manager import register_apis, connection_type_to_api_mapping
+            from promptflow._core.tool import ToolProvider
+            from promptflow.connections import OpenAIConnection, ServerlessConnection
+
+            class MockAI(ToolProvider):
+                def __init__(self, connection: Union[OpenAIConnection, ServerlessConnection]):
+                    super().__init__()
+
+            register_apis(MockAI)
+
+            assert len(connection_type_to_api_mapping) == 2
+            assert "OpenAIConnection" in connection_type_to_api_mapping, "OpenAIConnection is not in connection_type_to_api_mapping"
+            assert "ServerlessConnection" in connection_type_to_api_mapping, "ServerlessConnection is not in connection_type_to_api_mapping"
+
 
 @pytest.mark.unittest
 class TestBuiltinsManager:

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -378,23 +378,23 @@ class TestToolsManager:
         assert expected in str(e.value)
 
     def test_register_apis(self):
-            from typing import Union
-            from promptflow._core.tools_manager import register_apis, connection_type_to_api_mapping
-            from promptflow._core.tool import ToolProvider
-            from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
+        from typing import Union
+        from promptflow._core.tools_manager import register_apis, connection_type_to_api_mapping
+        from promptflow._core.tool import ToolProvider
+        from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
 
-            class MockAI1(ToolProvider):
-                def __init__(self, connection: Union[OpenAIConnection, ServerlessConnection]):
-                    super().__init__()
+        class MockAI1(ToolProvider):
+            def __init__(self, connection: Union[OpenAIConnection, ServerlessConnection]):
+                super().__init__()
 
-            class MockAI2(ToolProvider):
-                def __init__(self, connection: AzureOpenAIConnection):
-                    super().__init__()
+        class MockAI2(ToolProvider):
+            def __init__(self, connection: AzureOpenAIConnection):
+                super().__init__()
 
-            register_apis(MockAI1)
-            register_apis(MockAI2)
+        register_apis(MockAI1)
+        register_apis(MockAI2)
 
-            assert len(connection_type_to_api_mapping) == 3
+        assert len(connection_type_to_api_mapping) == 3
 
 
 @pytest.mark.unittest


### PR DESCRIPTION
Issue, currently the register_apis only support below api which only have one connection type:
![image](https://github.com/microsoft/promptflow/assets/49388944/73121d92-affd-476e-ad68-94d692ee26d6)

But we have a requirement to change the connection to Union to include ServerlessConnection like below:
![image](https://github.com/microsoft/promptflow/assets/49388944/bff6e966-6ceb-49a0-ac7b-5083a63ab050)

So here make change to let the register_apis support Union connections.

Add UT for it.