### PR TITLE
Use batch run id as evaluation dict's key for batch run.

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/summary.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/summary.py
@@ -240,6 +240,10 @@ class Summary:
             batch_run_id = attributes[SpanAttributeFieldName.BATCH_RUN_ID]
             item.batch_run_id = batch_run_id
             item.line_number = line_number
+            # Use batch run id instead of name as key in evaluations dict.
+            # Customer may run the same evaluation flow multiple times target a batch run, we should be able to
+            # save all evaluations.
+            name = batch_run_id
 
         patch_operations = [{"op": "add", "path": f"/evaluations/{name}", "value": asdict(item)}]
         self.logger.info(f"Insert evaluation for LineSummary main_id: {main_id}")

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_summary.py
@@ -224,9 +224,7 @@ class TestSummary:
             name=self.summary.span.name,
             created_by=self.FAKE_CREATED_BY,
         )
-        expected_patch_operations = [
-            {"op": "add", "path": f"/evaluations/{self.summary.span.name}", "value": asdict(expected_item)}
-        ]
+        expected_patch_operations = [{"op": "add", "path": "/evaluations/batch_run_id", "value": asdict(expected_item)}]
         client.patch_item.assert_called_once_with(
             item="main_id",
             partition_key="test_main_partition_key",


### PR DESCRIPTION
# Description

Use batch run id as evaluation dict's key for batch run.
https://int.ml.azure.com/prompts/trace/list?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourceGroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/promptflow-canary-dev&searchText={%22batchRunId%22:%22test_main_variant_0_20240401_095544_611576%22}&tid=72f988bf-86f1-41af-91ab-2d7cd011db47
Current UX can't show eval output in LineSummary list after this change.
Because UX will update to new UI soon, we accept this breaking change.
![image](https://github.com/microsoft/promptflow/assets/17527303/7bad359e-b619-43a6-aad2-fd62a9462167)
![image](https://github.com/microsoft/promptflow/assets/17527303/e14800b7-3584-4b9b-8dd2-3a5daa9eb251)


# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
