### PR TITLE
Skip flushing if tracer provider doesn't have method

### DIFF
--- a/src/promptflow-core/promptflow/executor/_line_execution_process_pool.py
+++ b/src/promptflow-core/promptflow/executor/_line_execution_process_pool.py
@@ -748,7 +748,9 @@ def _exec_line_for_queue(
                         # Meet span missing issue when end process normally (even add wait() when end it).
                         # Shutdown the tracer provider to flush the remaining spans.
                         # The tracer provider is created for each process, so it's ok to shutdown it here.
-                        otel_trace.get_tracer_provider().shutdown()
+                        tracer_provider = otel_trace.get_tracer_provider()
+                        if hasattr(tracer_provider, "shutdown"):
+                            tracer_provider.shutdown()
                     except Exception as e:
                         bulk_logger.warning(f"Error occurred while shutting down tracer provider: {e}")
 

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -1380,7 +1380,9 @@ def _force_flush_tracer_provider():
     finally:
         try:
             # Force flush the tracer provider to ensure all spans are exported before the process exits.
-            otel_trace.get_tracer_provider().force_flush()
+            tracer_provider = otel_trace.get_tracer_provider()
+            if hasattr(tracer_provider, "force_flush"):
+                tracer_provider.force_flush()
         except Exception as e:
             flow_logger.warning(f"Error occurred while force flush tracer provider: {e}")
 


### PR DESCRIPTION
# Description

If customer don't use tracer provider, otel will return ProxyTracerProvider, which doesn't have `shutdown` `force_flush` method.

Add hasattr check to guarantee the tracer provider has necessary methods.

![image](https://github.com/microsoft/promptflow/assets/17527303/da0b9f7c-c864-4260-ac3c-b6fc1d55c380)

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
