### PR TITLE
Remove get_workspace_triad_from_local by using common error message for vision model used in llm

### DIFF
--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -247,8 +247,6 @@ def get_workspace_triad():
             and 'AZUREML_ARM_WORKSPACE_NAME' in os.environ:
         return os.environ["AZUREML_ARM_SUBSCRIPTION"], os.environ["AZUREML_ARM_RESOURCEGROUP"], \
                os.environ["AZUREML_ARM_WORKSPACE_NAME"]
-
-    # Return a tuple of Nones if flow is not submitted from cloud
     return "", "", ""
 
 

--- a/src/promptflow-tools/promptflow/tools/common.py
+++ b/src/promptflow-tools/promptflow/tools/common.py
@@ -12,7 +12,6 @@ from promptflow.tools.exception import ChatAPIInvalidRole, WrappedOpenAIError, L
     ExceedMaxRetryTimes, ChatAPIInvalidFunctions, FunctionCallNotSupportedInStreamMode, \
     ChatAPIFunctionRoleInvalidFormat, InvalidConnectionType, ListDeploymentsError, ParseConnectionError
 
-from promptflow._cli._utils import get_workspace_triad_from_local
 from promptflow.connections import AzureOpenAIConnection, OpenAIConnection
 from promptflow.exceptions import SystemErrorException, UserErrorException
 
@@ -248,11 +247,9 @@ def get_workspace_triad():
             and 'AZUREML_ARM_WORKSPACE_NAME' in os.environ:
         return os.environ["AZUREML_ARM_SUBSCRIPTION"], os.environ["AZUREML_ARM_RESOURCEGROUP"], \
                os.environ["AZUREML_ARM_WORKSPACE_NAME"]
-    else:
-        # If flow is submitted from local, it will get workspace triad from your azure cloud config file
-        # If this config file isn't set up, it will return None.
-        workspace_triad = get_workspace_triad_from_local()
-        return workspace_triad.subscription_id, workspace_triad.resource_group_name, workspace_triad.workspace_name
+
+    # Return a tuple of Nones if flow is not submitted from cloud
+    return "", "", ""
 
 
 def list_deployment_connections(

--- a/src/promptflow-tools/tests/test_handle_openai_error.py
+++ b/src/promptflow-tools/tests/test_handle_openai_error.py
@@ -317,6 +317,7 @@ class TestHandleOpenAIError:
         assert exc_info.value.error_codes == error_codes.split("/")
 
     def test_aoai_with_vision_model_extra_fields_error(self, azure_open_ai_connection):
+        # test azure environment
         with (
             patch('promptflow.tools.common.get_workspace_triad') as mock_get,
             patch('promptflow.tools.common.list_deployment_connections') as mock_list,
@@ -333,3 +334,15 @@ class TestHandleOpenAIError:
 
         assert "extra fields not permitted" in exc_info.value.message
         assert "Please kindly avoid using vision model in LLM tool" in exc_info.value.message
+
+        # test local environment
+        with (
+            patch('promptflow.tools.common.get_workspace_triad') as mock_get,
+            pytest.raises(WrappedOpenAIError) as exc_info
+        ):
+            mock_get.return_value = ("", "", "")
+            chat(connection=azure_open_ai_connection, prompt="user:\nhello", deployment_name="gpt-4v",
+                 response_format={"type": "text"})
+
+        assert "extra fields not permitted" in exc_info.value.message
+        assert "Please kindly avoid using vision model in LLM tool" not in exc_info.value.message


### PR DESCRIPTION
# Description

Remove pf-devkit dependency (get_workspace_triad_from_local) by using common error message for vision model used in llm

local test:
![image](https://github.com/microsoft/promptflow/assets/75061414/66b25e5f-6c59-455e-95b9-9119be4f0b0a)

portal test:
![image](https://github.com/microsoft/promptflow/assets/75061414/e9e94fd6-3013-4520-ab04-de34318574fb)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
