### PR TITLE
[fundamental][bugfix] Refine dev setup script to not automatically touch `__init__.py`

### DIFF
--- a/docs/dev/dev_setup.md
+++ b/docs/dev/dev_setup.md
@@ -5,7 +5,7 @@
 - First create a new [conda](https://conda.io/projects/conda/en/latest/user-guide/getting-started.html) environment. Please specify python version as 3.9.
   `conda create -n <env_name> python=3.9`.
 - Activate the env you created.
-- In root folder, run `python scripts/dev-setup/main.py` to install the packages and dependencies.
+- In root folder, run `python scripts/dev-setup/main.py` to install the packages and dependencies; if you are using Visual Studio Code, it is recommended to add `--vscode` (which is `python scripts/dev-setup/main.py --vscode`) to enable VS Code to recognize the packages.
 
 ## How to run tests
 

--- a/scripts/dev-setup/main.py
+++ b/scripts/dev-setup/main.py
@@ -96,7 +96,7 @@ def install_pkg_editable(pkg: str, verbose: bool, is_vscode: bool = False) -> No
         elif os.path.exists("pyproject.toml"):
             collect_and_install_from_pyproject()
 
-            # touch __init__.py for the package for VS Code exclusivly
+            # touch __init__.py for the package for VS Code
             # NOTE that this is a workaround to enable VS Code to recognize the namespace package
             #      we should be able to remove this after we fully deprecate promptflow in local development
             if is_vscode:

--- a/scripts/dev-setup/main.py
+++ b/scripts/dev-setup/main.py
@@ -61,7 +61,7 @@ def inject_pth_file() -> None:
         f.write((REPO_ROOT_DIR / "src" / "promptflow").resolve().absolute().as_posix())
 
 
-def install_pkg_editable(pkg: str, verbose: bool) -> None:
+def install_pkg_editable(pkg: str, verbose: bool, is_vscode: bool = False) -> None:
     if "[" in pkg:
         folder_name, extras = pkg.split("[")
         extras = f"[{extras}"
@@ -96,17 +96,19 @@ def install_pkg_editable(pkg: str, verbose: bool) -> None:
         elif os.path.exists("pyproject.toml"):
             collect_and_install_from_pyproject()
 
-            # touch __init__.py for the package
+            # touch __init__.py for the package for VS Code exclusivly
             # NOTE that this is a workaround to enable VS Code to recognize the namespace package
             #      we should be able to remove this after we fully deprecate promptflow in local development
-            with open(pkg_working_dir / "promptflow" / "__init__.py", mode="w", encoding="utf-8") as f:
-                f.write("")
+            if is_vscode:
+                with open(pkg_working_dir / "promptflow" / "__init__.py", mode="w", encoding="utf-8") as f:
+                    f.write("")
 
 
 @dataclass
 class Arguments:
     packages: typing.List[str]
     verbose: bool = False
+    vscode: bool = False
 
     @staticmethod
     def parse_args() -> "Arguments":
@@ -127,17 +129,24 @@ class Arguments:
             "-v",
             "--verbose",
             action="store_true",
-            help="turn on verbose output")
+            help="turn on verbose output",
+        )
+        parser.add_argument(
+            "--vscode",
+            action="store_true",
+            help="extra setup step for Visual Studio Code",
+        )
         args = parser.parse_args()
         return Arguments(
             packages=args.packages,
             verbose=args.verbose,
+            vscode=args.vscode,
         )
 
 
 def main(args: Arguments) -> None:
     for pkg in args.packages:
-        install_pkg_editable(pkg, verbose=args.verbose)
+        install_pkg_editable(pkg, verbose=args.verbose, is_vscode=args.vscode)
         # invoke test resource template creation function if available
         if pkg in REGISTERED_TEST_RESOURCES_FUNCTIONS:
             REGISTERED_TEST_RESOURCES_FUNCTIONS[pkg]()

--- a/src/promptflow-core/pyproject.toml
+++ b/src/promptflow-core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "promptflow-core"
-version = "1.0.0.dev0"
+version = "1.1.0.dev0"
 description = "Prompt flow core"
 include = [
   "promptflow/core/_serving/static/*",


### PR DESCRIPTION
# Description

- Add a parameter `vscode` for dev setup script, so that the script will not automatically touch those `__init__.py` files.
- Bump `promptflow-core` version to 1.1.0.dev0 following the new version design/decision.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
