### PR TITLE
Fix the Openai init Union issue and import ServerlessConnection issue

### DIFF
--- a/src/promptflow-core/promptflow/executor/_tool_resolver.py
+++ b/src/promptflow-core/promptflow/executor/_tool_resolver.py
@@ -5,6 +5,7 @@
 import copy
 import inspect
 import types
+import logging
 from dataclasses import dataclass
 from functools import partial
 from pathlib import Path
@@ -515,7 +516,7 @@ class ToolResolver:
                         f"Invalid connection '{node.connection}' type {type(connection).__name__!r} "
                         f"for node '{node.name}', valid types {input.type}."
                     )
-                    raise InvalidConnectionType(message=msg)
+                    logging.warning(msg)
                 return key, connection
         raise InvalidConnectionType(
             message_format="Connection type can not be resolved for tool {tool_name}", tool_name=tool.name

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -569,7 +569,7 @@ def normalize_connection_config(connection):
             "base_url": connection.base_url
         }
     
-
+    # For old promptflow package, there is NO ServerlessConnection, so here add try
     try:
         from promptflow.connections import ServerlessConnection
         if isinstance(connection, ServerlessConnection):
@@ -591,6 +591,9 @@ def normalize_connection_config(connection):
     raise InvalidConnectionType(message=error_message)
 
 
+# Here the connection type should be Union[OpenAIConnection, ServerlessConnection]
+# But in order to compatible with old version (<=1.7.0) promptflow package, not add the ServerlessConnection here,
+# since there is NO ServerlessConnection in old promptflow package
 def init_openai_client(connection: OpenAIConnection):
     try:
         from openai import OpenAI as OpenAIClient

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -4,7 +4,7 @@ import os
 import re
 import sys
 import time
-from typing import List, Mapping, Union
+from typing import List, Mapping
 
 from jinja2 import Template
 from openai import APIConnectionError, APIStatusError, OpenAIError, RateLimitError, APITimeoutError, BadRequestError
@@ -13,7 +13,7 @@ from promptflow.tools.exception import ChatAPIInvalidRole, WrappedOpenAIError, L
     ChatAPIFunctionRoleInvalidFormat, InvalidConnectionType, ListDeploymentsError, ParseConnectionError
 
 from promptflow._cli._utils import get_workspace_triad_from_local
-from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
+from promptflow.connections import AzureOpenAIConnection, OpenAIConnection
 from promptflow.exceptions import SystemErrorException, UserErrorException
 
 
@@ -568,24 +568,30 @@ def normalize_connection_config(connection):
             "organization": connection.organization,
             "base_url": connection.base_url
         }
-    elif isinstance(connection, ServerlessConnection):
-        suffix = "/v1"
-        base_url = connection.api_base
-        if not base_url.endswith(suffix):
-            # append "/v1" to ServerlessConnection api_base so that it can directly use the OpenAI SDK.
-            base_url += suffix
-        return {
-            "max_retries": 0,
-            "api_key": connection.api_key,
-            "base_url": base_url
-        }
-    else:
-        error_message = f"Not Support connection type '{type(connection).__name__}'. " \
-                        f"Connection type should be in [AzureOpenAIConnection, OpenAIConnection]."
-        raise InvalidConnectionType(message=error_message)
+    
+
+    try:
+        from promptflow.connections import ServerlessConnection
+        if isinstance(connection, ServerlessConnection):
+            suffix = "/v1"
+            base_url = connection.api_base
+            if not base_url.endswith(suffix):
+                # append "/v1" to ServerlessConnection api_base so that it can directly use the OpenAI SDK.
+                base_url += suffix
+            return {
+                "max_retries": 0,
+                "api_key": connection.api_key,
+                "base_url": base_url
+            }
+    except ImportError:
+        pass
+
+    error_message = f"Not Support connection type '{type(connection).__name__}'. " \
+                    f"Connection type should be in [AzureOpenAIConnection, OpenAIConnection]."
+    raise InvalidConnectionType(message=error_message)
 
 
-def init_openai_client(connection: Union[OpenAIConnection, ServerlessConnection]):
+def init_openai_client(connection: OpenAIConnection):
     try:
         from openai import OpenAI as OpenAIClient
     except ImportError as e:

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -568,7 +568,7 @@ def normalize_connection_config(connection):
             "organization": connection.organization,
             "base_url": connection.base_url
         }
