### PR TITLE
fix: csharp graceful shutdown

### DIFF
--- a/src/promptflow-devkit/promptflow/_proxy/_csharp_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/_proxy/_csharp_executor_proxy.py
@@ -124,7 +124,7 @@ class CSharpExecutorProxy(CSharpBaseExecutorProxy):
                     error_file_path=init_error_file,
                     yaml_path=flow_file.as_posix(),
                 ),
-                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,
+                creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if platform.system() == OSType.WINDOWS else 0,
             )
         else:
             # if port is provided, assume the execution service is already started

--- a/src/promptflow-devkit/promptflow/_proxy/_csharp_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/_proxy/_csharp_executor_proxy.py
@@ -182,6 +182,9 @@ class CSharpExecutorProxy(CSharpBaseExecutorProxy):
             else:
                 # for Linux and MacOS, Popen.terminate() will send SIGTERM to the process
                 self._process.terminate()
+
+            # TODO: there is a potential issue that, graceful shutdown won't work for streaming chat flow for now
+            #  because response will not be fully consumed before we destroy the executor proxy
             try:
                 self._process.wait(timeout=5)
             except subprocess.TimeoutExpired:

--- a/src/promptflow-devkit/promptflow/_proxy/_csharp_executor_proxy.py
+++ b/src/promptflow-devkit/promptflow/_proxy/_csharp_executor_proxy.py
@@ -1,8 +1,6 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-import platform
-import signal
 import socket
 import subprocess
 import uuid
@@ -10,7 +8,6 @@ from pathlib import Path
 from typing import NoReturn, Optional
 
 from promptflow._core._errors import UnexpectedError
-from promptflow._sdk._constants import OSType
 from promptflow._utils.flow_utils import is_flex_flow
 from promptflow.storage._run_storage import AbstractRunStorage
 
@@ -175,12 +172,7 @@ class CSharpExecutorProxy(CSharpBaseExecutorProxy):
         # process is not None, it means the executor service is started by the current executor proxy
         # and should be terminated when the executor proxy is destroyed if the service is still active
         if self._process and self._is_executor_active():
-            if platform.system() == OSType.WINDOWS:
-                # send CTRL_C_EVENT to the process to gracefully terminate the service
-                self._process.send_signal(signal.CTRL_C_EVENT)
-            else:
-                # for Linux and MacOS, Popen.terminate() will send SIGTERM to the process
-                self._process.terminate()
+            self._process.terminate()
             try:
                 self._process.wait(timeout=5)
             except subprocess.TimeoutExpired:

--- a/src/promptflow-devkit/promptflow/_proxy/_csharp_inspector_proxy.py
+++ b/src/promptflow-devkit/promptflow/_proxy/_csharp_inspector_proxy.py
@@ -11,7 +11,7 @@ import pydash
 from promptflow._constants import FlowEntryRegex
 from promptflow._core._errors import UnexpectedError
 from promptflow._sdk._constants import ALL_CONNECTION_TYPES, FLOW_TOOLS_JSON, PROMPT_FLOW_DIR_NAME
-from promptflow._utils.flow_utils import read_json_content
+from promptflow._utils.flow_utils import is_flex_flow, read_json_content
 from promptflow._utils.yaml_utils import load_yaml
 
 from ._base_inspector_proxy import AbstractInspectorProxy
@@ -26,6 +26,9 @@ class CSharpInspectorProxy(AbstractInspectorProxy):
     def get_used_connection_names(
         self, flow_file: Path, working_dir: Path, environment_variables_overrides: Dict[str, str] = None
     ) -> List[str]:
+        if is_flex_flow(flow_path=flow_file):
+            # in flex mode, csharp will always directly get connections from local pfs
+            return []
         # TODO: support environment_variables_overrides
         flow_tools_json_path = working_dir / PROMPT_FLOW_DIR_NAME / FLOW_TOOLS_JSON
         tools_meta = read_json_content(flow_tools_json_path, "meta of tools")


### PR DESCRIPTION
# Description

In csharp executor service, traces are sent in parallel with exec response, so it is possible that traces are not fully sent when we try to destroy the executor proxy. To avoid this, we need to enable graceful shutdown for csharp.

To enable graceful shutdown (supported in windows only for now), csharp required a `CTRL_C_EVENT` signal instead of `SIGTERM` signal, which will forcefully shutdown the csharp service.

On the other hand, directly sending `CTRL_C_EVENT` signal will touch all processes in target process group so the main process will also be terminated.

We fix this issue in this PR

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
