### PR TITLE
Implement Attribute Truncation in to_cosmosdb_item to Comply with CosmosDB Size Limit

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
@@ -79,20 +79,11 @@ class Span:
         """
         item = self.to_dict()  # use to_dict method to get a dictionary representation of the object
 
-        # Serialize the dictionary to a JSON string using separators (",", ":").
-        # This is done to align with the serialization method used by the CosmosDB Python SDK.
-        json_dumped = json.dumps(item, separators=(",", ":"))
-
-        item_size = len(json_dumped.encode("utf-8"))
-        max_size_in_bytes = 2 * 1024 * 1024  # 2MB in bytes
-
-        if item_size > max_size_in_bytes:
-            attributes = item.get("attributes")
-            if attributes:
-                item["attributes"] = {
-                    k: (v if not isinstance(v, str) else v[:attr_value_truncation_length])
-                    for k, v in attributes.items()
-                }
+        attributes = item.get("attributes")
+        if attributes:
+            item["attributes"] = {
+                k: (v[:attr_value_truncation_length] if isinstance(v, str) else v) for k, v in attributes.items()
+            }
         return item
 
     def _persist_events(self, blob_container_client: ContainerClient, blob_base_uri: str):

--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
@@ -72,7 +72,7 @@ class Span:
     def to_dict(self) -> Dict[str, Any]:
         return {k: v for k, v in self.__dict__.items() if v}
 
-    def to_cosmosdb_item(self, max_attr_value_length: int = 2048):
+    def to_cosmosdb_item(self, attr_value_length_limit: int = 1024):
         """
         Convert the object to a dictionary for persistence to CosmosDB.
         Truncate attribute values to avoid exceeding CosmosDB's 2MB size limit.
@@ -81,8 +81,7 @@ class Span:
         attributes = item.get("attributes")
         if attributes:
             item["attributes"] = {
-                k: (v if not isinstance(v, str) or len(v) <= max_attr_value_length else v[:max_attr_value_length])
-                for k, v in attributes.items()
+                k: (v if not isinstance(v, str) else v[:attr_value_length_limit]) for k, v in attributes.items()
             }
         return item
 

--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
@@ -3,7 +3,6 @@
 # ---------------------------------------------------------
 
 import json
-import sys
 from copy import deepcopy
 from typing import Any, Dict
 
