### PR TITLE
[test][bugfix] Add tracer provider reset fixture

### DIFF
--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_experiment.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_experiment.py
@@ -261,6 +261,12 @@ class TestExperiment:
             # Assert eval metric exists
             assert (expected_output_path / "eval" / "flow.metrics.json").exists()
             # Assert session exists
+            # traces need some time to be collected and persisted in the database
+            for _ in range(10):
+                line_runs = client.traces.list_line_runs(collection=session)
+                if len(line_runs) > 0:
+                    break
+                sleep(5)
             line_runs = client.traces.list_line_runs(collection=session)
             assert len(line_runs) == 1
             line_run = line_runs[0]


### PR DESCRIPTION
# Description

Tracer provider might be polluted during the test, this pr introduces a new fixture to reset.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
