### PR TITLE
feat: support TypedDict as flex flow return type

### DIFF
--- a/src/promptflow-core/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow-core/promptflow/_core/tool_meta_generator.py
@@ -543,7 +543,12 @@ def generate_flow_meta_dict_by_object(f, cls):
     if cls:
         init_tool = _parse_tool_from_function(cls.__init__, include_outputs=False)
         init_inputs = init_tool.inputs
-        # no need to validate init as dict is not allowed in init for now.
+        validate_interface(
+            init_inputs,
+            {k: v.annotation for k, v in inspect.signature(cls.__init__).parameters.items()},
+            tool.name,
+            "input",
+        )
     else:
         init_inputs = None
 

--- a/src/promptflow-core/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow-core/promptflow/_core/tool_meta_generator.py
@@ -543,7 +543,7 @@ def generate_flow_meta_dict_by_object(f, cls):
         raise BadFunctionInterface(
             message_format=(
                 "Parse interface for '{entry}' failed: "
-                "The return annotation of the entry function must be dataclass, TypedDict, string or no return, "
+                "The return annotation of the entry function must be dataclass, TypedDict or string, "
                 "but got {t}."
             ),
             entry=cls.__name__ if cls else f.__name__,

--- a/src/promptflow-core/promptflow/_core/tool_meta_generator.py
+++ b/src/promptflow-core/promptflow/_core/tool_meta_generator.py
@@ -5,7 +5,6 @@
 """
 This file can generate a meta file for the given prompt template or a python file.
 """
-import dataclasses
 import importlib.util
 import inspect
 import json
@@ -45,6 +44,7 @@ from promptflow._utils.tool_utils import (
     function_to_interface,
     get_inputs_for_prompt_template,
     resolve_annotation,
+    resolve_complicated_type,
 )
 from promptflow.contracts.tool import InputDefinition, Tool, ToolType, ValueType
 from promptflow.exceptions import ErrorTarget, UserErrorException
@@ -536,11 +536,7 @@ def generate_flow_meta_dict_by_object(f, cls):
 
     # validate output
     return_type = resolve_annotation(signature.return_annotation)
-    if dataclasses.is_dataclass(return_type):
-        output_fields = {x.name: x.type for x in dataclasses.fields(return_type)}
-    else:
-        output_fields = {"output": return_type}
-    validate_interface(tool.outputs, output_fields, tool.name, "output")
+    validate_interface(tool.outputs, resolve_complicated_type(return_type), tool.name, "output")
 
     # Include data in generated meta to avoid flow definition's fields(e.g. environment variable) missing.
     flow_meta = {}

--- a/src/promptflow-core/promptflow/_utils/tool_utils.py
+++ b/src/promptflow-core/promptflow/_utils/tool_utils.py
@@ -129,13 +129,11 @@ def param_to_definition(param, gen_custom_type_conn=False) -> (InputDefinition, 
 
 def resolve_complicated_type(return_type):
     if is_dataclass(return_type):
-        output_fields = {x.name: x.type for x in fields(return_type)}
+        return {x.name: x.type for x in fields(return_type)}, True
     elif isinstance(return_type, type) and issubclass(return_type, dict) and hasattr(return_type, "__annotations__"):
-        output_fields = return_type.__annotations__
+        return return_type.__annotations__, True
     else:
-        output_fields = {"output": return_type}
-
-    return output_fields
+        return {"output": return_type}, False
 
 
 def function_to_interface(
@@ -170,7 +168,7 @@ def function_to_interface(
         if is_connection:
             connection_types.append(input_def.type)
     # Resolve output to definition
-    output_fields = resolve_complicated_type(resolve_annotation(sign.return_annotation))
+    output_fields, _ = resolve_complicated_type(resolve_annotation(sign.return_annotation))
     outputs = {
         k: OutputDefinition(
             # If the output annotation is a union type, then it should be a list.

--- a/src/promptflow-core/promptflow/_utils/tool_utils.py
+++ b/src/promptflow-core/promptflow/_utils/tool_utils.py
@@ -130,6 +130,8 @@ def param_to_definition(param, gen_custom_type_conn=False) -> (InputDefinition, 
 def resolve_complicated_type(return_type):
     if is_dataclass(return_type):
         output_fields = {x.name: x.type for x in fields(return_type)}
+    elif isinstance(return_type, type) and issubclass(return_type, dict) and hasattr(return_type, "__annotations__"):
+        output_fields = return_type.__annotations__
     else:
         output_fields = {"output": return_type}
 

--- a/src/promptflow-core/promptflow/_utils/tool_utils.py
+++ b/src/promptflow-core/promptflow/_utils/tool_utils.py
@@ -127,6 +127,15 @@ def param_to_definition(param, gen_custom_type_conn=False) -> (InputDefinition, 
     )
 
 
+def resolve_complicated_type(return_type):
+    if is_dataclass(return_type):
+        output_fields = {x.name: x.type for x in fields(return_type)}
+    else:
+        output_fields = {"output": return_type}
+
+    return output_fields
+
+
 def function_to_interface(
     f: Callable, initialize_inputs=None, gen_custom_type_conn=False, skip_prompt_template=False
 ) -> tuple:
@@ -159,20 +168,16 @@ def function_to_interface(
         if is_connection:
             connection_types.append(input_def.type)
     # Resolve output to definition
-    typ = resolve_annotation(sign.return_annotation)
-    if typ is inspect.Signature.empty:
-        outputs = {"output": OutputDefinition(type=[ValueType.OBJECT])}
-    elif is_dataclass(typ):
-        outputs = {}
-        for field in fields(typ):
-            outputs[field.name] = OutputDefinition(type=[ValueType.from_type(field.type)])
-    else:
-        # If the output annotation is a union type, then it should be a list.
-        outputs = {
-            "output": OutputDefinition(
-                type=[ValueType.from_type(t) for t in typ] if isinstance(typ, list) else [ValueType.from_type(typ)]
-            )
-        }
+    output_fields = resolve_complicated_type(resolve_annotation(sign.return_annotation))
+    outputs = {
+        k: OutputDefinition(
+            # If the output annotation is a union type, then it should be a list.
+            type=[ValueType.from_type(v) for v in v]
+            if isinstance(v, list)
+            else [ValueType.from_type(v)]
+        )
+        for k, v in output_fields.items()
+    }
 
     return input_defs, outputs, connection_types, enable_kwargs
 

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
@@ -987,7 +987,9 @@ class FlowOperations(TelemetryMixin):
             if key in extracted:
                 signature[key] = extracted[key]
             elif key in signature_overrides:
-                raise UserErrorException(f"Provided signature for {key}, which is not found in the entry.")
+                raise UserErrorException(
+                    f"Provided signature for {key}, which can't be overridden according to the entry."
+                )
 
             if key not in signature_overrides:
                 continue

--- a/src/promptflow-devkit/promptflow/_sdk/schemas/_flow.py
+++ b/src/promptflow-devkit/promptflow/_sdk/schemas/_flow.py
@@ -72,7 +72,7 @@ class FlexFlowInitSchema(FlowInputSchema):
     type = fields.Str(
         required=True,
         validate=validate.OneOf(
-            [SignatureValueType.NUMBER, SignatureValueType.BOOL, SignatureValueType.INT, SignatureValueType.STRING]
+            list(map(lambda x: x.value, SignatureValueType))
             + list(
                 map(lambda x: f"{x.value}Connection", filter(lambda x: x != ConnectionType._NOT_SET, ConnectionType))
             )

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_cli.py
@@ -2324,11 +2324,6 @@ class TestCli:
                         "type": "string",
                     }
                 },
-                "outputs": {
-                    "output": {
-                        "type": "string",
-                    }
-                },
             }
             os.unlink(Path(temp_dir) / FLOW_FLEX_YAML)
             run_pf_command(

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
@@ -42,7 +42,7 @@ class GlobalHello:
 
 
 class GlobalHelloWithInvalidInit:
-    def __init__(self, connection: AzureOpenAIConnection, words: list):
+    def __init__(self, connection: AzureOpenAIConnection, words: GlobalHello):
         self.connection = connection
 
     def __call__(self, text: str) -> str:
@@ -227,6 +227,12 @@ class TestFlowSave:
                         "b": {
                             "type": "boolean",
                         },
+                        "li": {
+                            "type": "array",
+                        },
+                        "d": {
+                            "type": "object",
+                        },
                     },
                     "inputs": {
                         "s": {
@@ -350,8 +356,8 @@ class TestFlowSave:
                     "entry": "hello:Hello",
                 },
                 UserErrorException,
-                r"Schema validation failed: {'init.words.type'",
-                id="class_init_with_list_init",
+                r"The input 'words' is of a complex python type. Please use a dict instead",
+                id="class_init_with_entity_init",
             ),
             pytest.param(
                 {
@@ -533,7 +539,7 @@ class TestFlowSave:
 
     def test_infer_signature_failed(self):
         pf = PFClient()
-        with pytest.raises(UserErrorException, match="Schema validation failed: {'init.words.type'"):
+        with pytest.raises(UserErrorException, match="The input 'words' is of a complex python type"):
             pf.flows.infer_signature(entry=GlobalHelloWithInvalidInit)
 
     def test_public_save(self):

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
@@ -454,7 +454,6 @@ class TestFlowSave:
             },
         }
 
-    @pytest.mark.skip(reason="not supported yet")
     @pytest.mark.parametrize(
         "target_function, expected_signature",
         [

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -465,7 +465,7 @@ def test_eager_flow_swagger(simple_eager_flow):
                             "content": {
                                 "application/json": {
                                     "schema": {
-                                        "properties": {"output": {"additionalProperties": {}, "type": "object"}},
+                                        "properties": {"output": {"type": "string"}},
                                         "type": "object",
                                     }
                                 }
@@ -523,11 +523,7 @@ def test_eager_flow_primitive_output_swagger(simple_eager_flow_primitive_output)
                     },
                     "responses": {
                         "200": {
-                            "content": {
-                                "application/json": {
-                                    "schema": {"properties": {"output": {"type": "string"}}, "type": "object"}
-                                }
-                            },
+                            "content": {"application/json": {"schema": {"type": "object"}}},
                             "description": "successful " "operation",
                         },
                         "400": {"description": "Invalid " "input"},
@@ -559,7 +555,7 @@ def test_eager_flow_serve_dataclass_output(simple_eager_flow_dataclass_output):
 
 @pytest.mark.e2etest
 def test_eager_flow_serve_non_json_serializable_output(mocker):
-    with pytest.raises(UserErrorException, match="Parse interface for tool 'my_flow' failed:"):
+    with pytest.raises(UserErrorException, match="Parse interface for 'my_flow' failed:"):
         # instead of giving 400 response for all requests, we raise user error on serving now
         from pathlib import Path
 

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -338,7 +338,6 @@ class TestFlowTest:
                     "entry": "entry:my_flow",
                     "function": "my_flow",
                     "inputs": {"input_val": {"default": "gpt", "type": "string"}},
-                    "outputs": {"output": {"type": "string"}},
                 },
             ),
             (
@@ -347,7 +346,6 @@ class TestFlowTest:
                     "entry": "my_module.entry:my_flow",
                     "function": "my_flow",
                     "inputs": {"input_val": {"default": "gpt", "type": "string"}},
-                    "outputs": {"output": {"type": "string"}},
                 },
             ),
             (
@@ -356,7 +354,6 @@ class TestFlowTest:
                     "entry": "flow:my_flow_entry",
                     "function": "my_flow_entry",
                     "inputs": {"input_val": {"default": "gpt", "type": "string"}},
-                    "outputs": {"output": {"type": "string"}},
                 },
             ),
         ],

--- a/src/promptflow/tests/test_configs/eager_flows/basic_callable_class/simple_callable_class.py
+++ b/src/promptflow/tests/test_configs/eager_flows/basic_callable_class/simple_callable_class.py
@@ -1,12 +1,17 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+from typing import TypedDict
+
 
 class MyFlow:
     def __init__(self, obj_input: str):
         self.obj_input = obj_input
 
-    def __call__(self, func_input: str) -> dict:
+    def __call__(self, func_input: str) -> TypedDict(
+        "MyFlowResult",
+        {"obj_input": str, "func_input": str, "obj_id": int}
+    ):
         return {
             "obj_input": self.obj_input,
             "func_input": func_input,

--- a/src/promptflow/tests/test_configs/eager_flows/dummy_flow_with_trace/flow_with_trace.meta.json
+++ b/src/promptflow/tests/test_configs/eager_flows/dummy_flow_with_trace/flow_with_trace.meta.json
@@ -8,12 +8,7 @@
         },
         "models": {
             "type": "list",
-            "default": "['default_model']"
-        }
-    },
-    "outputs": {
-        "output": {
-            "type": "string"
+            "default": ""
         }
     },
     "source": "flow_with_trace.py"

--- a/src/promptflow/tests/test_configs/eager_flows/dummy_flow_with_trace/flow_with_trace.py
+++ b/src/promptflow/tests/test_configs/eager_flows/dummy_flow_with_trace/flow_with_trace.py
@@ -14,8 +14,12 @@ async def dummy_llm(prompt: str, model: str, wait_seconds: int):
     return prompt
 
 
-async def my_flow(text: str = "default_text", models: list = ["default_model"]) -> str:
+# 1. In Python, it's not recommended to use `list` as a default argument.
+# 2. current tool meta generation logic will return a string instead of a valid json for list default value.
+async def my_flow(text: str = "default_text", models: list = None) -> str:
     tasks = []
+    if models is None:
+        models = ["default_model"]
     for i, model in enumerate(models):
         tasks.append(asyncio.create_task(dummy_llm(text, model, i + 1)))
     await asyncio.wait(tasks)

--- a/src/promptflow/tests/test_configs/eager_flows/multiple_stream_outputs/multiple_stream_outputs.py
+++ b/src/promptflow/tests/test_configs/eager_flows/multiple_stream_outputs/multiple_stream_outputs.py
@@ -1,7 +1,10 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-def my_flow(input_val: str = "gpt") -> dict:
+from typing import TypedDict
+
+
+def my_flow(input_val: str = "gpt") -> TypedDict("MyFlowResult", {"output1": int, "output2": int}):
     generator1 = (i for i in range(10))
     generator2 = (i for i in range(10))
     return {

--- a/src/promptflow/tests/test_configs/eager_flows/simple_with_dict_output/dict_output_entry.py
+++ b/src/promptflow/tests/test_configs/eager_flows/simple_with_dict_output/dict_output_entry.py
@@ -1,7 +1,9 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+from typing import TypedDict
 
-def my_flow(input_val: str = "gpt") -> dict:
+
+def my_flow(input_val: str = "gpt") -> TypedDict("MyFlowResult", {"output": str}):
     """Simple flow without yaml."""
     return {"output": f"Hello world! {input_val}"}

--- a/src/promptflow/tests/test_configs/functions/class_init_complicated_ports/hello.py
+++ b/src/promptflow/tests/test_configs/functions/class_init_complicated_ports/hello.py
@@ -21,6 +21,8 @@ class Hello:
         i: int,
         f: float,
         b: bool,
+        li: list,
+        d: dict,
     ) -> None:
         pass
 

--- a/src/promptflow/tests/test_configs/functions/class_init_with_entity_init/hello.py
+++ b/src/promptflow/tests/test_configs/functions/class_init_with_entity_init/hello.py
@@ -1,6 +1,11 @@
-class Hello:
+class CustomConfig:
     def __init__(self, words: list) -> None:
         self.words = words
+
+
+class Hello:
+    def __init__(self, words: CustomConfig) -> None:
+        self.words = words.words
 
     def __call__(self, text: str) -> str:
         return f"Hello {','.join(self.words)} {text}!"


### PR DESCRIPTION
# Description

This PR includes 3 changes:
1. treat `TypedDict` in the same way as `dataclass`. Below 3 functions will get the same signature. This support **will not be applied to tools** for now as such support is for output only and we don't generate output signature for tools.
```python
from typing import TypedDict
from dataclasses import dataclass

class TypedOutput(TypedDict):
    s: str

@dataclass
class DataOutput:
    s: str

def hello_typed_dict_inline(str text) -> TypedDict("TypedOutput", {"s": str}):
    pass

def hello_typed_dict(str text) -> TypedOutput:
    pass

def hello_dataclass(str text) -> DataOutput:
    pass
```
2. change the expected signature for primitive flow output:
```json
{
    "inputs": ...
    "outputs": {"output": {"type": "string"}}
}
```
=>
```json
{
    "inputs": ...
}
```
3. support `list` and `dict` in class init

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