@@ -79,7 +78,12 @@ class Span:
         Truncate attribute values to avoid exceeding CosmosDB's 2MB size limit.
         """
         item = self.to_dict()  # use to_dict method to get a dictionary representation of the object
-        item_size = sys.getsizeof(json.dumps(item))
+
+        # Serialize the dictionary to a JSON string using separators (",", ":").
+        # This is done to align with the serialization method used by the CosmosDB Python SDK.
+        json_dumped = json.dumps(item, separators=(",", ":"))
+
+        item_size = len(json_dumped.encode("utf-8"))
         max_size_in_bytes = 2 * 1024 * 1024  # 2MB in bytes
 
         if item_size > max_size_in_bytes:

--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/span.py
@@ -65,12 +65,26 @@ class Span:
         from azure.cosmos.exceptions import CosmosResourceExistsError
 
         try:
-            return cosmos_client.create_item(body=self.to_dict())
+            return cosmos_client.create_item(body=self.to_cosmosdb_item())
         except CosmosResourceExistsError:
             return
 
     def to_dict(self) -> Dict[str, Any]:
         return {k: v for k, v in self.__dict__.items() if v}
+
+    def to_cosmosdb_item(self, max_attr_value_length: int = 2048):
+        """
+        Convert the object to a dictionary for persistence to CosmosDB.
+        Truncate attribute values to avoid exceeding CosmosDB's 2MB size limit.
+        """
+        item = self.to_dict()  # use to_dict method to get a dictionary representation of the object
+        attributes = item.get("attributes")
+        if attributes:
+            item["attributes"] = {
+                k: (v if not isinstance(v, str) or len(v) <= max_attr_value_length else v[:max_attr_value_length])
+                for k, v in attributes.items()
+            }
+        return item
 
     def _persist_events(self, blob_container_client: ContainerClient, blob_base_uri: str):
         for idx, event in enumerate(self.events):

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
@@ -1,6 +1,5 @@
 import datetime
 import json
-import sys
 
 import pytest
 
@@ -123,7 +122,7 @@ class TestSpan:
 
         item = span.to_cosmosdb_item()
 
-        item_size = sys.getsizeof(json.dumps(item))
+        item_size = len(json.dumps(item, separators=(",", ":")).encode("utf-8"))
         max_size_in_bytes = 2 * 1024 * 1024  # 2MB in bytes
         assert item_size <= max_size_in_bytes  # item size should not exceed 2MB
 
@@ -162,7 +161,7 @@ class TestSpan:
         item = span.to_cosmosdb_item()
 
         # Check that the size of the item does not exceed the 2MB limit
-        item_size = sys.getsizeof(json.dumps(item))
+        item_size = len(json.dumps(item, separators=(",", ":")).encode("utf-8"))
         max_size_in_bytes = 2 * 1024 * 1024  # 2MB in bytes
         assert item_size <= max_size_in_bytes
 

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
@@ -146,9 +146,9 @@ class TestSpan:
                 end_time=datetime.datetime.fromisoformat("2022-01-01T00:01:00"),
                 status={},
                 attributes={
-                    "attr1": "a" * 1024 * 500,  # 0.5MB
-                    "attr2": "b" * 1024 * 500,  # 0.5MB
-                    "attr3": "c" * 1024 * 500,  # 0.5MB
+                    "attr1": "a" * 1024 * 5,
+                    "attr2": "b" * 1024 * 5,
+                    "attr3": "c" * 1024 * 5,
                 },
                 events=[],
                 resource={"collection": "test_session_id"},
@@ -167,7 +167,7 @@ class TestSpan:
 
         # Check that the attribute values have not been truncated
         for value in item["attributes"].values():
-            assert len(value) == 1024 * 500
+            assert len(value) == 1024 * 5
 
     def test_event_path(self):
         span = Span(

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
@@ -1,4 +1,6 @@
 import datetime
+import json
+import sys
 
 import pytest
 
@@ -92,7 +94,7 @@ class TestSpan:
             "resource": {"collection": "test_session_id"},
         }
 
-    def test_to_cosmosdb_item(self):
+    def test_to_cosmosdb_item_truncation(self):
         span = Span(
             SpanEntity(
                 name="test",
@@ -107,7 +109,11 @@ class TestSpan:
                 start_time=datetime.datetime.fromisoformat("2022-01-01T00:00:00"),
                 end_time=datetime.datetime.fromisoformat("2022-01-01T00:01:00"),
                 status={},
-                attributes={"long_attribute": "a" * 2000},  # attribute value that exceeds max length
+                attributes={
+                    "attr1": "a" * 1024 * 1024,  # 1MB
+                    "attr2": "b" * 1024 * 1024,  # 1MB
+                    "attr3": "c" * 1024 * 1024,  # 1MB
+                },  # attribute value that exceeds max length
                 events=[],
                 resource={"collection": "test_session_id"},
             ),
@@ -115,9 +121,54 @@ class TestSpan:
             created_by=self.FAKE_CREATED_BY,
         )
 
-        item = span.to_cosmosdb_item(max_attr_value_length=1000)
+        item = span.to_cosmosdb_item()
 
-        assert len(item["attributes"]["long_attribute"]) == 1000  # attribute value should be truncated to max length
+        item_size = sys.getsizeof(json.dumps(item))
+        max_size_in_bytes = 2 * 1024 * 1024  # 2MB in bytes
+        assert item_size <= max_size_in_bytes  # item size should not exceed 2MB
+
+        for value in item["attributes"].values():
+            assert len(value) == 8 * 1024  # attribute value should be truncated to max length
+
+    def test_to_cosmosdb_item_no_truncation_needed(self):
+        # Create a Span object with a long attribute that does not exceed the 2MB limit
+        span = Span(
+            SpanEntity(
+                name="test",
+                trace_id=self.FAKE_TRACE_ID,
+                span_id=self.FAKE_SPAN_ID,
+                context={
+                    "trace_id": self.FAKE_TRACE_ID,
+                    "span_id": self.FAKE_SPAN_ID,
+                },
+                kind="test",
+                parent_id="test",
+                start_time=datetime.datetime.fromisoformat("2022-01-01T00:00:00"),
+                end_time=datetime.datetime.fromisoformat("2022-01-01T00:01:00"),
+                status={},
+                attributes={
+                    "attr1": "a" * 1024 * 500,  # 0.5MB
+                    "attr2": "b" * 1024 * 500,  # 0.5MB
+                    "attr3": "c" * 1024 * 500,  # 0.5MB
+                },
+                events=[],
+                resource={"collection": "test_session_id"},
+            ),
+            collection_id=self.FAKE_COLLECTION_ID,
+            created_by=self.FAKE_CREATED_BY,
+        )
+
+        # Convert the Span object to a CosmosDB item
+        item = span.to_cosmosdb_item()
+
+        # Check that the size of the item does not exceed the 2MB limit
+        item_size = sys.getsizeof(json.dumps(item))
+        max_size_in_bytes = 2 * 1024 * 1024  # 2MB in bytes
+        assert item_size <= max_size_in_bytes
+
+        # Check that the attribute values have not been truncated
+        for value in item["attributes"].values():
+            assert len(value) == 1024 * 500
 
     def test_event_path(self):
         span = Span(

--- a/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
+++ b/src/promptflow/tests/sdk_cli_azure_test/unittests/test_span.py
@@ -92,6 +92,33 @@ class TestSpan:
             "resource": {"collection": "test_session_id"},
         }
 
+    def test_to_cosmosdb_item(self):
+        span = Span(
+            SpanEntity(
+                name="test",
+                trace_id=self.FAKE_TRACE_ID,
+                span_id=self.FAKE_SPAN_ID,
+                context={
+                    "trace_id": self.FAKE_TRACE_ID,
+                    "span_id": self.FAKE_SPAN_ID,
+                },
+                kind="test",
+                parent_id="test",
+                start_time=datetime.datetime.fromisoformat("2022-01-01T00:00:00"),
+                end_time=datetime.datetime.fromisoformat("2022-01-01T00:01:00"),
+                status={},
+                attributes={"long_attribute": "a" * 2000},  # attribute value that exceeds max length
+                events=[],
+                resource={"collection": "test_session_id"},
+            ),
+            collection_id=self.FAKE_COLLECTION_ID,
+            created_by=self.FAKE_CREATED_BY,
+        )
+
+        item = span.to_cosmosdb_item(max_attr_value_length=1000)
+
+        assert len(item["attributes"]["long_attribute"]) == 1000  # attribute value should be truncated to max length
+
     def test_event_path(self):
         span = Span(
             SpanEntity(


### PR DESCRIPTION
# Description

This PR add the `to_cosmosdb_item` method in the `Span` class, ensuring that attribute values are truncated to a specified maximum length. This change is critical to prevent exceeding CosmosDB's 2MB item size limit. The `attr_value_truncation_length` parameter allows for flexible adjustment of the truncation threshold, accommodating different use cases and requirements.

By merging this PR, we will improve the reliability of our telemetry data storage in CosmosDB, especially for larger spans that previously risked rejection due to size limitations. The code aligns with the serialization method used by the CosmosDB Python SDK, ensuring compatibility and consistency across our application.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
