### PR TITLE
[Internal] Add CosmosDBContainerName to promptflow._internal

### DIFF
--- a/src/promptflow-devkit/promptflow/_internal/__init__.py
+++ b/src/promptflow-devkit/promptflow/_internal/__init__.py
@@ -6,7 +6,12 @@ __path__ = __import__("pkgutil").extend_path(__path__, __name__)  # type: ignore
 # flake8: noqa
 
 """Put some imports here for internal packages to minimize the effort of refactoring."""
-from promptflow._constants import PROMPTFLOW_CONNECTIONS, SpanAttributeFieldName, TraceEnvironmentVariableName
+from promptflow._constants import (
+    PROMPTFLOW_CONNECTIONS,
+    CosmosDBContainerName,
+    SpanAttributeFieldName,
+    TraceEnvironmentVariableName,
+)
 from promptflow._core._errors import GenerateMetaUserError, PackageToolNotFoundError, ToolExecutionError
 from promptflow._core.cache_manager import AbstractCacheManager, CacheManager, enable_cache
 from promptflow._core.connection_manager import ConnectionManager
@@ -45,6 +50,7 @@ from promptflow._proxy._base_executor_proxy import APIBasedExecutorProxy
 from promptflow._proxy._csharp_executor_proxy import CSharpBaseExecutorProxy
 from promptflow._sdk._constants import LOCAL_MGMT_DB_PATH, CreatedByFieldName
 from promptflow._sdk._service.apis.collector import trace_collector
+from promptflow._sdk._version import VERSION
 from promptflow._utils.context_utils import _change_working_dir, inject_sys_path
 from promptflow._utils.credential_scrubber import CredentialScrubber
 from promptflow._utils.dataclass_serializer import deserialize_dataclass
@@ -93,7 +99,6 @@ from promptflow._utils.utils import (
     set_context,
     transpose,
 )
-from promptflow._sdk._version import VERSION
 from promptflow.core._serving.response_creator import ResponseCreator
 from promptflow.core._serving.swagger import generate_swagger
 from promptflow.core._serving.utils import (


### PR DESCRIPTION
# Description

Add CosmosDBContainerName to promptflow._internal for runtime to use. This is for checking if the db has init.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
