### PR TITLE
[tracing][bugfix] Use eval run name instead of root span name

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_trace.py
@@ -457,10 +457,7 @@ class LineRun:
         for evaluation in evaluations:
             if self.evaluations is None:
                 self.evaluations = dict()
-            # # TODO: 3050320 - make evaluation name equal to batch run name
-            # #       need to update this once UX update their logic
-            # eval_name = evaluation.run if evaluation.run is not None else evaluation.name
-            eval_name = evaluation.name
+            eval_name = evaluation.run if evaluation.run is not None else evaluation.name
             self.evaluations[eval_name] = evaluation
 
     def _to_rest_object(self) -> typing.Dict:


### PR DESCRIPTION
# Description

For eval line run(s), use run name, instead of root span name.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
