### PR TITLE
fix serverless connection does not work issue

### DIFF
--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -715,6 +715,8 @@ def normalize_connection_config(connection):
     This function takes a connection object and normalizes its configuration,
     ensuring it is compatible and standardized for use.
     """
+    from promptflow.connections import ServerlessConnection
+
     if isinstance(connection, AzureOpenAIConnection):
         if connection.api_key:
             return {
@@ -739,9 +741,21 @@ def normalize_connection_config(connection):
             "organization": connection.organization,
             "base_url": connection.base_url
         }
+    elif isinstance(connection, ServerlessConnection):
+        suffix = "/v1"
+        base_url = connection.api_base
+        if not base_url.endswith(suffix):
+            # append "/v1" to ServerlessConnection api_base so that it can directly use the OpenAI SDK.
+            base_url += suffix
+        return {
+            "max_retries": 0,
+            "api_key": connection.api_key,
+            "base_url": base_url
+        }
     else:
         error_message = f"Not Support connection type '{type(connection).__name__}'. " \
-                        f"Connection type should be in [AzureOpenAIConnection, OpenAIConnection]."
+                        "Connection type should be in [AzureOpenAIConnection, OpenAIConnection, " \
+                        "ServerlessConnection]."
         raise InvalidConnectionType(message=error_message)
 
 

--- a/src/promptflow-tools/promptflow/tools/llm.py
+++ b/src/promptflow-tools/promptflow/tools/llm.py
@@ -1,4 +1,4 @@
-from typing import Union, List, Dict
+from typing import List, Dict
 
 from promptflow.tools.common import handle_openai_error, _get_credential
 from promptflow.tools.exception import InvalidConnectionType
@@ -28,7 +28,8 @@ def get_cloud_connection(connection_name, subscription_id, resource_group_name, 
     except Exception as e:
         print(f"Error getting cloud connection: {e}")
         return None
-    
+
+
 def get_local_connection(connection_name):
     try:
         # TODO: remove pf-devkit dependencies by using ConnectionProvider.get_instance() method.
@@ -74,8 +75,9 @@ def list_apis(
 @handle_openai_error()
 def llm(
     # connection can be of type AzureOpenAIConnection, OpenAIConnection, ServerlessConnection.
-    # do not set type hint here to be compatible with pf version < 1.6.0.
-    connection, 
+    # ServerlessConnection was introduced in pf version 1.6.0.
+    # cannot set type hint here to be compatible with pf version < 1.6.0.
+    connection,
     prompt: PromptTemplate,
     api: str = "chat",
     deployment_name: str = "", model: str = "",

--- a/src/promptflow-tools/promptflow/tools/llm.py
+++ b/src/promptflow-tools/promptflow/tools/llm.py
@@ -9,7 +9,7 @@ from promptflow.tools.openai import OpenAI
 # Avoid circular dependencies: Use import 'from promptflow._internal' instead of 'from promptflow'
 # since the code here is in promptflow namespace as well
 from promptflow._internal import tool
-from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
+from promptflow.connections import AzureOpenAIConnection, OpenAIConnection
 
 
 def get_cloud_connection(connection_name, subscription_id, resource_group_name, workspace_name):
@@ -73,7 +73,7 @@ def list_apis(
 @tool
 @handle_openai_error()
 def llm(
-    connection: Union[AzureOpenAIConnection, OpenAIConnection, ServerlessConnection], 
+    connection, 
     prompt: PromptTemplate,
     api: str = "chat",
     deployment_name: str = "", model: str = "",
@@ -98,6 +98,8 @@ def llm(
     **kwargs,
 ):
     # TODO: get rid of `register_apis` dependency from llm.py.
+    from promptflow.connections import ServerlessConnection
+
     if isinstance(connection, AzureOpenAIConnection):
         if api == "completion":
             return AzureOpenAI(connection).completion(

--- a/src/promptflow-tools/promptflow/tools/llm.py
+++ b/src/promptflow-tools/promptflow/tools/llm.py
@@ -73,6 +73,8 @@ def list_apis(
 @tool
 @handle_openai_error()
 def llm(
+    # connection can be of type AzureOpenAIConnection, OpenAIConnection, ServerlessConnection.
+    # do not set type hint here to be compatible with pf version < 1.6.0.
     connection, 
     prompt: PromptTemplate,
     api: str = "chat",

--- a/src/promptflow-tools/promptflow/tools/llm_vision.py
+++ b/src/promptflow-tools/promptflow/tools/llm_vision.py
@@ -15,7 +15,7 @@ from promptflow.tools.openai_gpt4v import OpenAI
 @tool
 @handle_openai_error()
 def llm_vision(
-    connection: Union[AzureOpenAIConnection, OpenAIConnection], 
+    connection: Union[AzureOpenAIConnection, OpenAIConnection],
     prompt: PromptTemplate,
     deployment_name: str = "", model: str = "",
     temperature: float = 1.0,


### PR DESCRIPTION
Issue: new llm cannot work with serverless connection error.

Root cause: fallback in executor just work from old llm.

Fix:
![image](https://github.com/microsoft/promptflow/assets/49483542/56fbb7fd-1b3d-46ab-868f-1e1ccb6f93f1)
![image](https://github.com/microsoft/promptflow/assets/49483542/9f3b7ccb-f93e-43f4-8d34-f57e64bf502d)
