### PR TITLE
Use new openai api name in metrics calculator and tests

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_openai_utils.py
+++ b/src/promptflow-tracing/promptflow/tracing/_openai_utils.py
@@ -57,13 +57,13 @@ class OpenAIMetricsCalculator:
         #   https://github.com/openai/openai-python/blob/main/src/openai/resources/chat/completions.py
         #   https://github.com/openai/openai-python/blob/main/src/openai/resources/completions.py
         if (
-            name == "openai.api_resources.chat_completion.ChatCompletion.create"
-            or name == "openai.resources.chat.completions.Completions.create"  # openai v1
+            name == "openai_chat_legacy"
+            or name == "openai_chat"  # openai v1
         ):
             return self.get_openai_metrics_for_chat_api(inputs, output)
         elif (
-            name == "openai.api_resources.completion.Completion.create"
-            or name == "openai.resources.completions.Completions.create"  # openai v1
+            name == "openai_completion_legacy"
+            or name == "openai_completion"  # openai v1
         ):
             return self.get_openai_metrics_for_completion_api(inputs, output)
         else:

--- a/src/promptflow/setup.py
+++ b/src/promptflow/setup.py
@@ -51,7 +51,7 @@ REQUIRES = [
     "opentelemetry-exporter-otlp-proto-http>=1.22.0,<2.0.0",  # trace support
     "flask-restx>=1.2.0,<2.0.0",  # PFS Swagger
     "flask-cors>=4.0.0,<5.0.0",  # handle PFS CORS
-    "promptflow-tracing==1.0.0",  # tracing capabilities
+    "promptflow-tracing>=1.0.0",  # tracing capabilities
 ]
 
 setup(

--- a/src/promptflow/tests/executor/e2etests/test_traces.py
+++ b/src/promptflow/tests/executor/e2etests/test_traces.py
@@ -97,11 +97,11 @@ class TestExecutorTraces:
         """
         get_trace = False
         if apicall.get("name", "") in (
-            "openai.api_resources.chat_completion.ChatCompletion.create",
-            "openai.api_resources.completion.Completion.create",
-            "openai.api_resources.embedding.Embedding.create",
-            "openai.resources.completions.Completions.create",  # openai>=1.0.0
-            "openai.resources.chat.completions.Completions.create",  # openai>=1.0.0
+            "openai_completion_legacy",
+            "openai_chat_legacy",
+            "openai_embedding_legacy",
+            "openai_chat",  # openai>=1.0.0
+            "openai_completion",  # openai>=1.0.0
         ):
             get_trace = True
             output = apicall.get("output")

--- a/src/promptflow/tests/executor/unittests/batch/test_result.py
+++ b/src/promptflow/tests/executor/unittests/batch/test_result.py
@@ -115,13 +115,13 @@ class TestBatchResult:
 
         api_call_1 = get_api_call(
             "LLM",
-            "openai.resources.completions.Completions.create",
+            "openai_completion",
             inputs={"prompt": "Please tell me a joke.", "model": "text-davinci-003"},
             output={"choices": [{"text": "text"}]},
         )
         api_call_2 = get_api_call(
             "LLM",
-            "openai.resources.completions.Completions.create",
+            "openai_completion",
             inputs={
                 "prompt": ["Please tell me a joke.", "Please tell me a joke about fruit."],
                 "model": "text-davinci-003",
@@ -146,7 +146,7 @@ class TestBatchResult:
         line_api_calls = get_api_call("Chain", "Chain", children=[api_call_1, api_call_2])
         aggr_api_call = get_api_call(
             "LLM",
-            "openai.resources.chat.completions.Completions.create",
+            "openai_chat",
             inputs={
                 "messages": [{"system": "You are a helpful assistant.", "user": "Please tell me a joke."}],
                 "model": "gpt-35-turbo",


### PR DESCRIPTION
# Description

We have modified openai api name in this [PR](https://github.com/microsoft/promptflow/pull/2459), so we also need to change other places used these names.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
