### PR TITLE
Convert input data in advance to make sure image is correct for root span

### DIFF
--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -841,7 +841,6 @@ class FlowExecutor:
         run_info: FlowRunInfo,
         run_tracker: RunTracker,
         context: FlowExecutionContext,
-        validate_inputs=False,
         allow_generator_output=False,
     ):
         # need to get everytime to ensure tracer is latest
@@ -865,7 +864,6 @@ class FlowExecutor:
                 run_info,
                 run_tracker,
                 context,
-                validate_inputs,
                 allow_generator_output,
             )
             # enrich span with trace type
@@ -880,15 +878,8 @@ class FlowExecutor:
         run_info: FlowRunInfo,
         run_tracker: RunTracker,
         context: FlowExecutionContext,
-        validate_inputs=False,
         allow_generator_output=False,
     ):
-        if validate_inputs:
-            inputs = FlowValidator.ensure_flow_inputs_type(flow=self._flow, inputs=inputs, idx=run_info.index)
-        inputs = self._multimedia_processor.load_multimedia_data(self._flow.inputs, inputs)
-        # Inputs are assigned after validation and multimedia data loading, instead of at the start of the flow run.
-        # This way, if validation or multimedia data loading fails, we avoid persisting invalid inputs.
-        run_info.inputs = inputs
         output, nodes_outputs = self._traverse_nodes(inputs, context)
         output = self._stringify_generator_output(output) if not allow_generator_output else output
         # Persist the node runs for the nodes that have a generator output
@@ -952,12 +943,17 @@ class FlowExecutor:
         output = {}
         aggregation_inputs = {}
         try:
+            if validate_inputs:
+                inputs = FlowValidator.ensure_flow_inputs_type(flow=self._flow, inputs=inputs, idx=run_info.index)
+            inputs = self._multimedia_processor.load_multimedia_data(self._flow.inputs, inputs)
+            # Inputs are assigned after validation and multimedia data loading, instead of at the start of the flow run.
+            # This way, if validation or multimedia data loading fails, we avoid persisting invalid inputs.
+            run_info.inputs = inputs
             output, aggregation_inputs = self._exec_inner_with_trace(
                 inputs,
                 run_info,
                 run_tracker,
                 context,
-                validate_inputs,
                 allow_generator_output,
             )
         except KeyboardInterrupt as ex:


### PR DESCRIPTION
# Description

Before, we load flow input image after creating root span. Which makes we only have input image's path for root span.
![image](https://github.com/microsoft/promptflow/assets/17527303/893346c5-6398-4633-b8dc-858260ebe49f)


In this PR, we load flow input image in advance to record correct image data in root span.
![image](https://github.com/microsoft/promptflow/assets/17527303/b65b6ce7-1cf2-4621-89b8-e9b489d28501)


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
