### PR TITLE
[test][bugfix] Fix promptflow-recording not work in non-editable mode & try to fix a flaky test

### DIFF
--- a/src/promptflow-recording/promptflow/recording/azure/bases.py
+++ b/src/promptflow-recording/promptflow/recording/azure/bases.py
@@ -82,6 +82,11 @@ class PFAzureIntegrationTestRecording:
     def _get_recording_file(self) -> Path:
         test_file_path = Path(inspect.getfile(self.test_class)).resolve()
         recording_dir = (Path(__file__).parent / "../../../recordings/azure").resolve()
+        # when promptflow-recording is installed as a package (not editable mode)
+        # __file__ will direct to the installed package path (with "site-packages" in it)
+        # where the recording is not there, so we need to leverage test class to find the recording in repo
+        if "site-packages" in recording_dir.as_posix():
+            recording_dir = test_file_path.parent.parent.parent.parent.parent / "promptflow-recording/recordings/azure"
         recording_dir.mkdir(exist_ok=True)
 
         test_file_name = test_file_path.stem


### PR DESCRIPTION
# Description

This PR targets to refine tests:

- `promptflow-recording` not work in non-editable mode: when file path has "site-packages", we regard it as in non-editable mode, in this case, we will navigate to the recording files from test file.
- For flaky Azure test `test_cli_telemetry`: this error might happen in concurrency, so add a retry logic to try to resolve this.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
