### PR TITLE
fix: add codeowners for sdk

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -31,13 +31,16 @@
 /src/promptflow-core/promptflow/storage/ @microsoft/promptflow-execution
 /src/promptflow-devkit/promptflow/_internal/ @microsoft/promptflow-execution
 /src/promptflow-devkit/promptflow/batch/ @microsoft/promptflow-execution
-/src/promptflow-devkit/promptflow/_proxy/ @microsoft/promptflow-execution
-
 /src/promptflow/tests/executor/ @microsoft/promptflow-execution
+
+/src/promptflow-devkit/promptflow/_proxy/ @microsoft/promptflow-execution @microsoft/promptflow-sdk
+
 /src/promptflow/tests/sdk_cli_test/ @microsoft/promptflow-sdk
 /src/promptflow/tests/sdk_cli_azure_test/ @microsoft/promptflow-sdk
 /src/promptflow/tests/sdk_cli_global_config_test/ @microsoft/promptflow-sdk
 /src/promptflow/tests/sdk_pfs_test/ @microsoft/promptflow-sdk
+/src/promptflow/tests/executor/_prompty_executor.py @microsoft/promptflow-sdk
+/src/promptflow/tests/executor/_script_executor.py @microsoft/promptflow-sdk
+/src/promptflow-tracing/promptflow/tracing/_start_trace.py @microsoft/promptflow-sdk
 
 /docs/how-to-guides/develop-a-tool/ @microsoft/promptflow-tools
-/src/promptflow-tracing/promptflow/tracing/_start_trace.py @microsoft/promptflow-sdk

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -39,8 +39,8 @@
 /src/promptflow/tests/sdk_cli_azure_test/ @microsoft/promptflow-sdk
 /src/promptflow/tests/sdk_cli_global_config_test/ @microsoft/promptflow-sdk
 /src/promptflow/tests/sdk_pfs_test/ @microsoft/promptflow-sdk
-/src/promptflow/tests/executor/_prompty_executor.py @microsoft/promptflow-sdk
-/src/promptflow/tests/executor/_script_executor.py @microsoft/promptflow-sdk
+/src/promptflow/tests/executor/_prompty_executor.py @microsoft/promptflow-execution @microsoft/promptflow-sdk
+/src/promptflow/tests/executor/_script_executor.py @microsoft/promptflow-execution @microsoft/promptflow-sdk
 /src/promptflow-tracing/promptflow/tracing/_start_trace.py @microsoft/promptflow-sdk
 
 /docs/how-to-guides/develop-a-tool/ @microsoft/promptflow-tools


### PR DESCRIPTION
# Description

This pull request includes a few changes to the `.github/CODEOWNERS` file. The changes mostly involve reassigning code ownership for several directories and files within the `promptflow` project.

* `/src/promptflow-devkit/promptflow/_proxy/` has been reassigned from solely `@microsoft/promptflow-execution` to both `@microsoft/promptflow-execution` and `@microsoft/promptflow-sdk`.
* New ownership assignments have been added for the following files: 
  * `/src/promptflow/tests/executor/_prompty_executor.py` is now owned by `@microsoft/promptflow-sdk`.
  * `/src/promptflow/tests/executor/_script_executor.py` is now owned by `@microsoft/promptflow-sdk`.
  * `/src/promptflow-tracing/promptflow/tracing/_start_trace.py` is now owned by `@microsoft/promptflow-sdk`.
* The ownership assignment for `/src/promptflow-tracing/promptflow/tracing/_start_trace.py` to `@microsoft/promptflow-sdk` has been removed and readded, possibly to correct an ordering issue.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
