### PR TITLE
[trace][feature] Local cache for workspace kind & support `trace.provider=local`

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_utils/_tracing.py
+++ b/src/promptflow-azure/promptflow/azure/_utils/_tracing.py
@@ -9,6 +9,7 @@ from azure.ai.ml import MLClient
 from azure.core.exceptions import ResourceNotFoundError
 
 from promptflow._constants import AzureWorkspaceKind, CosmosDBContainerName
+from promptflow._sdk._tracing import PF_CONFIG_TRACE_LOCAL
 from promptflow._sdk._utils import extract_workspace_triad_from_trace_provider
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow.azure import PFClient
@@ -63,6 +64,10 @@ def validate_trace_provider(value: str) -> None:
     3. the resource is an Azure ML workspace or AI project
     4. the workspace Cosmos DB is initialized
     """
+    if value.lower() == PF_CONFIG_TRACE_LOCAL:
+        _logger.debug(f"trace.provider is set to {PF_CONFIG_TRACE_LOCAL!r}, it's valid and no need to validate.")
+        return
+
     # valid workspace/project ARM resource ID; otherwise, a ValueError will be raised
     _logger.debug("Validating trace provider value...")
     try:

--- a/src/promptflow-core/promptflow/_constants.py
+++ b/src/promptflow-core/promptflow/_constants.py
@@ -286,14 +286,21 @@ class AzureWorkspaceKind:
     HUB = "hub"
     PROJECT = "project"
 
+    # obj can be string or azure.ai.ml.entities.Workspace
     @staticmethod
     def is_workspace(obj) -> bool:
+        if isinstance(obj, str):
+            return obj == AzureWorkspaceKind.DEFAULT
         return obj._kind == AzureWorkspaceKind.DEFAULT
 
     @staticmethod
     def is_hub(obj) -> bool:
+        if isinstance(obj, str):
+            return obj == AzureWorkspaceKind.HUB
         return obj._kind == AzureWorkspaceKind.HUB
 
     @staticmethod
     def is_project(obj) -> bool:
+        if isinstance(obj, str):
+            return obj == AzureWorkspaceKind.PROJECT
         return obj._kind == AzureWorkspaceKind.PROJECT

--- a/src/promptflow-devkit/promptflow/_sdk/_configuration.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_configuration.py
@@ -18,7 +18,7 @@ from promptflow._sdk._constants import (
     SERVICE_CONFIG_FILE,
 )
 from promptflow._sdk._errors import MissingAzurePackage
-from promptflow._sdk._tracing import PF_CONFIG_TRACE_FEATURE_DISABLE
+from promptflow._sdk._tracing import PF_CONFIG_TRACE_FEATURE_DISABLE, PF_CONFIG_TRACE_LOCAL
 from promptflow._sdk._utils import call_from_extension, gen_uuid_by_compute_info, read_write_by_user
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow._utils.yaml_utils import dump_yaml, load_yaml
@@ -222,6 +222,9 @@ class Configuration(object):
         elif key == Configuration.TRACE_PROVIDER:
             # disable trace feature, no need to validate
             if value.lower() == PF_CONFIG_TRACE_FEATURE_DISABLE:
+                return
+            # enable trace feature, but disable local to cloud
+            if value.lower() == PF_CONFIG_TRACE_LOCAL:
                 return
             try:
                 from promptflow.azure._utils._tracing import validate_trace_provider

--- a/src/promptflow-devkit/promptflow/_sdk/_tracing.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing.py
@@ -58,6 +58,7 @@ from promptflow.tracing._operation_context import OperationContext
 _logger = get_cli_sdk_logger()
 
 PF_CONFIG_TRACE_FEATURE_DISABLE = "none"
+PF_CONFIG_TRACE_LOCAL = "local"
 TRACER_PROVIDER_PFS_EXPORTER_SET_ATTR = "_pfs_exporter_set"
 
 
@@ -151,6 +152,9 @@ def _get_ws_triad_from_pf_config() -> typing.Optional[AzureMLWorkspaceTriad]:
     from promptflow._sdk._configuration import Configuration
 
     ws_arm_id = Configuration.get_instance().get_trace_provider()
+    # enable local only trace feature, no workspace
+    if ws_arm_id == PF_CONFIG_TRACE_LOCAL:
+        return
     return extract_workspace_triad_from_trace_provider(ws_arm_id) if ws_arm_id is not None else None
 
 

--- a/src/promptflow-devkit/promptflow/_sdk/_tracing_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing_utils.py
@@ -59,7 +59,6 @@ class WorkspaceKindLocalCache:
         return time_delta.days > WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS
 
     def get_kind(self) -> str:
-        _logger.debug(f"local cache timestamp: {self.timestamp.isoformat()}")
         if not self.is_cache_exists or self.is_expired:
             _logger.debug(f"refreshing local cache for resource {self.workspace_name}...")
             self._refresh()

--- a/src/promptflow-devkit/promptflow/_sdk/_tracing_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing_utils.py
@@ -1,0 +1,112 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+
+import datetime
+import json
+import typing
+from dataclasses import dataclass
+from pathlib import Path
+
+from promptflow._sdk._constants import HOME_PROMPT_FLOW_DIR, AzureMLWorkspaceTriad
+from promptflow._sdk._utils import json_load
+from promptflow._utils.logger_utils import get_cli_sdk_logger
+from promptflow.core._errors import MissingRequiredPackage
+
+_logger = get_cli_sdk_logger()
+
+PF_DIR_TRACING = "tracing"
+WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS = 1
+
+
+@dataclass
+class WorkspaceKindLocalCache:
+    subscription_id: str
+    resource_group_name: str
+    workspace_name: str
+    kind: typing.Optional[str] = None
+    timestamp: typing.Optional[datetime.datetime] = None
+
+    SUBSCRIPTION_ID = "subscription_id"
+    RESOURCE_GROUP_NAME = "resource_group_name"
+    WORKSPACE_NAME = "workspace_name"
+    KIND = "kind"
+    TIMESTAMP = "timestamp"
+
+    def __post_init__(self):
+        if self.is_cache_exists:
+            cache = json_load(self.cache_path)
+            self.kind = cache[self.KIND]
+            self.timestamp = datetime.datetime.fromisoformat(cache[self.TIMESTAMP])
+
+    @property
+    def cache_path(self) -> Path:
+        tracing_dir = HOME_PROMPT_FLOW_DIR / PF_DIR_TRACING
+        if not tracing_dir.exists():
+            tracing_dir.mkdir(parents=True)
+        filename = f"{self.subscription_id}_{self.resource_group_name}_{self.workspace_name}.json"
+        return (tracing_dir / filename).resolve()
+
+    @property
+    def is_cache_exists(self) -> bool:
+        return self.cache_path.is_file()
+
+    @property
+    def is_expired(self) -> bool:
+        if not self.is_cache_exists:
+            return True
+        time_delta = datetime.datetime.now() - self.timestamp
+        return time_delta.days > WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS
+
+    def get_kind(self) -> str:
+        _logger.debug(f"local cache timestamp: {self.timestamp.isoformat()}")
+        if not self.is_cache_exists or self.is_expired:
+            _logger.debug(f"refreshing local cache for resource {self.workspace_name}...")
+            self._refresh()
+        _logger.debug(f"local cache kind for resource {self.workspace_name}: {self.kind}")
+        return self.kind
+
+    def _refresh(self) -> None:
+        self.kind = self._get_workspace_kind_from_azure()
+        self.timestamp = datetime.datetime.now()
+        cache = {
+            self.SUBSCRIPTION_ID: self.subscription_id,
+            self.RESOURCE_GROUP_NAME: self.resource_group_name,
+            self.WORKSPACE_NAME: self.workspace_name,
+            self.KIND: self.kind,
+            self.TIMESTAMP: self.timestamp.isoformat(),
+        }
+        with open(self.cache_path, "w") as f:
+            f.write(json.dumps(cache))
+
+    def _get_workspace_kind_from_azure(self) -> str:
+        try:
+            from azure.ai.ml import MLClient
+
+            from promptflow.azure._cli._utils import get_credentials_for_cli
+        except ImportError:
+            error_message = "Please install 'promptflow-azure' to use Azure related tracing features."
+            raise MissingRequiredPackage(message=error_message)
+
+        _logger.debug("trying to get workspace from Azure...")
+        ml_client = MLClient(
+            credential=get_credentials_for_cli(),
+            subscription_id=self.subscription_id,
+            resource_group_name=self.resource_group_name,
+            workspace_name=self.workspace_name,
+        )
+        ws = ml_client.workspaces.get(name=self.workspace_name)
+        return ws._kind
+
+
+def get_workspace_kind(ws_triad: AzureMLWorkspaceTriad) -> str:
+    """Get workspace kind.
+
+    Note that we will cache this result locally with timestamp, so that we don't
+    really need to request every time, but need to check timestamp.
+    """
+    return WorkspaceKindLocalCache(
+        subscription_id=ws_triad.subscription_id,
+        resource_group_name=ws_triad.resource_group_name,
+        workspace_name=ws_triad.workspace_name,
+    ).get_kind()

--- a/src/promptflow-devkit/promptflow/_sdk/_tracing_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing_utils.py
@@ -15,9 +15,6 @@ from promptflow.core._errors import MissingRequiredPackage
 
 _logger = get_cli_sdk_logger()
 
-PF_DIR_TRACING = "tracing"
-WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS = 1
-
 
 @dataclass
 class WorkspaceKindLocalCache:
@@ -32,6 +29,9 @@ class WorkspaceKindLocalCache:
     WORKSPACE_NAME = "workspace_name"
     KIND = "kind"
     TIMESTAMP = "timestamp"
+    # class-related constants
+    PF_DIR_TRACING = "tracing"
+    WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS = 1
 
     def __post_init__(self):
         if self.is_cache_exists:
@@ -41,7 +41,7 @@ class WorkspaceKindLocalCache:
 
     @property
     def cache_path(self) -> Path:
-        tracing_dir = HOME_PROMPT_FLOW_DIR / PF_DIR_TRACING
+        tracing_dir = HOME_PROMPT_FLOW_DIR / self.PF_DIR_TRACING
         if not tracing_dir.exists():
             tracing_dir.mkdir(parents=True)
         filename = f"{self.subscription_id}_{self.resource_group_name}_{self.workspace_name}.json"
@@ -56,7 +56,7 @@ class WorkspaceKindLocalCache:
         if not self.is_cache_exists:
             return True
         time_delta = datetime.datetime.now() - self.timestamp
-        return time_delta.days > WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS
+        return time_delta.days > self.WORKSPACE_KIND_LOCAL_CACHE_EXPIRE_DAYS
 
     def get_kind(self) -> str:
         if not self.is_cache_exists or self.is_expired:

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_trace.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_trace.py
@@ -25,12 +25,14 @@ from promptflow._constants import (
     TraceEnvironmentVariableName,
 )
 from promptflow._sdk._constants import (
+    HOME_PROMPT_FLOW_DIR,
     PF_TRACE_CONTEXT,
     PF_TRACE_CONTEXT_ATTR,
     TRACE_DEFAULT_COLLECTION,
     ContextAttributeKey,
 )
 from promptflow._sdk._tracing import start_trace_with_devkit
+from promptflow._sdk._tracing_utils import WorkspaceKindLocalCache
 from promptflow._sdk.operations._trace_operations import TraceOperations
 from promptflow.client import PFClient
 from promptflow.exceptions import UserErrorException
@@ -211,3 +213,67 @@ class TestTraceOperations:
         _validate_invalid_params({"run": str(uuid.uuid4()), "started_before": datetime.datetime.now().isoformat()})
         _validate_invalid_params({"collection": TRACE_DEFAULT_COLLECTION})
         _validate_invalid_params({"collection": str(uuid.uuid4()), "started_before": "invalid isoformat"})
+
+
+@pytest.mark.unittest
+@pytest.mark.sdk_test
+class TestWorkspaceKindLocalCache:
+    def test_no_cache(self):
+        mock_sub, mock_rg, mock_ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        ws_local_cache = WorkspaceKindLocalCache(
+            subscription_id=mock_sub, resource_group_name=mock_rg, workspace_name=mock_ws
+        )
+        assert not ws_local_cache.is_cache_exists
+        # mock `WorkspaceKindLocalCache._get_workspace_kind_from_azure`
+        mock_kind = str(uuid.uuid4())
+        with patch(
+            "promptflow._sdk._tracing_utils.WorkspaceKindLocalCache._get_workspace_kind_from_azure"
+        ) as mock_get_kind:
+            mock_get_kind.return_value = mock_kind
+            assert ws_local_cache.get_kind() == mock_kind
+
+    def test_valid_cache(self):
+        mock_sub, mock_rg, mock_ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        # manually create a valid local cache
+        mock_kind = str(uuid.uuid4())
+        with open(HOME_PROMPT_FLOW_DIR / "tracing" / f"{mock_sub}_{mock_rg}_{mock_ws}.json", "w") as f:
+            cache = {
+                WorkspaceKindLocalCache.SUBSCRIPTION_ID: mock_sub,
+                WorkspaceKindLocalCache.RESOURCE_GROUP_NAME: mock_rg,
+                WorkspaceKindLocalCache.WORKSPACE_NAME: mock_ws,
+                WorkspaceKindLocalCache.KIND: mock_kind,
+                WorkspaceKindLocalCache.TIMESTAMP: datetime.datetime.now().isoformat(),
+            }
+            f.write(json.dumps(cache))
+        ws_local_cache = WorkspaceKindLocalCache(
+            subscription_id=mock_sub, resource_group_name=mock_rg, workspace_name=mock_ws
+        )
+        assert ws_local_cache.is_cache_exists is True
+        assert not ws_local_cache.is_expired
+        assert ws_local_cache.get_kind() == mock_kind
+
+    def test_expired_cache(self):
+        mock_sub, mock_rg, mock_ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        # manually create an expired local cache
+        with open(HOME_PROMPT_FLOW_DIR / "tracing" / f"{mock_sub}_{mock_rg}_{mock_ws}.json", "w") as f:
+            cache = {
+                WorkspaceKindLocalCache.SUBSCRIPTION_ID: mock_sub,
+                WorkspaceKindLocalCache.RESOURCE_GROUP_NAME: mock_rg,
+                WorkspaceKindLocalCache.WORKSPACE_NAME: mock_ws,
+                WorkspaceKindLocalCache.KIND: str(uuid.uuid4()),  # this value is not important as it will be refreshed
+                WorkspaceKindLocalCache.TIMESTAMP: (datetime.datetime.now() - datetime.timedelta(days=7)).isoformat(),
+            }
+            f.write(json.dumps(cache))
+        ws_local_cache = WorkspaceKindLocalCache(
+            subscription_id=mock_sub, resource_group_name=mock_rg, workspace_name=mock_ws
+        )
+        assert ws_local_cache.is_cache_exists is True
+        assert ws_local_cache.is_expired is True
+        # mock `WorkspaceKindLocalCache._get_workspace_kind_from_azure`
+        mock_kind = str(uuid.uuid4())
+        with patch(
+            "promptflow._sdk._tracing_utils.WorkspaceKindLocalCache._get_workspace_kind_from_azure"
+        ) as mock_get_kind:
+            mock_get_kind.return_value = mock_kind
+            assert ws_local_cache.get_kind() == mock_kind
+        assert not ws_local_cache.is_expired

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_trace.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_trace.py
@@ -219,10 +219,8 @@ class TestTraceOperations:
 @pytest.mark.sdk_test
 class TestWorkspaceKindLocalCache:
     def test_no_cache(self):
-        mock_sub, mock_rg, mock_ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
-        ws_local_cache = WorkspaceKindLocalCache(
-            subscription_id=mock_sub, resource_group_name=mock_rg, workspace_name=mock_ws
-        )
+        sub, rg, ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        ws_local_cache = WorkspaceKindLocalCache(subscription_id=sub, resource_group_name=rg, workspace_name=ws)
         assert not ws_local_cache.is_cache_exists
         # mock `WorkspaceKindLocalCache._get_workspace_kind_from_azure`
         mock_kind = str(uuid.uuid4())
@@ -233,47 +231,43 @@ class TestWorkspaceKindLocalCache:
             assert ws_local_cache.get_kind() == mock_kind
 
     def test_valid_cache(self):
-        mock_sub, mock_rg, mock_ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        sub, rg, ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         # manually create a valid local cache
-        mock_kind = str(uuid.uuid4())
-        with open(HOME_PROMPT_FLOW_DIR / "tracing" / f"{mock_sub}_{mock_rg}_{mock_ws}.json", "w") as f:
+        kind = str(uuid.uuid4())
+        with open(HOME_PROMPT_FLOW_DIR / WorkspaceKindLocalCache.PF_DIR_TRACING / f"{sub}_{rg}_{ws}.json", "w") as f:
             cache = {
-                WorkspaceKindLocalCache.SUBSCRIPTION_ID: mock_sub,
-                WorkspaceKindLocalCache.RESOURCE_GROUP_NAME: mock_rg,
-                WorkspaceKindLocalCache.WORKSPACE_NAME: mock_ws,
-                WorkspaceKindLocalCache.KIND: mock_kind,
+                WorkspaceKindLocalCache.SUBSCRIPTION_ID: sub,
+                WorkspaceKindLocalCache.RESOURCE_GROUP_NAME: rg,
+                WorkspaceKindLocalCache.WORKSPACE_NAME: ws,
+                WorkspaceKindLocalCache.KIND: kind,
                 WorkspaceKindLocalCache.TIMESTAMP: datetime.datetime.now().isoformat(),
             }
             f.write(json.dumps(cache))
-        ws_local_cache = WorkspaceKindLocalCache(
-            subscription_id=mock_sub, resource_group_name=mock_rg, workspace_name=mock_ws
-        )
+        ws_local_cache = WorkspaceKindLocalCache(subscription_id=sub, resource_group_name=rg, workspace_name=ws)
         assert ws_local_cache.is_cache_exists is True
         assert not ws_local_cache.is_expired
-        assert ws_local_cache.get_kind() == mock_kind
+        assert ws_local_cache.get_kind() == kind
 
     def test_expired_cache(self):
-        mock_sub, mock_rg, mock_ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
+        sub, rg, ws = str(uuid.uuid4()), str(uuid.uuid4()), str(uuid.uuid4())
         # manually create an expired local cache
-        with open(HOME_PROMPT_FLOW_DIR / "tracing" / f"{mock_sub}_{mock_rg}_{mock_ws}.json", "w") as f:
+        with open(HOME_PROMPT_FLOW_DIR / WorkspaceKindLocalCache.PF_DIR_TRACING / f"{sub}_{rg}_{ws}.json", "w") as f:
             cache = {
-                WorkspaceKindLocalCache.SUBSCRIPTION_ID: mock_sub,
-                WorkspaceKindLocalCache.RESOURCE_GROUP_NAME: mock_rg,
-                WorkspaceKindLocalCache.WORKSPACE_NAME: mock_ws,
+                WorkspaceKindLocalCache.SUBSCRIPTION_ID: sub,
+                WorkspaceKindLocalCache.RESOURCE_GROUP_NAME: rg,
+                WorkspaceKindLocalCache.WORKSPACE_NAME: ws,
                 WorkspaceKindLocalCache.KIND: str(uuid.uuid4()),  # this value is not important as it will be refreshed
                 WorkspaceKindLocalCache.TIMESTAMP: (datetime.datetime.now() - datetime.timedelta(days=7)).isoformat(),
             }
             f.write(json.dumps(cache))
-        ws_local_cache = WorkspaceKindLocalCache(
-            subscription_id=mock_sub, resource_group_name=mock_rg, workspace_name=mock_ws
-        )
+        ws_local_cache = WorkspaceKindLocalCache(subscription_id=sub, resource_group_name=rg, workspace_name=ws)
         assert ws_local_cache.is_cache_exists is True
         assert ws_local_cache.is_expired is True
         # mock `WorkspaceKindLocalCache._get_workspace_kind_from_azure`
-        mock_kind = str(uuid.uuid4())
+        kind = str(uuid.uuid4())
         with patch(
             "promptflow._sdk._tracing_utils.WorkspaceKindLocalCache._get_workspace_kind_from_azure"
         ) as mock_get_kind:
-            mock_get_kind.return_value = mock_kind
-            assert ws_local_cache.get_kind() == mock_kind
+            mock_get_kind.return_value = kind
+            assert ws_local_cache.get_kind() == kind
         assert not ws_local_cache.is_expired


### PR DESCRIPTION
# Description

**Local cache for Azure ML workspace/AI project type**

Local cache resource type, so that we don't need to request Azure everytime. There is a timeout 1 day, so that we can avoid missing the Cosmos status in the future.

**Support `trace.provider=local`**

Enable local only trace feature.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
