### PR TITLE
[Internal] Set timeout when getting cosmos db token 

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/client.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/client.py
@@ -78,11 +78,15 @@ def _get_resource_token(
 ) -> object:
     from promptflow.azure import PFClient
 
+    # The default connection_time and read_timeout are both 300s.
+    # The get token operation should be fast, so we set a short timeout.
     pf_client = PFClient(
         credential=credential,
         subscription_id=subscription_id,
         resource_group_name=resource_group_name,
         workspace_name=workspace_name,
+        connection_timeout=15.0,
+        read_timeout=30.0,
     )
 
     token_resp = pf_client._traces._get_cosmos_db_token(container_name=container_name, acquire_write=True)


### PR DESCRIPTION
# Description

When call get cosmos db token API, we found that sometimes we will met timeout. The default connection_timeout and read_timeout are both 300s([code](https://github.com/Azure/azure-sdk-for-python/blob/9fa8967963f263d6211f1d566b41f46fe7cf27bf/sdk/core/azure-core/azure/core/configuration.py#L109)).
In this PR, we set the connection_timeout to 15s and read_timeout to 30s to reduce the possible latency when met timeout.
 
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
