### PR TITLE
fix: avoid lazy shutdown for executor proxy in local pfs flow test

### DIFF
--- a/src/promptflow/promptflow/_sdk/entities/_flow/_flow_context_resolver.py
+++ b/src/promptflow/promptflow/_sdk/entities/_flow/_flow_context_resolver.py
@@ -125,20 +125,15 @@ class FlowContextResolver:
                 dump_yaml(self.flow_dag, fp)
             resolved_flow._path = flow_file.absolute().as_posix()
 
-            executable_flow = resolved_flow._init_executable()
             if is_async_call:
                 return AsyncFlowInvoker(
-                    flow=executable_flow,
+                    flow=resolved_flow,
                     connections=connections,
                     streaming=flow_context.streaming,
-                    flow_path=resolved_flow.path,
-                    working_dir=resolved_flow.code,
                 )
             else:
                 return FlowInvoker(
-                    flow=executable_flow,
+                    flow=resolved_flow,
                     connections=connections,
                     streaming=flow_context.streaming,
-                    flow_path=resolved_flow.path,
-                    working_dir=resolved_flow.code,
                 )

--- a/src/promptflow/promptflow/_sdk/entities/_flow/base.py
+++ b/src/promptflow/promptflow/_sdk/entities/_flow/base.py
@@ -1,7 +1,6 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-import abc
 import json
 from os import PathLike
 from pathlib import Path
@@ -11,6 +10,7 @@ from promptflow._constants import DEFAULT_ENCODING
 from promptflow._sdk.entities._validation import SchemaValidatableMixin
 from promptflow._utils.flow_utils import is_flex_flow, resolve_flow_path
 from promptflow._utils.yaml_utils import load_yaml_string
+from promptflow.core._flow import AbstractFlowBase
 from promptflow.exceptions import UserErrorException
 
 
@@ -80,18 +80,12 @@ class FlowContext:
         return hash(json.dumps(self._to_dict(), sort_keys=True))
 
 
-class FlowBase(abc.ABC, SchemaValidatableMixin):
+class FlowBase(AbstractFlowBase, SchemaValidatableMixin):
     def __init__(self, *, data: dict, code: Path, path: Path, **kwargs):
         self._context = FlowContext()
-        # flow.dag.yaml's content if provided
-        self._data = data
-        # working directory of the flow
-        self._code = Path(code).resolve()
-        # flow file path, can be script file or flow definition YAML file
-        self._path = Path(path).resolve()
+        AbstractFlowBase.__init__(self, data=data, code=code, path=path, **kwargs)
         # hash of flow's entry file, used to skip invoke if entry file is not changed
         self._content_hash = kwargs.pop("content_hash", None)
-        super().__init__(**kwargs)
 
     @property
     def context(self) -> FlowContext:

--- a/src/promptflow/promptflow/core/_flow.py
+++ b/src/promptflow/promptflow/core/_flow.py
@@ -7,15 +7,15 @@ from os import PathLike
 from pathlib import Path
 from typing import Any, Mapping, Union
 
-from promptflow._constants import DEFAULT_ENCODING, FlowLanguage, LANGUAGE_KEY
+from promptflow._constants import DEFAULT_ENCODING, LANGUAGE_KEY, FlowLanguage
 from promptflow._utils.flow_utils import is_flex_flow, resolve_flow_path
 from promptflow._utils.yaml_utils import load_yaml_string
-from promptflow.core._serving.flow_invoker import AsyncFlowInvoker, FlowInvoker
-from promptflow.core._utils import init_executable
 from promptflow.exceptions import UserErrorException
 
 
-class FlowBase(abc.ABC):
+class AbstractFlowBase(abc.ABC):
+    """Abstract class for all Flow entities in both core and devkit."""
+
     def __init__(self, *, data: dict, code: Path, path: Path, **kwargs):
         # yaml content if provided
         self._data = data
@@ -23,6 +23,11 @@ class FlowBase(abc.ABC):
         self._code = Path(code).resolve()
         # flow file path, can be script file or flow definition YAML file
         self._path = Path(path).resolve()
+
+
+class FlowBase(AbstractFlowBase):
+    def __init__(self, *, data: dict, code: Path, path: Path, **kwargs):
+        super().__init__(data=data, code=code, path=path, **kwargs)
 
     @property
     def code(self) -> Path:
@@ -59,12 +64,10 @@ class FlowBase(abc.ABC):
         if flow_language != FlowLanguage.Python:
             raise UserErrorException(
                 message_format="Only python flows are allowed to be loaded with "
-                               "promptflow-core but got a {language} flow",
-                language=flow_language
+                "promptflow-core but got a {language} flow",
+                language=flow_language,
             )
 
