### PR TITLE
feat: add param to add back primitive output type in signature

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
@@ -1020,6 +1020,7 @@ class FlowOperations(TelemetryMixin):
         keep_entry: bool = False,
         validate: bool = True,
         language: str = FlowLanguage.Python,
+        include_primitive_output: bool = False,
     ) -> Tuple[dict, Path, List[str]]:
         """Infer signature of a flow entry.
 
@@ -1087,6 +1088,14 @@ class FlowOperations(TelemetryMixin):
             # this path is actually not used
             flow = FlexFlow(path=code / FLOW_FLEX_YAML, code=code, data=flow_meta, entry=flow_meta["entry"])
             flow._validate(raise_error=True)
+
+        if include_primitive_output and "outputs" not in flow_meta:
+            flow_meta["outputs"] = {
+                "output": {
+                    "type": "string",
+                }
+            }
+
         if not keep_entry:
             flow_meta.pop("entry", None)
         return flow_meta, code, snapshot_list

--- a/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
+++ b/src/promptflow/tests/sdk_cli_test/e2etests/test_flow_save.py
@@ -420,6 +420,22 @@ class TestFlowSave:
             },
         }
 
+    def test_pf_infer_signature_include_primitive_output(self):
+        pf = PFClient()
+        flow_meta, _, _ = pf.flows._infer_signature(entry=global_hello, include_primitive_output=True)
+        assert flow_meta == {
+            "inputs": {
+                "text": {
+                    "type": "string",
+                }
+            },
+            "outputs": {
+                "output": {
+                    "type": "string",
+                }
+            },
+        }
+
     def test_pf_save_callable_function(self):
         pf = PFClient()
         target_path = f"{FLOWS_DIR}/saved/hello_callable"


### PR DESCRIPTION
# Description

add a parameter to add back output signature for primitive output flex flow before chat window support no outputs

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