-    
+
     # For old promptflow package, there is NO ServerlessConnection, so here add try
     try:
         from promptflow.connections import ServerlessConnection

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -155,7 +155,7 @@ class OpenAI(ToolProvider):
 
 register_apis(OpenAI)
 
-# Hard code to register ServerlessConnection for OpenAI so that ServerlessConnection 
+# Hard code to register ServerlessConnection for OpenAI so that ServerlessConnection
 # can call into promptflow.tools.openai.Reason for this hard code:
 # In order to compatible with old version (<=1.7.0) promptflow package, since
 # the register_apis in the old version promptflow package doesn't support Union

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -8,6 +8,7 @@ from promptflow.tools.common import render_jinja_template, handle_openai_error, 
 from promptflow._internal import ToolProvider, tool, register_apis
 from promptflow.connections import OpenAIConnection
 from promptflow.contracts.types import PromptTemplate
+from promptflow._core.tools_manager import connection_type_to_api_mapping
 
 
 class Engine(str, Enum):
@@ -154,11 +155,10 @@ class OpenAI(ToolProvider):
 
 register_apis(OpenAI)
 
-# Hard code to register ServerlessConnection for OpenAI so that ServerlessConnection can call into promptflow.tools.openai
-# Reason for this hard code:
+# Hard code to register ServerlessConnection for OpenAI so that ServerlessConnection 
+# can call into promptflow.tools.openai.Reason for this hard code:
 # In order to compatible with old version (<=1.7.0) promptflow package, since
 # the register_apis in the old version promptflow package doesn't support Union
-from promptflow._core.tools_manager import connection_type_to_api_mapping
 connection_type_to_api_mapping["ServerlessConnection"] = "OpenAI"
 
 

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -22,6 +22,9 @@ class Engine(str, Enum):
 
 
 class OpenAI(ToolProvider):
+    # Here the connection type should be Union[OpenAIConnection, ServerlessConnection]
+    # But in order to compatible with old version (<=1.7.0) promptflow package, not add the ServerlessConnection here,
+    # since the register_apis in the old version promptflow package doesn't support Union
     def __init__(self, connection: OpenAIConnection):
         super().__init__()
         self._client = init_openai_client(connection)

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Union
 from promptflow.tools.common import render_jinja_template, handle_openai_error, \
     parse_chat, to_bool, validate_functions, process_function_call, \
     post_process_chat_api_response, init_openai_client
@@ -7,7 +6,7 @@ from promptflow.tools.common import render_jinja_template, handle_openai_error, 
 # Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
 # since the code here is in promptflow namespace as well
 from promptflow._internal import ToolProvider, tool, register_apis
-from promptflow.connections import OpenAIConnection, ServerlessConnection
+from promptflow.connections import OpenAIConnection
 from promptflow.contracts.types import PromptTemplate
 
 
@@ -23,7 +22,7 @@ class Engine(str, Enum):
 
 
 class OpenAI(ToolProvider):
-    def __init__(self, connection: Union[OpenAIConnection, ServerlessConnection]):
+    def __init__(self, connection: OpenAIConnection):
         super().__init__()
         self._client = init_openai_client(connection)
 
@@ -151,6 +150,13 @@ class OpenAI(ToolProvider):
 
 
 register_apis(OpenAI)
+
+# Hard code to register ServerlessConnection for OpenAI so that ServerlessConnection can call into promptflow.tools.openai
+# Reason for this hard code:
+# In order to compatible with old version (<=1.7.0) promptflow package, since
+# the register_apis in the old version promptflow package doesn't support Union
+from promptflow._core.tools_manager import connection_type_to_api_mapping
+connection_type_to_api_mapping["ServerlessConnection"] = "OpenAI"
 
 
 @tool


### PR DESCRIPTION
Fix below two issues:
1. For old promptflow package, there is NO ServerlessConnection. So Add try for import ServerlessConnection.
2. For old promptflow package, the register_apis doesn't support Union input, so change the connection type to only contain OpenAIConnection and hard code ServerlessConnection into connection_type_to_api_mapping.

Test with promptflow 1.3.0 which doesn't have ServerlessConnection:
![image](https://github.com/microsoft/promptflow/assets/49388944/f211c7e6-2834-458d-84e2-d9c8413c3b41)
