### PR TITLE
[Internal][Executor] Update the corresponding error to node run info when async node is canceled

### DIFF
--- a/src/promptflow/promptflow/_core/run_tracker.py
+++ b/src/promptflow/promptflow/_core/run_tracker.py
@@ -337,10 +337,15 @@ class RunTracker(ThreadLocalSingleton):
         """Update exception details into run info."""
         # Update status to Cancelled the run terminates because of KeyboardInterruption or CancelledError.
         if isinstance(ex, KeyboardInterrupt) or isinstance(ex, asyncio.CancelledError):
+            ex = ToolCanceledError(
+                message_format="Tool execution is canceled because: {msg}.",
+                msg="Received cancel request.",
+                target=ErrorTarget.EXECUTOR,
+            )
             run_info.status = Status.Canceled
         else:
-            run_info.error = ExceptionPresenter.create(ex).to_dict(include_debug_info=self._debug)
             run_info.status = Status.Failed
+        run_info.error = ExceptionPresenter.create(ex).to_dict(include_debug_info=self._debug)
 
     def collect_all_run_infos_as_dicts(self) -> Mapping[str, List[Mapping[str, Any]]]:
         flow_runs = self.flow_run_list


### PR DESCRIPTION
# Description

Update the corresponding error to node run info when async node is canceled.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
