### PR TITLE
Use batch run id as partition key for local batch run

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/collection.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/collection.py
@@ -44,11 +44,15 @@ class CollectionCosmosDB:
         self.collection_name = resource_attributes.get(
             SpanResourceAttributesFieldName.COLLECTION, TRACE_DEFAULT_COLLECTION
         )
-        self.collection_id = (
-            resource_attributes[SpanResourceAttributesFieldName.COLLECTION_ID]
-            if is_cloud_trace
-            else generate_collection_id_by_name_and_created_by(self.collection_name, created_by)
-        )
+        span_attributes = self.span.attributes
+        if SpanAttributeFieldName.BATCH_RUN_ID in span_attributes:
+            self.collection_id = span_attributes[SpanAttributeFieldName.BATCH_RUN_ID]
+        else:
+            self.collection_id = (
+                resource_attributes[SpanResourceAttributesFieldName.COLLECTION_ID]
+                if is_cloud_trace
+                else generate_collection_id_by_name_and_created_by(self.collection_name, created_by)
+            )
 
     def create_collection_if_not_exist(self, client: ContainerProxy):
         span_attributes = self.span.attributes

--- a/src/promptflow-devkit/promptflow/_sdk/_service/apis/collector.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/apis/collector.py
@@ -166,6 +166,9 @@ def _try_write_trace_to_cosmosdb(
 
         collection_db = CollectionCosmosDB(first_span, is_cloud_trace, created_by)
         collection_db.create_collection_if_not_exist(collection_client)
+        # For runtime, collection id is flow id for test, batch run id for batch run.
+        # For local, collection id is collection name + user id for non batch run, batch run id for batch run.
+        # We assign it to LineSummary and Span and use it as partition key.
         collection_id = collection_db.collection_id
 
         for span in all_spans:

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_collection.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_collection.py
@@ -27,11 +27,23 @@ class TestCollectionCosmosDB:
         assert collection.collection_id == "test_collection_id"
         assert collection.location == 1
 
+        self.span.attributes = {"batch_run_id": "test_batch_run_id"}
+        collection = CollectionCosmosDB(self.span, True, self.created_by)
+        assert collection.collection_name == "test_collection_name"
+        assert collection.collection_id == "test_batch_run_id"
+        assert collection.location == 1
+
     def test_collection_properties_local(self):
         collection = CollectionCosmosDB(self.span, False, self.created_by)
         assert collection.collection_name == "test_collection_name"
         # For local, use collection name and user id to generate collection id
         assert collection.collection_id == "test_collection_name_test_user_id"
+        assert collection.location == 0
+
+        self.span.attributes = {"batch_run_id": "test_batch_run_id"}
+        collection = CollectionCosmosDB(self.span, False, self.created_by)
+        assert collection.collection_name == "test_collection_name"
+        assert collection.collection_id == "test_batch_run_id"
         assert collection.location == 0
 
     def test_create_collection_if_not_exist(self):

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
@@ -135,12 +135,14 @@ class TestSummary:
             {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
         ]
 
-        client.query_items.return_value = [{"id": "main_id", "status": OK_LINE_RUN_STATUS}]
+        client.query_items.return_value = [
+            {"id": "main_id", "partition_key": "test_main_partition_key", "status": OK_LINE_RUN_STATUS}
+        ]
         self.summary._insert_evaluation(client)
         client.query_items.assert_called_once()
         client.patch_item.assert_called_once_with(
             item="main_id",
-            partition_key=self.FAKE_COLLECTION_ID,
+            partition_key="test_main_partition_key",
             patch_operations=expected_patch_operations,
         )
 
@@ -151,7 +153,9 @@ class TestSummary:
             SpanAttributeFieldName.LINE_RUN_ID: "line_run_id",
             SpanAttributeFieldName.OUTPUT: '{"output_key": "output_value"}',
         }
-        client.query_items.return_value = [{"id": "main_id", "status": OK_LINE_RUN_STATUS}]
+        client.query_items.return_value = [
+            {"id": "main_id", "partition_key": "test_main_partition_key", "status": OK_LINE_RUN_STATUS}
+        ]
         self.summary._insert_evaluation(client)
         client.query_items.assert_called_once_with(
             query=(
@@ -163,7 +167,7 @@ class TestSummary:
                 {"name": "@batch_run_id", "value": None},
                 {"name": "@line_number", "value": None},
             ],
-            partition_key=self.FAKE_COLLECTION_ID,
+            enable_cross_partition_query=True,
         )
 
         expected_item = LineEvaluation(
@@ -180,7 +184,7 @@ class TestSummary:
         ]
         client.patch_item.assert_called_once_with(
             item="main_id",
-            partition_key=self.FAKE_COLLECTION_ID,
+            partition_key="test_main_partition_key",
             patch_operations=expected_patch_operations,
         )
 
@@ -192,7 +196,9 @@ class TestSummary:
             SpanAttributeFieldName.LINE_NUMBER: 1,
             SpanAttributeFieldName.OUTPUT: '{"output_key": "output_value"}',
         }
-        client.query_items.return_value = [{"id": "main_id", "status": OK_LINE_RUN_STATUS}]
+        client.query_items.return_value = [
+            {"id": "main_id", "partition_key": "test_main_partition_key", "status": OK_LINE_RUN_STATUS}
+        ]
 
         self.summary._insert_evaluation(client)
         client.query_items.assert_called_once_with(
@@ -205,7 +211,7 @@ class TestSummary:
                 {"name": "@batch_run_id", "value": "referenced_batch_run_id"},
                 {"name": "@line_number", "value": 1},
             ],
-            partition_key=self.FAKE_COLLECTION_ID,
+            enable_cross_partition_query=True,
         )
 
         expected_item = LineEvaluation(
@@ -223,7 +229,7 @@ class TestSummary:
         ]
         client.patch_item.assert_called_once_with(
             item="main_id",
-            partition_key=self.FAKE_COLLECTION_ID,
+            partition_key="test_main_partition_key",
             patch_operations=expected_patch_operations,
         )
 


### PR DESCRIPTION
# Description

Set batch run id as partition key for local batch run. 
Because we need a separate partition key for batch run from flow test in case of cosmosDB's 20GB limitation.

Remove partition key condition for eval run insertion query.
As evaluation flow, we can't know the specific partition key for main flow.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
