### PR TITLE
Apply flow_name for multi container execution

### DIFF
--- a/src/promptflow-core/promptflow/executor/_service/apis/batch.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/batch.py
@@ -32,10 +32,11 @@ def initialize(request: InitializationRequest):
         set_environment_variables(request)
         # init batch coordinator to validate flow and create process pool
         batch_coordinator = BatchCoordinator(
-            request.working_dir,
-            request.flow_file,
-            request.output_dir,
-            request.connections,
+            working_dir=request.working_dir,
+            flow_file=request.flow_file,
+            output_dir=request.output_dir,
+            flow_name=request.flow_name,
+            connections=request.connections,
             worker_count=request.worker_count,
             line_timeout_sec=request.line_timeout_sec,
         )

--- a/src/promptflow-core/promptflow/executor/_service/apis/execution.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/execution.py
@@ -94,6 +94,7 @@ def flow_test(request: FlowExecutionRequest):
             request.inputs,
             run_id=request.run_id,
             storage=storage,
+            name=request.flow_name,
         )
 
 

--- a/src/promptflow-core/promptflow/executor/_service/contracts/execution_request.py
+++ b/src/promptflow-core/promptflow/executor/_service/contracts/execution_request.py
@@ -20,6 +20,7 @@ class BaseExecutionRequest(BaseRequest):
     log_path: Optional[str] = None
     connections: Optional[Mapping[str, Any]] = None
     environment_variables: Optional[Mapping[str, Any]] = None
+    flow_name: str = None
 
     def get_run_mode(self):
         raise NotImplementedError(f"Request type {self.__class__.__name__} is not implemented.")

--- a/src/promptflow-core/promptflow/executor/_service/utils/batch_coordinator.py
+++ b/src/promptflow-core/promptflow/executor/_service/utils/batch_coordinator.py
@@ -28,6 +28,7 @@ class BatchCoordinator:
         working_dir: Path,
         flow_file: Path,
         output_dir: Path,
+        flow_name: str = None,
         connections: Optional[Mapping[str, Any]] = None,
         worker_count: Optional[int] = None,
         line_timeout_sec: Optional[int] = None,
@@ -46,7 +47,7 @@ class BatchCoordinator:
         # So we pass DummyRunStorage to FlowExecutor because we don't need to
         # persist the run infos during execution in server mode.
         self._flow_executor = FlowExecutor.create(
-            flow_file, connections, working_dir, storage=DummyRunStorage(), raise_ex=False
+            flow_file, connections, working_dir, storage=DummyRunStorage(), raise_ex=False, name=flow_name
         )
 
         # Init line execution process pool and set serialize_multimedia_during_execution to True

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_batch_coordinator.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_batch_coordinator.py
@@ -1,0 +1,37 @@
+import pytest
+
+from promptflow.executor._service.utils.batch_coordinator import BatchCoordinator
+
+from .....utils import get_flow_folder
+
+
+@pytest.mark.unittest
+class TestBatchCoordinator:
+    @pytest.fixture(autouse=True)
+    def resource_setup_and_teardown(self):
+        # Setup code goes here
+
+        # Yield to the test function
+        yield
+
+        # Teardown code goes here
+        # Set _instance to None to avoid singleton pattern
+        # Seems like BatchCoordinator.get_instance().close() can't be called if we don't call start first.
+        BatchCoordinator._instance = None
+
+    @pytest.mark.parametrize(
+        "file_name, name_from_payload, expected_name",
+        [
+            ("yaml_with_name.yaml", "name_from_payload", "name_from_payload"),
+            ("yaml_with_name.yaml", None, "name_from_yaml"),
+            ("yaml_without_name.yaml", "name_from_payload", "name_from_payload"),
+            ("yaml_without_name.yaml", None, "flow_name"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_executor_flow_name(self, file_name, name_from_payload, expected_name):
+        flow_folder = get_flow_folder("flow_name")
+        coordinator = BatchCoordinator(
+            working_dir=flow_folder, flow_file=file_name, output_dir="", flow_name=name_from_payload
+        )
+        assert coordinator._flow_executor._flow.name == expected_name


### PR DESCRIPTION
# Description
After https://github.com/microsoft/promptflow/pull/2658, we enable setting flow name by payload.
But for multi container scenario, we need to pass `flow_name` by http request.

In this PR, add `flow_name` field in contract and use it to create executor.
Validation:
https://int.ml.azure.com/prompts/trace/list?wsid=%2Fsubscriptions%2F96aede12-2f73-41cb-b983-6d11a904839b%2FresourceGroups%2Fpromptflow%2Fproviders%2FMicrosoft.MachineLearningServices%2Fworkspaces%2Fpeiwen-ws&searchText=%7B%22sessionId%22%3A%22%22%7D&tid=72f988bf-86f1-41af-91ab-2d7cd011db47



# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
