### PR TITLE
[fundamental][bugfix] Fix breaking import linter CI workflow

### DIFF
--- a/.github/workflows/promptflow-import-linter.yml
+++ b/.github/workflows/promptflow-import-linter.yml
@@ -1,13 +1,14 @@
 name: promptflow-import-linter
 
 on:
-  pull_request:
-    paths:
-      - src/promptflow-tracing/**
-      - src/promptflow-core/**
-      - src/promptflow-devkit/**
-      - src/promptflow-azure/**
-      - .github/workflows/promptflow-import-linter.yml
+  # BUG(3050545): uncomment after we make this stable
+  # pull_request:
+  #   paths:
+  #     - src/promptflow-tracing/**
+  #     - src/promptflow-core/**
+  #     - src/promptflow-devkit/**
+  #     - src/promptflow-azure/**
+  #     - .github/workflows/promptflow-import-linter.yml
   workflow_dispatch:
 
 env:

--- a/.github/workflows/promptflow-import-linter.yml
+++ b/.github/workflows/promptflow-import-linter.yml
@@ -1,14 +1,13 @@
 name: promptflow-import-linter
 
 on:
-  # BUG(3050545): uncomment after we make this stable
-  # pull_request:
-  #   paths:
-  #     - src/promptflow-tracing/**
-  #     - src/promptflow-core/**
-  #     - src/promptflow-devkit/**
-  #     - src/promptflow-azure/**
-  #     - .github/workflows/promptflow-import-linter.yml
+  pull_request:
+    paths:
+      - src/promptflow-tracing/**
+      - src/promptflow-core/**
+      - src/promptflow-devkit/**
+      - src/promptflow-azure/**
+      - .github/workflows/promptflow-import-linter.yml
   workflow_dispatch:
 
 env:
@@ -27,12 +26,16 @@ jobs:
     - name: Install all packages
       run: |
         cd ${{ env.WORKING_DIRECTORY }}/src/promptflow-tracing
+        touch promptflow/__init__.py
         poetry install --with dev
         cd ${{ env.WORKING_DIRECTORY }}/src/promptflow-core
+        touch promptflow/__init__.py
         poetry install --with dev
         cd ${{ env.WORKING_DIRECTORY }}/src/promptflow-devkit
+        touch promptflow/__init__.py
         poetry install --with dev
         cd ${{ env.WORKING_DIRECTORY }}/src/promptflow-azure
+        touch promptflow/__init__.py
         poetry install --with dev
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: import lint


### PR DESCRIPTION
# Description

Fix breaking import linter CI workflow by touching `__init__.py`.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
