### PR TITLE
[Executor][Feature]Allow function/instance as the entry of script executor

### DIFF
--- a/src/promptflow-core/promptflow/executor/_script_executor.py
+++ b/src/promptflow-core/promptflow/executor/_script_executor.py
@@ -6,7 +6,7 @@ import uuid
 from dataclasses import is_dataclass
 from pathlib import Path
 from types import GeneratorType
-from typing import Any, Callable, Dict, Mapping, Optional
+from typing import Any, Callable, Dict, Mapping, Optional, Union
 
 from promptflow._constants import LINE_NUMBER_KEY, MessageFormatType
 from promptflow._core.log_manager import NodeLogManager
@@ -33,7 +33,7 @@ from .flow_executor import FlowExecutor
 class ScriptExecutor(FlowExecutor):
     def __init__(
         self,
-        flow_file: Path,
+        flow_file: Union[Path, str, Callable],
         connections: Optional[dict] = None,
         working_dir: Optional[Path] = None,
         *,
@@ -44,8 +44,13 @@ class ScriptExecutor(FlowExecutor):
         logger.debug(f"Init params for script executor: {init_kwargs}")
 
         self._flow_file = flow_file
+        entry = flow_file  # Entry could be both a path or a callable
+        self._entry = entry
         self._init_kwargs = init_kwargs or {}
-        self._working_dir = Flow._resolve_working_dir(flow_file, working_dir)
+        if isinstance(entry, (str, Path)):
+            self._working_dir = Flow._resolve_working_dir(entry, working_dir)
+        else:
+            self._working_dir = working_dir or Path.cwd()
         self._initialize_function()
         self._connections = connections
         self._storage = storage or DefaultRunStorage()
@@ -155,7 +160,15 @@ class ScriptExecutor(FlowExecutor):
             resolved_init_kwargs[key] = provider.get(init_kwargs[key])
         return resolved_init_kwargs
 
-    def _initialize_function(self):
+    @property
+    def is_function_entry(self):
+        return hasattr(self._entry, "__call__") or inspect.isfunction(self._entry)
+
+    def _parse_entry_func(self):
+        if self.is_function_entry:
+            if inspect.isfunction(self._entry):
+                return self._entry
+            return self._entry.__call__
         try:
             module_name, func_name = self._parse_flow_file()
             module = importlib.import_module(module_name)
@@ -185,10 +198,15 @@ class ScriptExecutor(FlowExecutor):
                 )
         elif func is None or not inspect.isfunction(func):
             raise PythonLoadError(
-                message_format="Failed to load python function '{func_name}' from file '{module_name}'.",
+                message_format="Failed to load python function '{func_name}' from file '{module_name}', got {func}.",
                 func_name=func_name,
                 module_name=module_name,
+                func=func,
             )
+        return func
+
+    def _initialize_function(self):
+        func = self._parse_entry_func()
         # If the function is not decorated with trace, add trace for it.
         if not hasattr(func, "__original_function"):
             func = _traced(func)

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -204,7 +204,7 @@ class FlowExecutor:
         :rtype: ~promptflow.executor.flow_executor.FlowExecutor
         """
         setup_exporter_from_environ()
-        if hasattr(flow_file, "__call__") or isfunction(flow_file):
+        if hasattr(flow_file, "__call__") or inspect.isfunction(flow_file):
             from ._script_executor import ScriptExecutor
 
             return ScriptExecutor(flow_file, storage=storage)

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -204,6 +204,12 @@ class FlowExecutor:
         :rtype: ~promptflow.executor.flow_executor.FlowExecutor
         """
         setup_exporter_from_environ()
+        if hasattr(flow_file, "__call__") or isfunction(flow_file):
+            from ._script_executor import ScriptExecutor
+
+            return ScriptExecutor(flow_file, storage=storage)
+        if not isinstance(flow_file, (Path, str)):
+            raise NotImplementedError("Only support Path or str for flow_file.")
         if is_flex_flow(file_path=flow_file, working_dir=working_dir):
             from ._script_executor import ScriptExecutor
 

--- a/src/promptflow-core/tests/core/e2etests/test_eager_flow.py
+++ b/src/promptflow-core/tests/core/e2etests/test_eager_flow.py
@@ -16,6 +16,15 @@ SAMPLE_EVAL_FLOW = "classification_accuracy_evaluation"
 SAMPLE_FLOW_WITH_PARTIAL_FAILURE = "python_tool_partial_failure"
 
 
