### PR TITLE
[fundamental][bugfix] Make check-enforcer wait longer

### DIFF
--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -28,7 +28,7 @@ import sys
 github_repository = "microsoft/promptflow"
 snippet_debug = os.getenv("SNIPPET_DEBUG", 0)
 merge_commit = ""
-loop_times = 60  # 60 * 30 seconds = 30 minutes
+loop_times = 40  # 40 * 30 seconds = 20 minutes
 github_workspace = os.path.expanduser("~/promptflow/")
 
 # Special cases for pipelines that need to be triggered more or less than default value 1.
@@ -279,7 +279,7 @@ def run_checks():
     if failed_reason != "":
         raise Exception(failed_reason)
 
-    # Loop for 30 minutes at most.
+    # Loop for 20 minutes at most.
     for i in range(loop_times):
         # Wait for 30 seconds.
         time.sleep(30)

--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -279,7 +279,7 @@ def run_checks():
     if failed_reason != "":
         raise Exception(failed_reason)
 
-    # Loop for 15 minutes at most.
+    # Loop for 30 minutes at most.
     for i in range(loop_times):
         # Wait for 30 seconds.
         time.sleep(30)

--- a/scripts/check_enforcer/check_enforcer.py
+++ b/scripts/check_enforcer/check_enforcer.py
@@ -28,7 +28,7 @@ import sys
 github_repository = "microsoft/promptflow"
 snippet_debug = os.getenv("SNIPPET_DEBUG", 0)
 merge_commit = ""
-loop_times = 30
+loop_times = 60  # 60 * 30 seconds = 30 minutes
 github_workspace = os.path.expanduser("~/promptflow/")
 
 # Special cases for pipelines that need to be triggered more or less than default value 1.


### PR DESCRIPTION
# Description

We observe the CI are getting slower and slower, and as we target Build, we have little time to improve perf; so just make check-enforcer wait longer (from 15min to 20min), so that everyone does not need to rerun that workflow.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
