### PR TITLE
[devkit][refactor] Move protobuf span parse function to trace operation

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_service/apis/collector.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/apis/collector.py
@@ -22,6 +22,7 @@ from promptflow._constants import CosmosDBContainerName, SpanResourceAttributesF
 from promptflow._sdk._constants import TRACE_DEFAULT_COLLECTION
 from promptflow._sdk._utils import parse_kv_from_pb_attribute
 from promptflow._sdk.entities._trace import Span
+from promptflow._sdk.operations._trace_operations import TraceOperations
 from promptflow._utils.thread_utils import ThreadWithContextVars
 
 
@@ -66,10 +67,11 @@ def trace_collector(
             for scope_span in resource_span.scope_spans:
                 for span in scope_span.spans:
                     # TODO: persist with batch
-                    span = Span._from_protobuf_object(span, resource=resource, logger=logger)
+                    span: Span = TraceOperations._parse_protobuf_span(span, resource=resource, logger=logger)
                     if not cloud_trace_only:
                         all_spans.append(copy.deepcopy(span))
                         span._persist()
+                        logger.debug("Persisted trace id: %s, span id: %s", span.trace_id, span.span_id)
                     else:
                         all_spans.append(span)
 

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
@@ -3,8 +3,20 @@
 # ---------------------------------------------------------
 
 import datetime
+import json
+import logging
 import typing
 
+from google.protobuf.json_format import MessageToJson
+from opentelemetry.proto.trace.v1.trace_pb2 import Span as PBSpan
+
+from promptflow._constants import (
+    SpanContextFieldName,
+    SpanEventFieldName,
+    SpanFieldName,
+    SpanLinkFieldName,
+    SpanStatusFieldName,
+)
 from promptflow._sdk._constants import TRACE_DEFAULT_COLLECTION
 from promptflow._sdk._orm.retry import sqlite_retry
 from promptflow._sdk._orm.session import trace_mgmt_db_session
@@ -12,6 +24,11 @@ from promptflow._sdk._orm.trace import Event as ORMEvent
 from promptflow._sdk._orm.trace import LineRun as ORMLineRun
 from promptflow._sdk._orm.trace import Span as ORMSpan
 from promptflow._sdk._telemetry import ActivityType, monitor_operation
+from promptflow._sdk._utils import (
+    convert_time_unix_nano_to_timestamp,
+    flatten_pb_attributes,
+    parse_otel_span_status_code,
+)
 from promptflow._sdk.entities._trace import Event, LineRun, Span
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow.exceptions import UserErrorException
@@ -20,6 +37,83 @@ from promptflow.exceptions import UserErrorException
 class TraceOperations:
     def __init__(self):
         self._logger = get_cli_sdk_logger()
+
+    def _parse_protobuf_events(obj: typing.List[PBSpan.Event], logger: logging.Logger) -> typing.List[typing.Dict]:
+        events = []
+        if len(obj) == 0:
+            logger.debug("No events found in span")
+            return events
+        for pb_event in obj:
+            event_dict: dict = json.loads(MessageToJson(pb_event))
+            logger.debug("Received event: %s", json.dumps(event_dict))
+            event = {
+                SpanEventFieldName.NAME: pb_event.name,
+                # .isoformat() here to make this dumpable to JSON
+                SpanEventFieldName.TIMESTAMP: convert_time_unix_nano_to_timestamp(pb_event.time_unix_nano).isoformat(),
+                SpanEventFieldName.ATTRIBUTES: flatten_pb_attributes(
+                    event_dict.get(SpanEventFieldName.ATTRIBUTES, dict())
+                ),
+            }
+            events.append(event)
+        return events
+
+    def _parse_protobuf_links(obj: typing.List[PBSpan.Link], logger: logging.Logger) -> typing.List[typing.Dict]:
+        links = []
+        if len(obj) == 0:
+            logger.debug("No links found in span")
+            return links
+        for pb_link in obj:
+            link_dict: dict = json.loads(MessageToJson(pb_link))
+            logger.debug("Received link: %s", json.dumps(link_dict))
+            link = {
+                SpanLinkFieldName.CONTEXT: {
+                    SpanContextFieldName.TRACE_ID: pb_link.trace_id.hex(),
+                    SpanContextFieldName.SPAN_ID: pb_link.span_id.hex(),
+                    SpanContextFieldName.TRACE_STATE: pb_link.trace_state,
+                },
+                SpanLinkFieldName.ATTRIBUTES: flatten_pb_attributes(
+                    link_dict.get(SpanLinkFieldName.ATTRIBUTES, dict())
+                ),
+            }
+            links.append(link)
+        return links
+
+    def _parse_protobuf_span(span: PBSpan, resource: typing.Dict, logger: logging.Logger) -> Span:
+        # Open Telemetry does not provide official way to parse Protocol Buffer Span object
+        # so we need to parse it manually relying on `MessageToJson`
+        # reference: https://github.com/open-telemetry/opentelemetry-python/issues/3700#issuecomment-2010704554
+        span_dict: dict = json.loads(MessageToJson(span))
+        logger.debug("Received span: %s, resource: %s", json.dumps(span_dict), json.dumps(resource))
+        span_id = span.span_id.hex()
+        trace_id = span.trace_id.hex()
+        parent_id = span.parent_span_id.hex()
+        # we have observed in some scenarios, there is not `attributes` field
+        attributes = flatten_pb_attributes(span_dict.get(SpanFieldName.ATTRIBUTES, dict()))
+        links = TraceOperations._parse_protobuf_links(span.links, logger)
+        events = TraceOperations._parse_protobuf_events(span.events, logger)
+
+        return Span(
+            trace_id=trace_id,
+            span_id=span_id,
+            name=span.name,
+            context={
+                SpanContextFieldName.TRACE_ID: trace_id,
+                SpanContextFieldName.SPAN_ID: span_id,
+                SpanContextFieldName.TRACE_STATE: span.trace_state,
+            },
+            kind=span.kind,
+            parent_id=parent_id if parent_id else None,
+            start_time=convert_time_unix_nano_to_timestamp(span.start_time_unix_nano),
+            end_time=convert_time_unix_nano_to_timestamp(span.end_time_unix_nano),
+            status={
+                SpanStatusFieldName.STATUS_CODE: parse_otel_span_status_code(span.status.code),
+                SpanStatusFieldName.DESCRIPTION: span.status.message,
+            },
+            attributes=attributes,
+            links=links,
+            events=events,
+            resource=resource,
+        )
 
     def get_event(self, event_id: str) -> typing.Dict:
         return Event.get(event_id=event_id)

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
@@ -89,6 +89,7 @@ class TraceOperations:
         parent_id = span.parent_span_id.hex()
         # we have observed in some scenarios, there is not `attributes` field
         attributes = flatten_pb_attributes(span_dict.get(SpanFieldName.ATTRIBUTES, dict()))
+        logger.debug("Parsed attributes: %s", json.dumps(attributes))
         links = TraceOperations._parse_protobuf_links(span.links, logger)
         events = TraceOperations._parse_protobuf_events(span.events, logger)
 

--- a/src/promptflow/tests/sdk_cli_test/unittests/test_trace.py
+++ b/src/promptflow/tests/sdk_cli_test/unittests/test_trace.py
@@ -31,7 +31,7 @@ from promptflow._sdk._constants import (
     ContextAttributeKey,
 )
 from promptflow._sdk._tracing import start_trace_with_devkit
-from promptflow._sdk.entities._trace import Span
+from promptflow._sdk.operations._trace_operations import TraceOperations
 from promptflow.client import PFClient
 from promptflow.exceptions import UserErrorException
 from promptflow.tracing._operation_context import OperationContext
@@ -128,7 +128,7 @@ class TestStartTrace:
         pb_span.parent_span_id = base64.b64decode("C+++WS+OuxI=")
         pb_span.kind = PBSpan.SpanKind.SPAN_KIND_INTERNAL
         # below line should execute successfully
-        span = Span._from_protobuf_object(pb_span, resource=mock_resource, logger=logging.getLogger(__name__))
+        span = TraceOperations._parse_protobuf_span(pb_span, resource=mock_resource, logger=logging.getLogger(__name__))
         # as the above span do not have any attributes, so the parsed span should not have any attributes
         assert isinstance(span.attributes, dict)
         assert len(span.attributes) == 0


### PR DESCRIPTION
# Description

This PR moves the functions that parse protobuf span/events/links from span entity to trace operations; **ALSO**, pass logger along with these functions so that we can have more logs during parse, and we can know more when OTLP trace collector in PFS - which can make debug easier in the future.

**what will be printed in PFS debug logs**

![image](https://github.com/microsoft/promptflow/assets/38847871/f5ccac9a-8888-4c03-a0f3-7ad739be41a3)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
