### PR TITLE
revert: use dag type system for infer_signature

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
@@ -29,7 +29,6 @@ from promptflow._sdk._constants import (
     FLOW_TOOLS_JSON_GEN_TIMEOUT,
     LOCAL_MGMT_DB_PATH,
     SERVE_SAMPLE_JSON_PATH,
-    SignatureValueType,
 )
 from promptflow._sdk._load_functions import load_flow
 from promptflow._sdk._orchestrator import TestSubmitter
@@ -55,7 +54,6 @@ from promptflow._utils.flow_utils import (
     parse_variant,
 )
 from promptflow._utils.yaml_utils import dump_yaml, load_yaml
-from promptflow.contracts.tool import ValueType
 from promptflow.exceptions import ErrorTarget, UserErrorException
 
 
@@ -1063,11 +1061,12 @@ class FlowOperations(TelemetryMixin):
             raise UserErrorException("Entry must be a function or a class.")
 
         # signature is language irrelevant, so we apply json type system
+        # TODO: enable this mapping after service supports more types
         value_type_map = {
-            ValueType.INT.value: SignatureValueType.INT.value,
-            ValueType.DOUBLE.value: SignatureValueType.NUMBER.value,
-            ValueType.LIST.value: SignatureValueType.ARRAY.value,
-            ValueType.BOOL.value: SignatureValueType.BOOL.value,
+            # ValueType.INT.value: SignatureValueType.INT.value,
+            # ValueType.DOUBLE.value: SignatureValueType.NUMBER.value,
+            # ValueType.LIST.value: SignatureValueType.ARRAY.value,
+            # ValueType.BOOL.value: SignatureValueType.BOOL.value,
         }
         for port_type in ["inputs", "outputs", "init"]:
             if port_type not in flow_meta:

--- a/src/promptflow-devkit/promptflow/_sdk/schemas/_flow.py
+++ b/src/promptflow-devkit/promptflow/_sdk/schemas/_flow.py
@@ -6,9 +6,10 @@ from marshmallow import ValidationError, fields, validate, validates_schema
 
 from promptflow._constants import LANGUAGE_KEY, ConnectionType, FlowLanguage
 from promptflow._proxy import ProxyFactory
-from promptflow._sdk._constants import FlowType, SignatureValueType
+from promptflow._sdk._constants import FlowType
 from promptflow._sdk.schemas._base import PatchedSchemaMeta, YamlFileSchema
 from promptflow._sdk.schemas._fields import NestedField
+from promptflow.contracts.tool import ValueType
 
 
 class FlowInputSchema(metaclass=PatchedSchemaMeta):
@@ -60,11 +61,21 @@ class FlowSchema(BaseFlowSchema):
     node_variants = fields.Dict(keys=fields.Str(), values=fields.Dict())
 
 
+ALLOWED_TYPES = [
+    ValueType.STRING.value,
+    ValueType.INT.value,
+    ValueType.DOUBLE.value,
+    ValueType.BOOL.value,
+    ValueType.LIST.value,
+    ValueType.OBJECT.value,
+]
+
+
 class FlexFlowInputSchema(FlowInputSchema):
     type = fields.Str(
         required=True,
         # TODO 3062609: Flex flow GPT-V support
-        validate=validate.OneOf(list(map(lambda x: x.value, SignatureValueType))),
+        validate=validate.OneOf(ALLOWED_TYPES),
     )
 
 
@@ -72,7 +83,7 @@ class FlexFlowInitSchema(FlowInputSchema):
     type = fields.Str(
         required=True,
         validate=validate.OneOf(
-            list(map(lambda x: x.value, SignatureValueType))
+            ALLOWED_TYPES
             + list(
                 map(lambda x: f"{x.value}Connection", filter(lambda x: x != ConnectionType._NOT_SET, ConnectionType))
             )
@@ -83,7 +94,7 @@ class FlexFlowInitSchema(FlowInputSchema):
 class FlexFlowOutputSchema(FlowOutputSchema):
     type = fields.Str(
         required=True,
-        validate=validate.OneOf(list(map(lambda x: x.value, SignatureValueType))),
+        validate=validate.OneOf(ALLOWED_TYPES),
     )
 
 

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
@@ -74,7 +74,11 @@ def global_hello_int_return(text: str) -> int:
 
 
 def global_hello_strong_return(text: str) -> GlobalHello:
-    return len(text)
+    return GlobalHello(AzureOpenAIConnection("test"))
+
+
+def global_hello_kwargs(text: str, **kwargs) -> str:
+    return f"Hello {text}!"
 
 
 @pytest.mark.usefixtures(
@@ -166,7 +170,7 @@ class TestFlowSave:
                             "type": "string",
                         },
                         "length": {
-                            "type": "integer",
+                            "type": "int",
                         },
                     },
                 },
@@ -204,16 +208,16 @@ class TestFlowSave:
                             "type": "string",
                         },
                         "i": {
-                            "type": "integer",
+                            "type": "int",
                         },
                         "f": {
-                            "type": "number",
+                            "type": "double",
                         },
                         "b": {
-                            "type": "boolean",
+                            "type": "bool",
                         },
                         "li": {
-                            "type": "array",
+                            "type": "list",
                         },
                         "d": {
                             "type": "object",
@@ -224,16 +228,16 @@ class TestFlowSave:
                             "type": "string",
                         },
                         "i": {
-                            "type": "integer",
+                            "type": "int",
                         },
                         "f": {
-                            "type": "number",
+                            "type": "double",
                         },
                         "b": {
-                            "type": "boolean",
+                            "type": "bool",
                         },
                         "li": {
-                            "type": "array",
+                            "type": "list",
                         },
                         "d": {
                             "type": "object",
@@ -244,16 +248,16 @@ class TestFlowSave:
                             "type": "string",
                         },
                         "i": {
-                            "type": "integer",
+                            "type": "int",
                         },
                         "f": {
-                            "type": "number",
+                            "type": "double",
                         },
                         "b": {
-                            "type": "boolean",
+                            "type": "bool",
                         },
                         "l": {
-                            "type": "array",
+                            "type": "list",
                         },
                         "d": {
                             "type": "object",
@@ -493,6 +497,17 @@ class TestFlowSave:
                     },
                 },
                 id="inherited_typed_dict_output",
+            ),
+            pytest.param(
+                global_hello_kwargs,
+                {
+                    "inputs": {
+                        "text": {
+                            "type": "string",
+                        }
+                    },
+                },
+                id="kwargs",
             ),
         ],
     )


### PR DESCRIPTION
# Description

Use flow-dag-yaml type system for pf.flows.infer_signature and pf.flows.save before service-side done related support

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
