### PR TITLE
[Internal] Remove warning if CustomStrongTypeConnection type check failed

### DIFF
--- a/src/promptflow-core/promptflow/contracts/tool.py
+++ b/src/promptflow-core/promptflow/contracts/tool.py
@@ -8,7 +8,7 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, TypeVar
 
-from promptflow._constants import CONNECTION_NAME_PROPERTY, CONNECTION_DATA_CLASS_KEY
+from promptflow._constants import CONNECTION_DATA_CLASS_KEY, CONNECTION_NAME_PROPERTY
 
 from .multimedia import Image
 from .types import AssistantDefinition, FilePath, PromptTemplate, Secret
@@ -213,10 +213,7 @@ class ConnectionType:
 
         try:
             return issubclass(val, CustomStrongTypeConnection)
-        except TypeError as e:
-            # TypeError is not expected to happen, but if it does, we will log it for debugging and return False.
-            # The try-except block cannot be confidently removed due to the uncertainty of TypeError that may occur.
-            logger.warning(f"Failed to check if {val} is a custom strong type: {e}")
+        except TypeError:
             return False
 
     @staticmethod


### PR DESCRIPTION
# Description

Remove warning if CustomStrongTypeConnection type check failed. 

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
