### PR TITLE
[Draft][Batch][Flex] Directly call async function in batch engine for flex mode.

### DIFF
--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -736,6 +736,10 @@ class FlowExecutor:
             line_result.output[LINE_NUMBER_KEY] = index
         return line_result
 
+    @property
+    def prefer_async(self) -> bool:
+        return False
+
     async def exec_line_async(
         self,
         inputs: Mapping[str, Any],

--- a/src/promptflow-devkit/promptflow/batch/_batch_engine.py
+++ b/src/promptflow-devkit/promptflow/batch/_batch_engine.py
@@ -414,7 +414,8 @@ class BatchEngine:
 
         # execute lines
         is_timeout = False
-        if isinstance(self._executor_proxy, PythonExecutorProxy):
+        # When python is not using async functions, we use _exec_batch to run the batch with process pool.
+        if isinstance(self._executor_proxy, PythonExecutorProxy) and not self._executor_proxy.prefer_async:
             results, is_timeout = await self._executor_proxy._exec_batch(
                 inputs_to_run,
                 output_dir,

--- a/src/promptflow-devkit/promptflow/batch/_batch_engine.py
+++ b/src/promptflow-devkit/promptflow/batch/_batch_engine.py
@@ -175,6 +175,10 @@ class BatchEngine:
         :return: The result of this batch run
         :rtype: ~promptflow.batch._result.BatchResult
         """
+        from promptflow.contracts.run_mode import RunMode
+        from promptflow.tracing._operation_context import OperationContext
+
+        OperationContext.get_instance().run_mode = RunMode.Batch
         try:
             self._start_time = datetime.utcnow()
             with _change_working_dir(self._working_dir):

--- a/src/promptflow-devkit/promptflow/batch/_python_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/batch/_python_executor_proxy.py
@@ -71,6 +71,18 @@ class PythonExecutorProxy(AbstractExecutorProxy):
         with self._flow_executor._run_tracker.node_log_manager:
             return self._flow_executor._exec_aggregation(batch_inputs, aggregation_inputs, run_id=run_id)
 
+    @property
+    def prefer_async(self) -> bool:
+        return self._flow_executor.prefer_async
+
+    async def exec_line_async(
+        self,
+        inputs: Mapping[str, Any],
+        index: Optional[int] = None,
+        run_id: Optional[str] = None,
+    ) -> LineResult:
+        return await self._flow_executor.exec_line_async(inputs, index=index, run_id=run_id)
+
     async def _exec_batch(
         self,
         batch_inputs: List[Mapping[str, Any]],


### PR DESCRIPTION
# Description

When the user provides an async function as the entry of flex flow, we are still using a process pool to run each lines.
However we can actually expose `exec_line_async` which directly call the async entry function, then we can leverage the async part of the batch engine.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
