### PR TITLE
[devkit] Refine CLI `pf trace delete` experience

### DIFF
--- a/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
+++ b/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
@@ -5,8 +5,8 @@
 import argparse
 import typing
 
-from promptflow._cli._params import base_params
-from promptflow._cli._utils import activate_action
+from promptflow._cli._params import add_param_yes, base_params
+from promptflow._cli._utils import activate_action, confirm
 from promptflow._sdk._pf_client import PFClient
 
 _client: typing.Optional[PFClient] = None
@@ -63,6 +63,7 @@ pf trace delete --collection <collection> --started-before '2024-03-19T15:17:23.
         _add_param_run,
         _add_param_collection,
         _add_param_started_before,
+        add_param_yes,
     ] + base_params
     activate_action(
         name="delete",
@@ -76,7 +77,21 @@ pf trace delete --collection <collection> --started-before '2024-03-19T15:17:23.
 
 
 def delete_trace(args: argparse.Namespace) -> None:
-    _get_pf_client().traces.delete(
+    skip_confirm = args.yes
+    client = _get_pf_client()
+    if skip_confirm:
+        num_traces = client.traces.delete(
+            run=args.run,
+            collection=args.collection,
+            started_before=args.started_before,
+            dry_run=True,
+        )
+        prompt_msg = f"This delete operation will delete {num_traces} traces permanently, " "are you sure to continue?"
+        if not confirm(prompt_msg):
+            print("The delete operation is canceled.")
+            return
+
+    client.traces.delete(
         run=args.run,
         collection=args.collection,
         started_before=args.started_before,

--- a/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
+++ b/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
@@ -91,9 +91,9 @@ def delete_trace(args: argparse.Namespace) -> None:
             print("The delete operation is canceled.")
             return
 
-    client.traces.delete(
+    num_traces = client.traces.delete(
         run=args.run,
         collection=args.collection,
         started_before=args.started_before,
     )
-    print("Delete traces successfully.")
+    print(f"Delete {num_traces} traces successfully.")

--- a/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
+++ b/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
@@ -96,3 +96,4 @@ def delete_trace(args: argparse.Namespace) -> None:
         collection=args.collection,
         started_before=args.started_before,
     )
+    print("Delete traces successfully.")

--- a/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
+++ b/src/promptflow-devkit/promptflow/_cli/_pf/_trace.py
@@ -79,7 +79,7 @@ pf trace delete --collection <collection> --started-before '2024-03-19T15:17:23.
 def delete_trace(args: argparse.Namespace) -> None:
     skip_confirm = args.yes
     client = _get_pf_client()
-    if skip_confirm:
+    if not skip_confirm:
         num_traces = client.traces.delete(
             run=args.run,
             collection=args.collection,
@@ -87,7 +87,7 @@ def delete_trace(args: argparse.Namespace) -> None:
             dry_run=True,
         )
         prompt_msg = f"This delete operation will delete {num_traces} traces permanently, " "are you sure to continue?"
-        if not confirm(prompt_msg):
+        if not confirm(prompt_msg, skip_confirm=False):
             print("The delete operation is canceled.")
             return
 

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
@@ -172,6 +172,7 @@ class TraceOperations:
             'Valid delete queries: 1) specify `run`; 2) specify `collection` (not "default"); '
             "3) specify `collection` and `started_before` (ISO 8601)."
         )
+        self._logger.error(error_message)
         raise UserErrorException(error_message)
 
     @sqlite_retry

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
@@ -100,7 +100,7 @@ class TraceOperations:
         collection: typing.Optional[str] = None,
         started_before: typing.Optional[typing.Union[str, datetime.datetime]] = None,
         **kwargs,
-    ) -> typing.Optional[int]:
+    ) -> int:
         """Delete traces permanently.
 
         Support delete according to:
@@ -122,7 +122,7 @@ class TraceOperations:
         :param dry_run: If True, will not perform real deletion.
         :type dry_run: bool
         :return: Number of traces to delete, only return in dry run mode.
-        :rtype: Optional[int]
+        :rtype: int
         """
         dry_run = kwargs.get("dry_run", False)
         self._logger.debug(
@@ -182,7 +182,7 @@ class TraceOperations:
         collection: typing.Optional[str] = None,
         started_before: typing.Optional[datetime.datetime] = None,
         dry_run: bool = False,
-    ) -> typing.Optional[int]:
+    ) -> int:
         # delete will occur across 3 tables: line_runs, spans and events
         # which be done in a transaction
         from sqlalchemy.orm import Query
@@ -207,5 +207,5 @@ class TraceOperations:
             span_cnt = session.query(ORMSpan).filter(ORMSpan.trace_id.in_(trace_ids)).delete()
             line_run_cnt = query.delete()
             session.commit()
-
         self._logger.debug("deleted %d line runs, %d spans, and %d events", line_run_cnt, span_cnt, event_cnt)
+        return len(trace_ids)

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_trace.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_trace.py
@@ -247,6 +247,12 @@ class TestTraceEntitiesAndOperations:
         pf.traces.delete(collection=collection2, started_before=delete_query_time.isoformat())
         assert len(pf.traces.list_line_runs(collection=collection2)) == 0
 
+    def test_delete_traces_dry_run(self, pf: PFClient) -> None:
+        mock_run = str(uuid.uuid4())
+        mock_span_for_delete_tests(run=mock_run)
+        num_traces = pf.traces.delete(run=mock_run, dry_run=True)
+        assert num_traces == 1
+
 
 @pytest.mark.usefixtures("use_secrets_config_file", "recording_injection", "setup_local_connection")
 @pytest.mark.e2etest


### PR DESCRIPTION
# Description

This PR targets to refine the experience on CLI command `pf trace delete`:

- Prompt how many traces will be deleted with the given parameters
- Print error message when parameters are wrongly specified

![image](https://github.com/microsoft/promptflow/assets/38847871/9aa80955-7db3-489c-bc41-43a9a330379b)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
