### PR TITLE
Add Input/Output Events to OpenTelemetry Spans in PromptFlow

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -154,6 +154,9 @@ def traced_generator(original_span: ReadableSpan, inputs, generator):
         links=[link],
     ) as span:
         enrich_span_with_original_attributes(span, original_span.attributes)
+        # Enrich the new span with input before generator iteration to prevent loss of input information.
+        # The input is as an event within this span.
+        enrich_span_with_input(span, inputs)
         generator_proxy = GeneratorProxy(generator)
         yield from generator_proxy
         generator_output = generator_proxy.items

--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -22,7 +22,7 @@ from ._operation_context import OperationContext
 from ._tracer import Tracer, _create_trace_from_function_call, get_node_name_from_context
 from ._utils import get_input_names_for_prompt_template, get_prompt_param_name_from_func, serialize
 from .contracts.generator_proxy import GeneratorProxy
-from .contracts.trace import TraceType, Trace
+from .contracts.trace import Trace, TraceType
 
 IS_LEGACY_OPENAI = version("openai").startswith("0.")
 
@@ -122,6 +122,7 @@ def enrich_span_with_input(span, input):
     try:
         serialized_input = serialize_attribute(input)
         span.set_attribute("inputs", serialized_input)
+        span.add_event("promptflow.function.inputs", {"payload": serialized_input})
     except Exception as e:
         logging.warning(f"Failed to enrich span with input: {e}")
 
@@ -191,6 +192,7 @@ def enrich_span_with_output(span, output):
     try:
         serialized_output = serialize_attribute(output)
         span.set_attribute("output", serialized_output)
+        span.add_event("promptflow.function.output", {"payload": serialized_output})
     except Exception as e:
         logging.warning(f"Failed to enrich span with output: {e}")
 


### PR DESCRIPTION
# Description

This pull request introduces changes to the tracing functionality in PromptFlow. Specifically, it adds input and output events to the OpenTelemetry spans. The event names are `promptflow.function.inputs` and `promptflow.function.output`, and their attributes contain a payload which is a JSON dump of the input/output values. This enhancement will provide more detailed tracing information and facilitate debugging and performance monitoring.

This PR also includes updates to the relevant unit tests to validate these new events and their payloads.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
