### PR TITLE
[Tracing][Internal] Use otel_trace_id for correlation between line run and otel trace

### DIFF
--- a/src/promptflow-core/promptflow/_core/run_tracker.py
+++ b/src/promptflow-core/promptflow/_core/run_tracker.py
@@ -23,6 +23,7 @@ from promptflow.exceptions import ErrorTarget
 from promptflow.storage import AbstractRunStorage
 from promptflow.storage._run_storage import DummyRunStorage
 from promptflow.tracing._openai_utils import OpenAIMetricsCalculator
+from promptflow.tracing._operation_context import OperationContext
 from promptflow.tracing._thread_local_singleton import ThreadLocalSingleton
 from promptflow.tracing._utils import serialize
 
@@ -166,6 +167,8 @@ class RunTracker(ThreadLocalSingleton):
         return run_info
 
     def _flow_run_postprocess(self, run_info: FlowRunInfo, output, ex: Optional[Exception]):
+        #  Try get otel trace id for correlation.
+        run_info.otel_trace_id = OperationContext.get_instance().get("otel_trace_id")
         if output:
             try:
                 self._assert_flow_output_serializable(output)

--- a/src/promptflow-core/promptflow/contracts/run_info.py
+++ b/src/promptflow-core/promptflow/contracts/run_info.py
@@ -202,6 +202,7 @@ class FlowRunInfo:
     system_metrics: Dict[str, Any] = None
     result: object = None
     upload_metrics: bool = False  # only set as true for root runs in bulk test mode and evaluation mode
+    otel_trace_id: Optional[str] = ""
     message_format: str = MessageFormatType.BASIC
 
     @staticmethod

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -842,6 +842,8 @@ class FlowExecutor:
         allow_generator_output=False,
     ):
         with open_telemetry_tracer.start_as_current_span(self._flow.name) as span:
+            # Store otel trace id in context for correlation
+            OperationContext.get_instance()["otel_trace_id"] = f"{span.get_span_context().trace_id:032x}"
             # initialize span
             span.set_attributes(
                 {

--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -337,6 +337,8 @@ def _traced_async(
         # For node span we set the span name to node name, otherwise we use the function name.
         span_name = get_node_name_from_context(used_for_span_name=True) or trace.name
         with open_telemetry_tracer.start_as_current_span(span_name) as span:
+            # Store otel trace id in context for correlation
+            OperationContext.get_instance()["otel_trace_id"] = f"{span.get_span_context().trace_id:032x}"
             enrich_span_with_trace(span, trace)
             enrich_span_with_prompt_info(span, func, kwargs)
 
@@ -399,6 +401,8 @@ def _traced_sync(
         # For node span we set the span name to node name, otherwise we use the function name.
         span_name = get_node_name_from_context(used_for_span_name=True) or trace.name
         with open_telemetry_tracer.start_as_current_span(span_name) as span:
+            # Store otel trace id in context for correlation
+            OperationContext.get_instance()["otel_trace_id"] = f"{span.get_span_context().trace_id:032x}"
             enrich_span_with_trace(span, trace)
             enrich_span_with_prompt_info(span, func, kwargs)
 


### PR DESCRIPTION
# Description

Use otel_trace_id for correlation between line run and otel trace.

This pull request primarily focuses on enhancing the traceability of operations in the codebase. The changes involve storing the OpenTelemetry (otel) trace ID in the PromptFlow (pf) trace for correlation. This is achieved by introducing the `OperationContext` class and adding the `otel_trace_id` attribute to the `FlowRunInfo` class.

Here are the key changes:

Traceability enhancements:

* [`src/promptflow-core/promptflow/_core/run_tracker.py`](diffhunk://#diff-a5027d19a24cb28a68ead16dfe6c54492c78d6e0e7640e80533928808cdb3422R25): Imported `OperationContext` class and stored the otel trace ID in pf trace for correlation in the `_flow_run_postprocess` method. [[1]](diffhunk://#diff-a5027d19a24cb28a68ead16dfe6c54492c78d6e0e7640e80533928808cdb3422R25) [[2]](diffhunk://#diff-a5027d19a24cb28a68ead16dfe6c54492c78d6e0e7640e80533928808cdb3422R163-R164)
* [`src/promptflow-core/promptflow/contracts/run_info.py`](diffhunk://#diff-c74033a65184b4015ea5c4454ea07755054b6c9cdff63e537222d389393554d4R197): Added `otel_trace_id` attribute to the `FlowRunInfo` class.
* `src/promptflow-core/promptflow/executor/flow_executor.py`, `src/promptflow-tracing/promptflow/tracing/_trace.py`: Stored the otel trace ID in pf trace for correlation in the `_exec_inner_with_trace`, `wrapped` (async and sync versions) methods. [[1]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fR840-R841) [[2]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcR337-R338) [[3]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcR401-R402)

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
