### PR TITLE
[Tracing][Internal] Skip otel setup if no environment is set

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_start_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_start_trace.py
@@ -8,6 +8,8 @@ import typing
 from opentelemetry import trace
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT
+
 
 from ._constants import (
     PF_TRACING_SKIP_LOCAL_SETUP_ENVIRON,
@@ -55,8 +57,14 @@ def start_trace(
 
 
 def setup_exporter_from_environ() -> None:
+
     # openai instrumentation
     inject_openai_api()
+
+    # Ignore all the setup if the endpoint is not set
+    endpoint = os.getenv(OTEL_EXPORTER_OTLP_ENDPOINT)
+    if not endpoint:
+        return
 
     if _is_devkit_installed():
         from promptflow._sdk._tracing import setup_exporter_to_pfs

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_trace.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_trace.py
@@ -153,10 +153,11 @@ class TestStartTrace:
     def test_setup_exporter_in_executor(self, monkeypatch: pytest.MonkeyPatch):
         with monkeypatch.context() as m:
             m.delenv(OTEL_EXPORTER_OTLP_ENDPOINT, raising=False)
+            original_proivder = trace.get_tracer_provider()
             setup_exporter_from_environ()
-            tracer_provider: TracerProvider = trace.get_tracer_provider()
+            new_provider: TracerProvider = trace.get_tracer_provider()
             # Assert the provider without exporter is not the one with exporter
-            assert not isinstance(tracer_provider, TracerProvider)
+            assert original_proivder == new_provider
 
     def test_setup_exporter_in_executor_with_preview_flag(self, mock_promptflow_service_invocation):
         with mock.patch("promptflow._sdk._configuration.Configuration.is_internal_features_enabled") as mock_func:

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_trace.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_trace.py
@@ -96,6 +96,7 @@ class TestStartTrace:
                 TraceEnvironmentVariableName.SUBSCRIPTION_ID: "test_subscription_id",
                 TraceEnvironmentVariableName.RESOURCE_GROUP_NAME: "test_resource_group_name",
                 TraceEnvironmentVariableName.WORKSPACE_NAME: "test_workspace_name",
+                OTEL_EXPORTER_OTLP_ENDPOINT: "https://dummy-endpoint",
             },
             clear=True,
         ):
@@ -154,7 +155,8 @@ class TestStartTrace:
             m.delenv(OTEL_EXPORTER_OTLP_ENDPOINT, raising=False)
             setup_exporter_from_environ()
             tracer_provider: TracerProvider = trace.get_tracer_provider()
-            assert len(tracer_provider._active_span_processor._span_processors) == 0
+            # Assert the provider without exporter is not the one with exporter
+            assert not isinstance(tracer_provider, TracerProvider)
 
     def test_setup_exporter_in_executor_with_preview_flag(self, mock_promptflow_service_invocation):
         with mock.patch("promptflow._sdk._configuration.Configuration.is_internal_features_enabled") as mock_func:


### PR DESCRIPTION
# Description

This pull request primarily focuses on enhancing the tracing functionality in the `promptflow` module. The main changes are in the `src/promptflow-tracing/promptflow/tracing/_start_trace.py` file. The changes include importing the `OTEL_EXPORTER_OTLP_ENDPOINT` from `opentelemetry.sdk.environment_variables` and modifying the `setup_exporter_from_environ()` function to skip the setup if the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is not set.

Changes in detail:

* [`src/promptflow-tracing/promptflow/tracing/_start_trace.py`](diffhunk://#diff-7af0034cfa004d9b472906d191838650ce1a8bacaf3f90ec5fc2479a0a8ef909R11-R12): Imported `OTEL_EXPORTER_OTLP_ENDPOINT` from `opentelemetry.sdk.environment_variables`. This environment variable is used to determine the endpoint for OpenTelemetry.
* `src/promptflow-tracing/promptflow/tracing/_start_trace.py` (within `def start_trace(`): Modified the `setup_exporter_from_environ()` function to check if the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is set. If it's not set, the function will return early, skipping the rest of the setup. This change makes the function more robust by ensuring it doesn't attempt to set up the exporter if the necessary environment variable isn't available.
* 
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
