### PR TITLE
feat: support pf.run for dynamic callable

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
@@ -153,7 +153,7 @@ class RunSubmitter:
         )
         try:
             batch_engine = BatchEngine(
-                flow.path,
+                run._dynamic_callable or flow.path,
                 flow.code,
                 connections=connections,
                 entry=flow.entry if isinstance(flow, FlexFlow) else None,

--- a/src/promptflow-devkit/promptflow/_sdk/_pf_client.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_pf_client.py
@@ -1,6 +1,7 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
+import inspect
 import json
 import os
 from os import PathLike
@@ -172,6 +173,13 @@ class PFClient:
             raise FileNotFoundError(f"data path {data} does not exist")
         if not run and not data:
             raise ValueError("at least one of data or run must be provided")
+
+        if callable(flow) and not inspect.isclass(flow) and not inspect.isfunction(flow):
+            dynamic_callable = flow
+            flow = flow.__class__
+        else:
+            dynamic_callable = None
+
         with generate_yaml_entry(entry=flow, code=code) as flow:
             # load flow object for validation and early failure
             flow_obj = load_flow(source=flow)
@@ -193,6 +201,7 @@ class PFClient:
                 environment_variables=environment_variables,
                 config=Configuration(overrides=self._config),
                 init=init,
+                dynamic_callable=dynamic_callable,
             )
             return self.runs.create_or_update(run=run, **kwargs)
 

--- a/src/promptflow-devkit/promptflow/_sdk/entities/_run.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_run.py
@@ -196,6 +196,9 @@ class Run(YAMLTranslatableMixin):
         self._identity = kwargs.get("identity", {})
         self._outputs = kwargs.get("outputs", None)
         self._command = kwargs.get("command", None)
+        # To support `pf.run` for dynamic callable, we need to create a run whose target function is a dynamic callable.
+        # TODO: such run is not resumable, not sure if we need specific error message for this case.
+        self._dynamic_callable = kwargs.get("dynamic_callable", None)
         if init:
             self._properties[FlowRunProperties.INIT_KWARGS] = init
 

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -1713,6 +1713,17 @@ class TestFlowRun:
 
             assert_batch_run_result(run, pf, assert_func)
 
+            run = pf.run(
+                flow=MyFlow(obj_input="val"),
+                data=f"{EAGER_FLOWS_DIR}/basic_callable_class/inputs.jsonl",
+                # set code folder to avoid snapshot too big
+                code=f"{EAGER_FLOWS_DIR}/basic_callable_class",
+            )
+            assert run.status == "Completed"
+            assert "error" not in run._to_dict()
+
+            assert_batch_run_result(run, pf, assert_func)
+
 
 def assert_batch_run_result(run: Run, pf: PFClient, assert_func):
     assert run.status == "Completed"


### PR DESCRIPTION
# Description

Support `pf.run` for dynamic callable. If the callable entry is dynamic, we won't support resume for it.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
