### PR TITLE
Redirect print content to log for flex.

### DIFF
--- a/src/promptflow-core/promptflow/executor/_script_executor.py
+++ b/src/promptflow-core/promptflow/executor/_script_executor.py
@@ -62,8 +62,9 @@ class ScriptExecutor(FlowExecutor):
         **kwargs,
     ) -> LineResult:
         run_id = run_id or str(uuid.uuid4())
+        # TODO: refactor NodeLogManager, for script executor, we don't have node concept.
         log_manager = NodeLogManager()
-        # Not need to clear node context, since log_manger will be cleared after the with block.
+        # No need to clear node context, log_manger will be cleared after the with block.
         log_manager.set_node_context(run_id, "Flex", index)
         with log_manager:
             with self._update_operation_context(run_id, index):

--- a/src/promptflow-core/promptflow/executor/_script_executor.py
+++ b/src/promptflow-core/promptflow/executor/_script_executor.py
@@ -9,6 +9,7 @@ from types import GeneratorType
 from typing import Any, Callable, Dict, Mapping, Optional
 
 from promptflow._constants import LINE_NUMBER_KEY, MessageFormatType
+from promptflow._core.log_manager import NodeLogManager
 from promptflow._core.run_tracker import RunTracker
 from promptflow._core.tool_meta_generator import PythonLoadError
 from promptflow._utils.dataclass_serializer import convert_eager_flow_output_to_dict
@@ -61,8 +62,12 @@ class ScriptExecutor(FlowExecutor):
         **kwargs,
     ) -> LineResult:
         run_id = run_id or str(uuid.uuid4())
-        with self._update_operation_context(run_id, index):
-            return self._exec_line(inputs, index, run_id, allow_generator_output=allow_generator_output)
+        log_manager = NodeLogManager()
+        # Not need to clear node context, since log_manger will be cleared after the with block.
+        log_manager.set_node_context(run_id, "Flex", index)
+        with log_manager:
+            with self._update_operation_context(run_id, index):
+                return self._exec_line(inputs, index, run_id, allow_generator_output=allow_generator_output)
 
     def _exec_line(
         self,

--- a/src/promptflow-core/promptflow/executor/_script_executor.py
+++ b/src/promptflow-core/promptflow/executor/_script_executor.py
@@ -66,9 +66,8 @@ class ScriptExecutor(FlowExecutor):
         log_manager = NodeLogManager()
         # No need to clear node context, log_manger will be cleared after the with block.
         log_manager.set_node_context(run_id, "Flex", index)
-        with log_manager:
-            with self._update_operation_context(run_id, index):
-                return self._exec_line(inputs, index, run_id, allow_generator_output=allow_generator_output)
+        with log_manager, self._update_operation_context(run_id, index):
+            return self._exec_line(inputs, index, run_id, allow_generator_output=allow_generator_output)
 
     def _exec_line(
         self,

--- a/src/promptflow/tests/executor/e2etests/test_logs.py
+++ b/src/promptflow/tests/executor/e2etests/test_logs.py
@@ -113,16 +113,17 @@ class TestExecutorLogs:
             assert 40 <= line_count <= 50
 
     @pytest.mark.parametrize(
-        "root,folder_name, line_number", [[FLOW_ROOT, "print_input_flow", 8], [EAGER_FLOW_ROOT, "print_input_flex", 2]]
+        "flow_root_dir, flow_folder_name, line_number",
+        [[FLOW_ROOT, "print_input_flow", 8], [EAGER_FLOW_ROOT, "print_input_flex", 2]],
     )
-    def test_batch_run_flow_logs(self, root, folder_name, line_number):
+    def test_batch_run_flow_logs(self, flow_root_dir, flow_folder_name, line_number):
         logs_directory = Path(mkdtemp())
         bulk_run_log_path = str(logs_directory / "test_bulk_run.log")
         bulk_run_flow_logs_folder = str(logs_directory / "test_bulk_run_flow_logs_folder")
         Path(bulk_run_flow_logs_folder).mkdir()
         with LogContext(bulk_run_log_path, run_mode=RunMode.Batch, flow_logs_folder=bulk_run_flow_logs_folder):
-            self.submit_bulk_run(folder_name, root=root)
-            nlines = len(get_bulk_inputs_from_jsonl(folder_name, root=root))
+            self.submit_bulk_run(flow_folder_name, root=flow_root_dir)
+            nlines = len(get_bulk_inputs_from_jsonl(flow_folder_name, root=flow_root_dir))
             for i in range(nlines):
                 file_name = f"{str(i).zfill(LINE_NUMBER_WIDTH)}.log"
                 flow_log_file = Path(bulk_run_flow_logs_folder) / file_name

--- a/src/promptflow/tests/executor/utils.py
+++ b/src/promptflow/tests/executor/utils.py
@@ -108,6 +108,12 @@ def load_content(source: Union[str, Path]) -> str:
     return Path(source).read_text()
 
 
+def count_lines(filename):
+    with open(filename, "r") as f:
+        lines = f.readlines()
+    return len(lines)
+
+
 def is_jsonl_file(file_path: Path):
     return file_path.suffix.lower() == ".jsonl"
 

--- a/src/promptflow/tests/test_configs/eager_flows/print_input_flex/flow.dag.yaml
+++ b/src/promptflow/tests/test_configs/eager_flows/print_input_flex/flow.dag.yaml
@@ -1,0 +1,1 @@
+entry: print_input_flex:my_flow

--- a/src/promptflow/tests/test_configs/eager_flows/print_input_flex/inputs.jsonl
+++ b/src/promptflow/tests/test_configs/eager_flows/print_input_flex/inputs.jsonl
@@ -1,0 +1,10 @@
+{"text": "text_0"}
+{"text": "text_1"}
+{"text": "text_2"}
+{"text": "text_3"}
+{"text": "text_4"}
+{"text": "text_5"}
+{"text": "text_6"}
+{"text": "text_7"}
+{"text": "text_8"}
+{"text": "text_9"}

--- a/src/promptflow/tests/test_configs/eager_flows/print_input_flex/print_input_flex.py
+++ b/src/promptflow/tests/test_configs/eager_flows/print_input_flex/print_input_flex.py
@@ -1,0 +1,10 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+import sys
+
+def my_flow(text: str) -> str:
+    """Simple flow without yaml."""
+    print(f"Hello flex {text}")
+    print(f"Hello error {text}", file=sys.stderr)
+    return f"Hello world! {text}"


### PR DESCRIPTION
# Description

Use NodeLogManager to redirect customer print content for flex run.
Then customer could see print content in log file.
We will print the content to `flow_logger` or `logger`.
![image](https://github.com/microsoft/promptflow/assets/17527303/f787291b-ce09-4f3d-92a5-4c739b0ddf34)


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
