### PR TITLE
Allow retry for APIConnectionError "Server disconnected without sending a response"

### DIFF
--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -337,6 +337,19 @@ def refine_extra_fields_not_permitted_error(connection, deployment_name, model):
     return None
 
 
+def is_retriable_api_connection_error(e: APIConnectionError):
+    retriable_error_messages = [
+        "connection aborted",
+        # issue 2296
+        "server disconnected without sending a response"
+    ]
+    for message in retriable_error_messages:
+        if message in str(e).lower() or message in str(e.__cause__).lower():
+            return True
+
+    return False
+
+
 # TODO(2971352): revisit this tries=100 when there is any change to the 10min timeout logic
 def handle_openai_error(tries: int = 100):
     """
@@ -375,7 +388,7 @@ def handle_openai_error(tries: int = 100):
                             raise WrappedOpenAIError(e)
 
                     if isinstance(e, APIConnectionError) and not isinstance(e, APITimeoutError) \
-                            and "connection aborted" not in str(e).lower():
+                            and not is_retriable_api_connection_error(e):
                         raise WrappedOpenAIError(e)
                     # Retry InternalServerError(>=500), RateLimitError(429), UnprocessableEntityError(422)
                     if isinstance(e, APIStatusError):

--- a/src/promptflow-tools/tests/test_handle_openai_error.py
+++ b/src/promptflow-tools/tests/test_handle_openai_error.py
@@ -94,6 +94,13 @@ class TestHandleOpenAIError:
         assert mock_method.call_count == 1
         assert exc_info.value.error_codes == error_codes.split("/")
 
+    def create_api_connection_error_with_cause():
+        error = APIConnectionError(
+            request=httpx.Request('GET', 'https://www.example.com')
+        )
+        error.__cause__ = Exception("Server disconnected without sending a response.")
+        return error
+
     @pytest.mark.parametrize(
         "dummyExceptionList",
         [
@@ -105,6 +112,7 @@ class TestHandleOpenAIError:
                     APIConnectionError(
                         message="('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))",
                         request=httpx.Request('GET', 'https://www.example.com')),
+                    create_api_connection_error_with_cause(),
                     InternalServerError("Something went wrong", response=httpx.Response(
                         503, request=httpx.Request('GET', 'https://www.example.com')), body=None),
                     UnprocessableEntityError("Something went wrong", response=httpx.Response(


### PR DESCRIPTION
# Description

Issue: Customer found no retry when he met APIConnectionError "httpcore.RemoteProtocolError: Server disconnected without sending a response".

Root cause: We only retry on APIConnectionError if the error message contains "connection aborted" or it is APITimeOutError.

Solution: 
Considering not all APIConnectionError is retriable, for example, if api_base is invalid, the error is not retriable.
Append "Server disconnected without sending a response" to retriable error.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
