### PR TITLE
Fix unset span_type. Align default value with local sdk

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/summary.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/summary.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import time
 import typing
@@ -36,15 +35,15 @@ class SummaryLine:
     session_id: str
     trace_id: str
     collection_id: str
-    root_span_id: str = ""
+    root_span_id: str = None
     inputs: typing.Dict = field(default_factory=dict)
     outputs: typing.Dict = field(default_factory=dict)
-    start_time: str = ""
-    end_time: str = ""
-    status: str = ""
+    start_time: str = None
+    end_time: str = None
+    status: str = None
     latency: float = 0.0
-    name: str = ""
-    kind: str = ""
+    name: str = None
+    kind: str = None
     created_by: typing.Dict = field(default_factory=dict)
     cumulative_token_count: typing.Optional[typing.Dict[str, int]] = field(default_factory=dict)
     evaluations: typing.Dict = field(default_factory=dict)
@@ -198,9 +197,7 @@ class Summary:
 
         # Span's original format don't include latency, so we need to calculate it.
         # Convert ISO 8601 formatted strings to datetime objects
-        start_time_date = datetime.datetime.fromisoformat(start_time.replace("Z", "+00:00"))
-        end_time_date = datetime.datetime.fromisoformat(end_time.replace("Z", "+00:00"))
-        latency = (end_time_date - start_time_date).total_seconds()
+        latency = (self.span.end_time - self.span.start_time).total_seconds()
         # calculate `cumulative_token_count`
         completion_token_count = int(attributes.get(SpanAttributeFieldName.COMPLETION_TOKEN_COUNT, 0))
         prompt_token_count = int(attributes.get(SpanAttributeFieldName.PROMPT_TOKEN_COUNT, 0))
@@ -228,7 +225,7 @@ class Summary:
             status=self.span.status[SpanStatusFieldName.STATUS_CODE],
             latency=latency,
             name=self.span.name,
-            kind=attributes[SpanAttributeFieldName.SPAN_TYPE],
+            kind=attributes.get(SpanAttributeFieldName.SPAN_TYPE, None),
             cumulative_token_count=cumulative_token_count,
             created_by=self.created_by,
         )


### PR DESCRIPTION
# Description
Use None for span_type's default value. For customer created span, span_type is not always exist.
Use `None` as default value to align with local sdk.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