-        if is_flex_flow(yaml_dict=data, working_dir=flow_dir):
-            raise UserErrorException("Please call entry directly for flex flow.")
         return cls._create(code=flow_dir, path=flow_path, data=data)
 
     @classmethod
@@ -108,14 +111,16 @@ class Flow(FlowBase):
     def invoke(self, inputs: dict, connections: dict = None, **kwargs) -> "LineResult":
         """Invoke a flow and get a LineResult object."""
         # candidate parameters: connections, variant, overrides, streaming
+        from promptflow.core._serving.flow_invoker import FlowInvoker
+
+        if is_flex_flow(yaml_dict=self._data, working_dir=self.code):
+            raise UserErrorException("Please call entry directly for flex flow.")
 
         invoker = FlowInvoker(
-            flow=init_executable(flow_dag=self._data, working_dir=self.code),
+            flow=self,
             # TODO (3027983): resolve the connections before passing to invoker
             connections=connections,
             streaming=True,
-            flow_path=self.path,
-            working_dir=self.code,
         )
         result = invoker._invoke(
             data=inputs,
@@ -159,8 +164,10 @@ class AsyncFlow(FlowBase):
     async def invoke(self, inputs: dict, *, connections: dict = None, **kwargs) -> "LineResult":
         """Invoke a flow and get a LineResult object."""
 
+        from promptflow.core._serving.flow_invoker import AsyncFlowInvoker
+
         invoker = AsyncFlowInvoker(
-            flow=init_executable(flow_dag=self._data, working_dir=self.code),
+            flow=self,
             # TODO (3027983): resolve the connections before passing to invoker
             connections=connections,
             streaming=True,

--- a/src/promptflow/promptflow/core/_serving/flow_invoker.py
+++ b/src/promptflow/promptflow/core/_serving/flow_invoker.py
@@ -9,11 +9,12 @@ from promptflow._utils.dataclass_serializer import convert_eager_flow_output_to_
 from promptflow._utils.flow_utils import dump_flow_result, is_executable_chat_flow
 from promptflow._utils.logger_utils import LoggerFactory
 from promptflow._utils.multimedia_utils import convert_multimedia_data_to_base64, persist_multimedia_data
-from promptflow.contracts.flow import Flow as ExecutableFlow
 from promptflow.core._connection import _Connection
+from promptflow.core._flow import AbstractFlowBase
 from promptflow.core._serving._errors import UnexpectedConnectionProviderReturn, UnsupportedConnectionProvider
 from promptflow.core._serving.flow_result import FlowResult
 from promptflow.core._serving.utils import validate_request_data
+from promptflow.core._utils import init_executable
 from promptflow.executor import FlowExecutor
 from promptflow.storage._run_storage import DefaultRunStorage
 
@@ -22,8 +23,8 @@ class FlowInvoker:
     """
     The invoker of a flow.
 
-    :param flow: The path of the flow.
-    :type flow: [str, Path]
+    :param flow: A loaded Flow object.
+    :type flow: Flow
     :param connection_provider: The connection provider, defaults to None
     :type connection_provider: [str, Callable], optional
     :param streaming: The function or bool to determine enable streaming or not, defaults to lambda: False
@@ -40,19 +41,17 @@ class FlowInvoker:
 
     def __init__(
         self,
-        flow: ExecutableFlow,
+        flow: AbstractFlowBase,
         connection_provider: [str, Callable] = None,
         streaming: Union[Callable[[], bool], bool] = False,
         connections: dict = None,
         connections_name_overrides: dict = None,
         raise_ex: bool = True,
-        *,
-        flow_path: Path,
-        working_dir: Path,
         **kwargs,
     ):
         self.logger = kwargs.get("logger", LoggerFactory.get_logger("flowinvoker"))
-        self.flow = flow
+        # TODO: avoid to use private attribute after we finalize the inheritance
+        self.flow = init_executable(working_dir=flow._code, flow_path=flow._path)
         self.connections = connections or {}
         self.connections_name_overrides = connections_name_overrides or {}
         self.raise_ex = raise_ex
@@ -65,7 +64,8 @@ class FlowInvoker:
         self._credential = kwargs.get("credential", None)
 
         self._init_connections(connection_provider)
-        self._init_executor(flow_path, working_dir)
+        # TODO: avoid to use private attribute after we finalize the inheritance
+        self._init_executor(flow._path, flow._code)
         self._dump_file_prefix = "chat" if self._is_chat_flow else "flow"
 
     def _init_connections(self, connection_provider):

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_flow_invoker.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_flow_invoker.py
@@ -5,16 +5,16 @@ from pathlib import Path
 
 import pytest
 
+from promptflow._sdk._load_functions import load_flow
 from promptflow.core._serving._errors import UnexpectedConnectionProviderReturn, UnsupportedConnectionProvider
 from promptflow.core._serving.flow_invoker import FlowInvoker
-from promptflow.core._utils import init_executable
 from promptflow.exceptions import UserErrorException
 
 PROMOTFLOW_ROOT = Path(__file__).parent.parent.parent.parent
 FLOWS_DIR = Path(PROMOTFLOW_ROOT / "tests/test_configs/flows")
 EXAMPLE_FLOW_DIR = FLOWS_DIR / "web_classification"
 EXAMPLE_FLOW_FILE = EXAMPLE_FLOW_DIR / "flow.dag.yaml"
-EXAMPLE_FLOW = init_executable(flow_path=EXAMPLE_FLOW_FILE)
+EXAMPLE_FLOW = load_flow(EXAMPLE_FLOW_FILE)
 
 
 @pytest.mark.sdk_test
@@ -23,16 +23,12 @@ class TestFlowInvoker:
     # Note: e2e test of flow invoker has been covered by test_flow_serve.
     def test_flow_invoker_unsupported_connection_provider(self):
         with pytest.raises(UnsupportedConnectionProvider):
-            FlowInvoker(
-                flow=EXAMPLE_FLOW, connection_provider=[], flow_path=EXAMPLE_FLOW_FILE, working_dir=EXAMPLE_FLOW_DIR
-            )
+            FlowInvoker(flow=EXAMPLE_FLOW, connection_provider=[])
 
         with pytest.raises(UserErrorException):
             FlowInvoker(
                 flow=EXAMPLE_FLOW,
                 connection_provider="unsupported",
-                flow_path=EXAMPLE_FLOW_FILE,
-                working_dir=EXAMPLE_FLOW_DIR,
             )
 
     def test_flow_invoker_custom_connection_provider(self):
@@ -41,8 +37,6 @@ class TestFlowInvoker:
             FlowInvoker(
                 flow=EXAMPLE_FLOW,
                 connection_provider=lambda: {},
-                flow_path=EXAMPLE_FLOW_FILE,
-                working_dir=EXAMPLE_FLOW_DIR,
             )
         assert "should return a list of connections" in str(e.value)
 
@@ -51,7 +45,5 @@ class TestFlowInvoker:
             FlowInvoker(
                 flow=EXAMPLE_FLOW,
                 connection_provider=lambda: [1, 2],
-                flow_path=EXAMPLE_FLOW_FILE,
-                working_dir=EXAMPLE_FLOW_DIR,
             )
         assert "should be connection type" in str(e.value)


### PR DESCRIPTION
# Description

This PR is to revert args for `FlowInvoker.__init__`, which change will bring [compatibility issue with `mlflow`](https://github.com/mlflow/mlflow/blob/master/mlflow/promptflow/__init__.py#L401).

Given this is a refactor of a private class which has already been tested explicitly and implicitly in many tests, we haven't added new tests here.

This pull request primarily focuses on refactoring the flow invocation process in the `promptflow` package. The changes aim to simplify the codebase by introducing an `AbstractFlowBase` class, removing redundant parameters and methods, and adjusting the way flows are initialized and invoked.

Refactoring flow invocation:

* [`src/promptflow/promptflow/_sdk/entities/_flow/_flow_context_resolver.py`](diffhunk://#diff-a1a6133992adb765818f3a6474d0f2a1468a609368b4fbc25be1b97e7afa1b14L128-L143): Removed the `executable_flow` initialization and replaced it with `resolved_flow` in the `AsyncFlowInvoker` and `FlowInvoker` classes. Also removed the `flow_path` and `working_dir` parameters from these classes.

* [`src/promptflow/promptflow/_sdk/entities/_flow/base.py`](diffhunk://#diff-f2782d63bffa0012d5c70a10a4a3d6c8292ec50bbe3a666e39bf5100a4998c5bL4): Removed the import of `abc` and added the import of `AbstractFlowBase`. Changed the `FlowBase` class to inherit from `AbstractFlowBase` and `SchemaValidatableMixin`, and replaced the initialization of several instance variables with a call to `AbstractFlowBase.__init__`. [[1]](diffhunk://#diff-f2782d63bffa0012d5c70a10a4a3d6c8292ec50bbe3a666e39bf5100a4998c5bL4) [[2]](diffhunk://#diff-f2782d63bffa0012d5c70a10a4a3d6c8292ec50bbe3a666e39bf5100a4998c5bR13) [[3]](diffhunk://#diff-f2782d63bffa0012d5c70a10a4a3d6c8292ec50bbe3a666e39bf5100a4998c5bL83-L94)

* [`src/promptflow/promptflow/core/_flow.py`](diffhunk://#diff-a1b7af0df2fd1f9f1d07a45071795e8dc440a303c7847abe5033b9348909712bL10-R19): Renamed `FlowBase` to `AbstractFlowBase` and added a docstring. Added a `FlowBase` class that inherits from `AbstractFlowBase`. Removed the `flow_path` and `working_dir` parameters from the `FlowInvoker` and `AsyncFlowInvoker` classes. [[1]](diffhunk://#diff-a1b7af0df2fd1f9f1d07a45071795e8dc440a303c7847abe5033b9348909712bL10-R19) [[2]](diffhunk://#diff-a1b7af0df2fd1f9f1d07a45071795e8dc440a303c7847abe5033b9348909712bR28-R32) [[3]](diffhunk://#diff-a1b7af0df2fd1f9f1d07a45071795e8dc440a303c7847abe5033b9348909712bR117-L118) [[4]](diffhunk://#diff-a1b7af0df2fd1f9f1d07a45071795e8dc440a303c7847abe5033b9348909712bR167-R168)

* [`src/promptflow/promptflow/core/_serving/app.py`](diffhunk://#diff-642b8b1a75aacde64c3ad2b22c934b38b49e040e60e6d3536077d7c7df1fb19cL16-R20): Removed the import of `resolve_flow_path` and added the import of `Flow`. Changed the `FlowInvoker` initialization to load the flow from `self.project_path` instead of using `self.flow`. Removed the `flow_path` and `working_dir` parameters from the `FlowInvoker` initialization. [[1]](diffhunk://#diff-642b8b1a75aacde64c3ad2b22c934b38b49e040e60e6d3536077d7c7df1fb19cL16-R20) [[2]](diffhunk://#diff-642b8b1a75aacde64c3ad2b22c934b38b49e040e60e6d3536077d7c7df1fb19cL97-R98) [[3]](diffhunk://#diff-642b8b1a75aacde64c3ad2b22c934b38b49e040e60e6d3536077d7c7df1fb19cL108-L109)

* [`src/promptflow/promptflow/core/_serving/flow_invoker.py`](diffhunk://#diff-f01b1126601a80f6099597f2a5820f0722040156377fefd69cd86363d3a62c83L12-R17): Removed the import of `ExecutableFlow` and added the imports of `AbstractFlowBase` and `init_executable`. Changed the `flow` parameter in the `FlowInvoker` class to be of type `Flow` instead of `str` or `Path`. Replaced the `flow` instance variable with the result of `init_executable`. Removed the `flow_path` and `working_dir` parameters from the `FlowInvoker` initialization. [[1]](diffhunk://#diff-f01b1126601a80f6099597f2a5820f0722040156377fefd69cd86363d3a62c83L12-R17) [[2]](diffhunk://#diff-f01b1126601a80f6099597f2a5820f0722040156377fefd69cd86363d3a62c83L25-R27) [[3]](diffhunk://#diff-f01b1126601a80f6099597f2a5820f0722040156377fefd69cd86363d3a62c83L43-R54) [[4]](diffhunk://#diff-f01b1126601a80f6099597f2a5820f0722040156377fefd69cd86363d3a62c83L68-R68)

* [`src/promptflow/tests/sdk_cli_test/unittests/test_flow_invoker.py`](diffhunk://#diff-10080d296936c0ec3b532ca6fa629a813c2587d91a9d0b9c7ef987dc83ec9fccR8-R17): Replaced `init_executable` with `load_flow` to initialize `EXAMPLE_FLOW`. Removed the `flow_path` and `working_dir` parameters from the `FlowInvoker` initializations in the test cases. [[1]](diffhunk://#diff-10080d296936c0ec3b532ca6fa629a813c2587d91a9d0b9c7ef987dc83ec9fccR8-R17) [[2]](diffhunk://#diff-10080d296936c0ec3b532ca6fa629a813c2587d91a9d0b9c7ef987dc83ec9fccL26-L35) [[3]](diffhunk://#diff-10080d296936c0ec3b532ca6fa629a813c2587d91a9d0b9c7ef987dc83ec9fccL44-L45) [[4]](diffhunk://#diff-10080d296936c0ec3b532ca6fa629a813c2587d91a9d0b9c7ef987dc83ec9fccL54-L55)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
