### PR TITLE
Force flush traces for execute_flow

### DIFF
--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -16,6 +16,7 @@ from threading import current_thread
 from types import GeneratorType
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple
 
+import opentelemetry.trace as otel_trace
 from opentelemetry.trace.status import StatusCode
 
 from promptflow._constants import LINE_NUMBER_KEY
@@ -1335,32 +1336,39 @@ def execute_flow(
     """
     flow_executor = FlowExecutor.create(flow_file, connections, working_dir, raise_ex=False, **kwargs)
     flow_executor.enable_streaming_for_llm_flow(lambda: enable_stream_output)
-    with _change_working_dir(working_dir):
-        # Execute nodes in the flow except the aggregation nodes
-        # TODO: remove index=0 after UX no longer requires a run id similar to batch runs
-        # (run_id_index, eg. xxx_0) for displaying the interface
-        line_result = flow_executor.exec_line(
-            inputs, index=0, allow_generator_output=allow_generator_output, run_id=run_id
-        )
-        # persist the output to the output directory
-        line_result.output = flow_executor._multimedia_processor.persist_multimedia_data(
-            line_result.output, base_dir=working_dir, sub_dir=output_dir
-        )
-        if run_aggregation and line_result.aggregation_inputs:
-            # Convert inputs of aggregation to list type
-            flow_inputs = {k: [v] for k, v in inputs.items()}
-            aggregation_inputs = {k: [v] for k, v in line_result.aggregation_inputs.items()}
-            aggregation_results = flow_executor.exec_aggregation(
-                flow_inputs, aggregation_inputs=aggregation_inputs, run_id=run_id
+    try:
+        with _change_working_dir(working_dir):
+            # Execute nodes in the flow except the aggregation nodes
+            # TODO: remove index=0 after UX no longer requires a run id similar to batch runs
+            # (run_id_index, eg. xxx_0) for displaying the interface
+            line_result = flow_executor.exec_line(
+                inputs, index=0, allow_generator_output=allow_generator_output, run_id=run_id
             )
-            line_result.node_run_infos = {**line_result.node_run_infos, **aggregation_results.node_run_infos}
-            line_result.run_info.metrics = aggregation_results.metrics
-            # The aggregation inputs of line results is not utilized in the flow test. So we set it into None.
-            line_result.aggregation_inputs = None
-        if isinstance(line_result.output, dict):
-            # remove line_number from output
-            line_result.output.pop(LINE_NUMBER_KEY, None)
-        return line_result
+            # persist the output to the output directory
+            line_result.output = flow_executor._multimedia_processor.persist_multimedia_data(
+                line_result.output, base_dir=working_dir, sub_dir=output_dir
+            )
+            if run_aggregation and line_result.aggregation_inputs:
+                # Convert inputs of aggregation to list type
+                flow_inputs = {k: [v] for k, v in inputs.items()}
+                aggregation_inputs = {k: [v] for k, v in line_result.aggregation_inputs.items()}
+                aggregation_results = flow_executor.exec_aggregation(
+                    flow_inputs, aggregation_inputs=aggregation_inputs, run_id=run_id
+                )
+                line_result.node_run_infos = {**line_result.node_run_infos, **aggregation_results.node_run_infos}
+                line_result.run_info.metrics = aggregation_results.metrics
+                # The aggregation inputs of line results is not utilized in the flow test. So we set it into None.
+                line_result.aggregation_inputs = None
+            if isinstance(line_result.output, dict):
+                # remove line_number from output
+                line_result.output.pop(LINE_NUMBER_KEY, None)
+            return line_result
+    finally:
+        try:
+            # Force flush the tracer provider to ensure all spans are exported before the process exits.
+            otel_trace.get_tracer_provider().force_flush()
+        except Exception as e:
+            flow_logger.warning(f"Error occurred while force flush tracer provider: {e}")
 
 
 def signal_handler(sig, frame):

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -11,6 +11,7 @@ import os
 import signal
 import threading
 import uuid
+from contextlib import contextmanager
 from pathlib import Path
 from threading import current_thread
 from types import GeneratorType
@@ -1336,33 +1337,38 @@ def execute_flow(
     """
     flow_executor = FlowExecutor.create(flow_file, connections, working_dir, raise_ex=False, **kwargs)
     flow_executor.enable_streaming_for_llm_flow(lambda: enable_stream_output)
+    with _change_working_dir(working_dir), _force_flush_tracer_provider():
+        # Execute nodes in the flow except the aggregation nodes
+        # TODO: remove index=0 after UX no longer requires a run id similar to batch runs
+        # (run_id_index, eg. xxx_0) for displaying the interface
+        line_result = flow_executor.exec_line(
+            inputs, index=0, allow_generator_output=allow_generator_output, run_id=run_id
+        )
+        # persist the output to the output directory
+        line_result.output = flow_executor._multimedia_processor.persist_multimedia_data(
+            line_result.output, base_dir=working_dir, sub_dir=output_dir
+        )
+        if run_aggregation and line_result.aggregation_inputs:
+            # Convert inputs of aggregation to list type
+            flow_inputs = {k: [v] for k, v in inputs.items()}
+            aggregation_inputs = {k: [v] for k, v in line_result.aggregation_inputs.items()}
+            aggregation_results = flow_executor.exec_aggregation(
+                flow_inputs, aggregation_inputs=aggregation_inputs, run_id=run_id
+            )
+            line_result.node_run_infos = {**line_result.node_run_infos, **aggregation_results.node_run_infos}
+            line_result.run_info.metrics = aggregation_results.metrics
+            # The aggregation inputs of line results is not utilized in the flow test. So we set it into None.
+            line_result.aggregation_inputs = None
+        if isinstance(line_result.output, dict):
+            # remove line_number from output
+            line_result.output.pop(LINE_NUMBER_KEY, None)
+        return line_result
+
+
+@contextmanager
+def _force_flush_tracer_provider():
     try:
-        with _change_working_dir(working_dir):
-            # Execute nodes in the flow except the aggregation nodes
-            # TODO: remove index=0 after UX no longer requires a run id similar to batch runs
-            # (run_id_index, eg. xxx_0) for displaying the interface
-            line_result = flow_executor.exec_line(
-                inputs, index=0, allow_generator_output=allow_generator_output, run_id=run_id
-            )
-            # persist the output to the output directory
-            line_result.output = flow_executor._multimedia_processor.persist_multimedia_data(
-                line_result.output, base_dir=working_dir, sub_dir=output_dir
-            )
-            if run_aggregation and line_result.aggregation_inputs:
-                # Convert inputs of aggregation to list type
-                flow_inputs = {k: [v] for k, v in inputs.items()}
-                aggregation_inputs = {k: [v] for k, v in line_result.aggregation_inputs.items()}
-                aggregation_results = flow_executor.exec_aggregation(
-                    flow_inputs, aggregation_inputs=aggregation_inputs, run_id=run_id
-                )
-                line_result.node_run_infos = {**line_result.node_run_infos, **aggregation_results.node_run_infos}
-                line_result.run_info.metrics = aggregation_results.metrics
-                # The aggregation inputs of line results is not utilized in the flow test. So we set it into None.
-                line_result.aggregation_inputs = None
-            if isinstance(line_result.output, dict):
-                # remove line_number from output
-                line_result.output.pop(LINE_NUMBER_KEY, None)
-            return line_result
+        yield
     finally:
         try:
             # Force flush the tracer provider to ensure all spans are exported before the process exits.


### PR DESCRIPTION
# Description

Add trace force flush for `execute_flow`.
For multi container scenario, we may fail to export traces because process terminated directly.

Why we need to manually invoke force flush:
Seems like when we create worker process by `invoke_sync_function_in_process`, the atexit method registered by tracer provider is not invoked. Fix this issue by adding force flush first, it's recommended by GPT to handle it manually for multi process scenario.

Why use force flush but not shutdown:
In case of customer execute_flow manually in their code.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
