### PR TITLE
Fix multimedia_utils.

### DIFF
--- a/src/promptflow-core/promptflow/_utils/multimedia_utils.py
+++ b/src/promptflow-core/promptflow/_utils/multimedia_utils.py
@@ -209,7 +209,7 @@ class MultimediaProcessor(ABC):
         return image_reference
 
     def get_file_reference_encoder(
-        self, folder_path: Path, relative_path: Path = None, *, use_absolute_path=False
+        self, folder_path: Path, relative_path: Path = None, use_absolute_path=False
     ) -> Callable:
         def pfbytes_file_reference_encoder(obj):
             """Dumps PFBytes to a file and returns its reference."""
@@ -253,11 +253,9 @@ class MultimediaProcessor(ABC):
             for check_func, process_func in process_funcs.items():
                 if check_func(value):
                     return process_func(value)
-                else:
-                    return {
-                        k: MultimediaProcessor._process_multimedia_dict_recursively(v, process_funcs)
-                        for k, v in value.items()
-                    }
+            return {
+                k: MultimediaProcessor._process_multimedia_dict_recursively(v, process_funcs) for k, v in value.items()
+            }
         else:
             return value
 
@@ -489,11 +487,19 @@ class OpenaiVisionMultimediaProcessor(MultimediaProcessor):
 
 # TODO：Runtime relies on these old interfaces and will be removed in the future.
 def persist_multimedia_data(
-    value: Any, base_dir: Path, sub_dir: Path = None, multimedia_processor: MultimediaProcessor = None
+    value: Any,
+    base_dir: Path,
+    sub_dir: Path = None,
+    use_absolute_path=False,
+    multimedia_processor: MultimediaProcessor = None,
 ):
     if multimedia_processor:
-        return multimedia_processor.persist_multimedia_data(value, base_dir, sub_dir)
-    return BasicMultimediaProcessor().persist_multimedia_data(value, base_dir, sub_dir)
+        return multimedia_processor.persist_multimedia_data(
+            value, base_dir, sub_dir, use_absolute_path=use_absolute_path
+        )
+    return BasicMultimediaProcessor().persist_multimedia_data(
+        value, base_dir, sub_dir, use_absolute_path=use_absolute_path
+    )
 
 
 def load_multimedia_data_recursively(value: Any, multimedia_processor: MultimediaProcessor = None):

--- a/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_multimedia_utils.py
@@ -163,22 +163,32 @@ class TestMultimediaProcessor:
         assert isinstance(processor, processor_class)
 
     def test_process_multimedia_dict_recursively(self):
-        def process_func(image_dict):
+        def process_func_image(image_dict):
             return "image_placeholder"
 
+        def process_func_text(text_dict):
+            return "text_placeholder"
+
         image_dict = {"data:image/jpg;path": "logo.jpg"}
+        text_dict = {"type": "text", "text": "Hello, World!"}
         value = {
             "image": image_dict,
+            "text": text_dict,
             "images": [image_dict, image_dict],
-            "object": {"image": image_dict, "other_data": "other_data"},
+            "object": {"image": image_dict, "text": text_dict, "other_data": "other_data"},
         }
         updated_value = MultimediaProcessor._process_multimedia_dict_recursively(
-            value, {BasicMultimediaProcessor.is_multimedia_dict: process_func}
+            value,
+            {
+                BasicMultimediaProcessor.is_multimedia_dict: process_func_image,
+                TextProcessor.is_text_dict: process_func_text,
+            },
         )
         assert updated_value == {
             "image": "image_placeholder",
+            "text": "text_placeholder",
             "images": ["image_placeholder", "image_placeholder"],
-            "object": {"image": "image_placeholder", "other_data": "other_data"},
+            "object": {"image": "image_placeholder", "text": "text_placeholder", "other_data": "other_data"},
         }
 
 


### PR DESCRIPTION
# Description
Fix some bugs caused by this pr  https://github.com/microsoft/promptflow/pull/2287
1. Fix MultimediaProcessor._process_multimedia_dict_recursively.
2. Because this pr 2287 fully refactored multimedia_utils, some changes made to the file by others during development were ignored. Specific changes:
  - https://github.com/microsoft/promptflow/pull/2122
  - Remove `*,` for `get_file_reference_encoder` method.
  - Add parameter: `use_absolute_path` for `persist_multimedia_data` method.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