+class ClassEntry:
+    def __call__(self, input_str: str) -> str:
+        return "Hello " + input_str
+
+
+def func_entry(input_str: str) -> str:
+    return "Hello " + input_str
+
+
 @pytest.mark.e2etest
 class TestEagerFlow:
     @pytest.mark.parametrize(
@@ -54,6 +63,16 @@ class TestEagerFlow:
         # run the same line again will get same output
         line_result2 = executor.exec_line(inputs=inputs, index=0)
         assert line_result1.output == line_result2.output
+
+    @pytest.mark.parametrize(
+        "entry, inputs, expected_output",
+        [(ClassEntry(), {"input_str": "world"}, "Hello world"), (func_entry, {"input_str": "world"}, "Hello world")],
+    )
+    def test_flow_run_with_function_entry(self, entry, inputs, expected_output):
+        executor = FlowExecutor.create(entry, {})
+        line_result = executor.exec_line(inputs=inputs)
+        assert line_result.run_info.status == Status.Completed
+        assert line_result.output == expected_output
 
     def test_flow_run_with_invalid_case(self):
         flow_folder = "dummy_flow_with_exception"

--- a/src/promptflow-devkit/promptflow/batch/_batch_engine.py
+++ b/src/promptflow-devkit/promptflow/batch/_batch_engine.py
@@ -2,13 +2,14 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 import asyncio
+import inspect
 import signal
 import threading
 import uuid
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Mapping, Optional, Type
+from typing import Any, Callable, Dict, List, Mapping, Optional, Type, Union
 
 from promptflow._constants import (
     LANGUAGE_KEY,
@@ -75,7 +76,7 @@ class BatchEngine:
 
     def __init__(
         self,
-        flow_file: Path,
+        flow_file: Union[Path, Callable],
         working_dir: Optional[Path] = None,
         *,
         connections: Optional[dict] = None,
@@ -108,8 +109,15 @@ class BatchEngine:
         :type kwargs: Any
         """
         self._flow_file = flow_file
-        self._working_dir = Flow._resolve_working_dir(flow_file, working_dir)
-        if is_prompty_flow(self._flow_file):
+        is_function_entry = hasattr(flow_file, "__call__") or inspect.isfunction(flow_file)
+        if is_function_entry:
+            self._working_dir = working_dir or Path.cwd()
+        else:
+            self._working_dir = Flow._resolve_working_dir(flow_file, working_dir)
+        if is_function_entry:
+            self._is_eager_flow = True
+            self._program_language = FlowLanguage.Python
+        elif is_prompty_flow(self._flow_file):
             self._is_eager_flow = True
             self._program_language = FlowLanguage.Python
         else:


### PR DESCRIPTION
# Description

Allow passing a function/callable instance to executor.

This pull request involves changes primarily in the `src/promptflow-core/promptflow/executor/_script_executor.py` and `src/promptflow-devkit/promptflow/batch/_batch_engine.py` files, with the goal of expanding the types of entries that can be accepted by the `ScriptExecutor` and `BatchEngine` classes, and updating the relevant methods to handle these new types. The changes also include additions to the test file `src/promptflow-core/tests/core/e2etests/test_eager_flow.py` to ensure the new functionality works as expected.

Here are the key changes:

Expanded Entry Types:

* [`src/promptflow-core/promptflow/executor/_script_executor.py`](diffhunk://#diff-ee8f37478601ef45fdb2e773f04b280f5912f43868da4d5f1c4cf888a9980ab4L36-R36): The `flow_file` parameter in the `ScriptExecutor` class's constructor can now accept a `Union` of `Path`, `str`, and `Callable` types. This change is reflected in the `__init__` method, where the handling of `flow_file` has been modified to accommodate these new types. [[1]](diffhunk://#diff-ee8f37478601ef45fdb2e773f04b280f5912f43868da4d5f1c4cf888a9980ab4L36-R36) [[2]](diffhunk://#diff-ee8f37478601ef45fdb2e773f04b280f5912f43868da4d5f1c4cf888a9980ab4R47-R53)
* [`src/promptflow-devkit/promptflow/batch/_batch_engine.py`](diffhunk://#diff-0c95dd2aaf088a46d489e437605bbaa71150175508828fc5bbd36b5e15f4b554L78-R79): Similarly, the `flow_file` parameter in the `BatchEngine` class's constructor can now accept a `Union` of `Path` and `Callable` types. The `__init__` method has been updated to handle these new types. [[1]](diffhunk://#diff-0c95dd2aaf088a46d489e437605bbaa71150175508828fc5bbd36b5e15f4b554L78-R79) [[2]](diffhunk://#diff-0c95dd2aaf088a46d489e437605bbaa71150175508828fc5bbd36b5e15f4b554R112-R120)

Modified Methods:

* [`src/promptflow-core/promptflow/executor/_script_executor.py`](diffhunk://#diff-ee8f37478601ef45fdb2e773f04b280f5912f43868da4d5f1c4cf888a9980ab4L158-R171): Several methods in the `ScriptExecutor` class have been modified to handle the expanded entry types. These include the `_initialize_function`, `_parse_entry_func`, and `is_function_entry` methods. [[1]](diffhunk://#diff-ee8f37478601ef45fdb2e773f04b280f5912f43868da4d5f1c4cf888a9980ab4L158-R171) [[2]](diffhunk://#diff-ee8f37478601ef45fdb2e773f04b280f5912f43868da4d5f1c4cf888a9980ab4L188-R209)
* [`src/promptflow-core/promptflow/executor/flow_executor.py`](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fR207-R212): The `create` method has been updated to handle the new entry types and return a `ScriptExecutor` object when the `flow_file` is a callable or function.

Test Additions:

* [`src/promptflow-core/tests/core/e2etests/test_eager_flow.py`](diffhunk://#diff-162af09d07468e1340c2e7487f5964c9c7a3a54ac6430f11429a788d09e597c4R67-R76): New tests have been added to ensure that the `FlowExecutor` works correctly when given a callable or function for the `flow_file` parameter.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
