### PR TITLE
[trace] Support list line runs with new session id

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_orm/trace.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_orm/trace.py
@@ -189,6 +189,7 @@ class LineRun(Base):
         runs: typing.Optional[typing.List[str]] = None,
         experiments: typing.Optional[typing.List[str]] = None,
         trace_ids: typing.Optional[typing.List[str]] = None,
+        session_id: typing.Optional[str] = None,
     ) -> typing.List["LineRun"]:
         with trace_mgmt_db_session() as session:
             query = session.query(LineRun)
@@ -200,6 +201,8 @@ class LineRun(Base):
                 query = query.filter(LineRun.experiment.in_(experiments))
             elif trace_ids is not None:
                 query = query.filter(LineRun.trace_id.in_(trace_ids))
+            elif session_id is not None:
+                query = query.filter(LineRun.session_id == session_id)
             query = query.order_by(LineRun.start_time.desc())
             if collection is not None:
                 query = query.limit(TRACE_LIST_DEFAULT_LIMIT)

--- a/src/promptflow-devkit/promptflow/_sdk/_service/apis/line_run.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/apis/line_run.py
@@ -31,6 +31,7 @@ class ListLineRunParser:
     runs: typing.Optional[typing.List[str]] = None
     experiments: typing.Optional[typing.List[str]] = None
     trace_ids: typing.Optional[typing.List[str]] = None
+    session_id: typing.Optional[str] = None
 
     @staticmethod
     def _parse_string_list(value: typing.Optional[str]) -> typing.Optional[typing.List[str]]:
@@ -42,10 +43,11 @@ class ListLineRunParser:
     def from_request() -> "ListLineRunParser":
         args = list_line_run_parser.parse_args()
         return ListLineRunParser(
-            collection=args.collection or args.session,
+            collection=args.collection,
             runs=ListLineRunParser._parse_string_list(args.run),
             experiments=ListLineRunParser._parse_string_list(args.experiment),
             trace_ids=ListLineRunParser._parse_string_list(args.trace_ids),
+            session_id=args.session,
         )
 
 
@@ -91,5 +93,6 @@ class LineRuns(Resource):
             runs=args.runs,
             experiments=args.experiments,
             trace_ids=args.trace_ids,
+            session_id=args.session_id,
         )
         return [line_run._to_rest_object() for line_run in line_runs]

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_trace_operations.py
@@ -161,6 +161,7 @@ class TraceOperations:
         runs: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         experiments: typing.Optional[typing.Union[str, typing.List[str]]] = None,
         trace_ids: typing.Optional[typing.Union[str, typing.List[str]]] = None,
+        session_id: typing.Optional[str] = None,
     ) -> typing.List[LineRun]:
         # ensure runs, experiments, and trace_ids are list of string
         if isinstance(runs, str):
@@ -178,6 +179,7 @@ class TraceOperations:
             runs=runs,
             experiments=experiments,
             trace_ids=trace_ids,
+            session_id=session_id,
         )
         line_runs = []
         for obj in orm_line_runs:

--- a/src/promptflow-devkit/tests/sdk_pfs_test/e2etests/test_trace.py
+++ b/src/promptflow-devkit/tests/sdk_pfs_test/e2etests/test_trace.py
@@ -185,3 +185,10 @@ class TestTrace:
             # according to order by logic, the first line run is line 1, the completed
             assert line_runs[0][LineRunFieldName.STATUS] == "Ok"
             assert line_runs[1][LineRunFieldName.STATUS] == RUNNING_LINE_RUN_STATUS
+
+    def test_list_line_run_with_session_id(self, pfs_op: PFSOperations, mock_collection: str) -> None:
+        mock_session_id = str(uuid.uuid4())
+        custom_attributes = {SpanAttributeFieldName.SESSION_ID: mock_session_id}
+        persist_a_span(collection=mock_collection, custom_attributes=custom_attributes)
+        line_runs = pfs_op.list_line_runs(session_id=mock_session_id).json
+        assert len(line_runs) == 1

--- a/src/promptflow-devkit/tests/sdk_pfs_test/utils.py
+++ b/src/promptflow-devkit/tests/sdk_pfs_test/utils.py
@@ -247,6 +247,7 @@ class PFSOperations:
         collection: Optional[str] = None,
         runs: Optional[List[str]] = None,
         trace_ids: Optional[List[str]] = None,
+        session_id: Optional[str] = None,
     ):
         query_string = {}
         if collection is not None:
@@ -255,6 +256,8 @@ class PFSOperations:
             query_string["run"] = ",".join(runs)
         if trace_ids is not None:
             query_string["trace_ids"] = ",".join(trace_ids)
+        if session_id is not None:
+            query_string["session"] = session_id
         response = self._client.get(
             f"{self.LINE_RUNS_PREFIX}/list",
             query_string=query_string,


### PR DESCRIPTION
# Description

Support `session=<session>` in PFS API `/v1.0/LineRuns/list`, so that UX can query those traces with specified session id.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
