### PR TITLE
[Internal] Init FlowRequestException with _inner_exception.

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_restclient/flow_service_caller.py
+++ b/src/promptflow-azure/promptflow/azure/_restclient/flow_service_caller.py
@@ -67,7 +67,8 @@ def _request_wrapper():
                     f"Status code: {e.status_code} \n"
                     f"Reason: {e.reason} \n"
                     f"Error message: {e.message} \n",
-                    privacy_info=[e.reason, e.message]
+                    privacy_info=[e.reason, e.message],
+                    error=e,
                 )
 
         return wrapper

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
@@ -808,10 +808,6 @@ class TestFlowRun:
             assert "customized error message" in str(e.value)
             # request id should be included in FlowRequestException
             assert f"request id: {pf.runs._service_caller._request_id}" in str(e.value)
-            inner_exception = e.inner_exception()
-            assert inner_exception is not None
-            assert isinstance(inner_exception, HttpResponseError)
-            assert inner_exception.message == "customized error message."
 
     def test_get_detail_against_partial_fail_run(self, pf, runtime: str, randstr: Callable[[str], str]) -> None:
         run = pf.run(
@@ -906,6 +902,12 @@ class TestFlowRun:
             assert len(request_ids) == 1
             # request id should be included in FlowRequestException
             assert f"request id: {pf.runs._service_caller._request_id}" in str(e.value)
+
+            inner_exception = e.value.inner_exception
+            assert inner_exception is not None
+            assert isinstance(inner_exception, HttpResponseError)
+            assert inner_exception.message == "customized error message."
+
 
     # it is a known issue that executor/runtime might write duplicate storage for line records,
     # this will lead to the lines that assert line count (`len(detail)`) fails.

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
@@ -808,7 +808,7 @@ class TestFlowRun:
             assert "customized error message" in str(e.value)
             # request id should be included in FlowRequestException
             assert f"request id: {pf.runs._service_caller._request_id}" in str(e.value)
-            inner_exception = e.inner_exception
+            inner_exception = e.inner_exception()
             assert inner_exception is not None
             assert isinstance(inner_exception, HttpResponseError)
             assert inner_exception.message == "customized error message."

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
@@ -908,7 +908,6 @@ class TestFlowRun:
             assert isinstance(inner_exception, HttpResponseError)
             assert inner_exception.message == "customized error message."
 
-
     # it is a known issue that executor/runtime might write duplicate storage for line records,
     # this will lead to the lines that assert line count (`len(detail)`) fails.
     @pytest.mark.xfail(reason="BUG 2819328: Duplicate line in flow artifacts jsonl", run=True, strict=False)

--- a/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/e2etests/test_run_operations.py
@@ -808,6 +808,10 @@ class TestFlowRun:
             assert "customized error message" in str(e.value)
             # request id should be included in FlowRequestException
             assert f"request id: {pf.runs._service_caller._request_id}" in str(e.value)
+            inner_exception = e.inner_exception
+            assert inner_exception is not None
+            assert isinstance(inner_exception, HttpResponseError)
+            assert inner_exception.message == "customized error message."
 
     def test_get_detail_against_partial_fail_run(self, pf, runtime: str, randstr: Callable[[str], str]) -> None:
         run = pf.run(


### PR DESCRIPTION
# Description

In this PR, we init FlowRequestException with _inner_exception by param error. 
And then, we can use e.inner_exception for error handling.

![image](https://github.com/microsoft/promptflow/assets/2418764/b60b19e5-6950-4136-afa7-4f709cfa7119)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
