### PR TITLE
[Bugfix][Executor] Change the run id to line run id when creating line result with error

### DIFF
--- a/src/promptflow-core/promptflow/contracts/run_info.py
+++ b/src/promptflow-core/promptflow/contracts/run_info.py
@@ -236,8 +236,9 @@ class FlowRunInfo:
 
     @staticmethod
     def create_with_error(start_time, inputs, index, run_id, error):
+        line_run_id = run_id if index is None else f"{run_id}_{index}"
         return FlowRunInfo(
-            run_id=run_id,
+            run_id=line_run_id,
             status=Status.Failed,
             error=error,
             inputs=inputs,


### PR DESCRIPTION
# Description

If `root_run_id` is equal to `run_id`, runtime will not persist flow run, so we should use `line_run_id` as run_id when creating line result with error.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
