### PR TITLE
Handle job cancellation for root span

### DIFF
--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -881,7 +881,7 @@ class FlowExecutor:
         except KeyboardInterrupt as ex:
             if span.is_recording():
                 span.record_exception(ex)
-                span.set_status(StatusCode.ERROR, "KeyboardInterrupt received, execution cancelled.")
+                span.set_status(StatusCode.ERROR, "Execution cancelled.")
             raise
 
     def _exec_inner(

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -879,8 +879,9 @@ class FlowExecutor:
         try:
             yield
         except KeyboardInterrupt as ex:
-            span.record_exception(ex)
-            span.set_status(StatusCode.ERROR, "KeyboardInterrupt received, execution cancelled.")
+            if span.is_recording():
+                span.record_exception(ex)
+                span.set_status(StatusCode.ERROR, "KeyboardInterrupt received, execution cancelled.")
             raise
 
     def _exec_inner(

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -18,7 +18,7 @@ from types import GeneratorType
 from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
 
 import opentelemetry.trace as otel_trace
-from opentelemetry.trace.span import format_trace_id
+from opentelemetry.trace.span import Span, format_trace_id
 from opentelemetry.trace.status import StatusCode
 
 from promptflow._constants import LINE_NUMBER_KEY
@@ -847,7 +847,7 @@ class FlowExecutor:
     ):
         # need to get everytime to ensure tracer is latest
         otel_tracer = otel_trace.get_tracer("promptflow")
-        with otel_tracer.start_as_current_span(self._flow.name) as span:
+        with otel_tracer.start_as_current_span(self._flow.name) as span, self._record_keyboard_interrupt_to_span(span):
             # Store otel trace id in context for correlation
             OperationContext.get_instance()["otel_trace_id"] = f"0x{format_trace_id(span.get_span_context().trace_id)}"
             # initialize span
@@ -873,6 +873,15 @@ class FlowExecutor:
             # set status
             span.set_status(StatusCode.OK)
             return output, aggregation_inputs
+
+    @contextlib.contextmanager
+    def _record_keyboard_interrupt_to_span(self, span: Span):
+        try:
+            yield
+        except KeyboardInterrupt as ex:
+            span.record_exception(ex)
+            span.set_status(StatusCode.ERROR, "KeyboardInterrupt received, execution cancelled.")
+            raise
 
     def _exec_inner(
         self,

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -976,9 +976,6 @@ class FlowExecutor:
             # Update the run info of those running nodes to a canceled status.
             run_tracker.cancel_node_runs(run_id)
             run_tracker.end_run(line_run_id, ex=ex)
-            # If async execution is enabled, ignore this exception and return the partial line results.
-            if not self._should_use_async():
-                raise
         except Exception as ex:
             run_tracker.end_run(line_run_id, ex=ex)
             if self._raise_ex:

--- a/src/promptflow/tests/executor/e2etests/test_concurent_execution.py
+++ b/src/promptflow/tests/executor/e2etests/test_concurent_execution.py
@@ -47,7 +47,7 @@ class TestConcurrentExecution:
     def test_concurrent_run_with_exception(self):
         executor = FlowExecutor.create(get_yaml_file(FLOW_FOLDER), {}, raise_ex=False)
         flow_result = executor.exec_line({"input1": "True", "input2": "False", "input3": "False", "input4": "False"})
-        assert 2 < flow_result.run_info.system_metrics["duration"] < 4, "Should at least finish the running job."
+        assert 1 > flow_result.run_info.system_metrics["duration"], "Will finish quickly with exception."
         error_response = ErrorResponse.from_error_dict(flow_result.run_info.error)
         assert error_response.error_code_hierarchy == "UserError/ToolExecutionError"
 

--- a/src/promptflow/tests/executor/e2etests/test_logs.py
+++ b/src/promptflow/tests/executor/e2etests/test_logs.py
@@ -113,10 +113,10 @@ class TestExecutorLogs:
             assert 40 <= line_count <= 50
 
     @pytest.mark.parametrize(
-        "flow_root_dir, flow_folder_name, line_number",
+        "flow_root_dir, flow_folder_name, max_line_number",
         [[FLOW_ROOT, "print_input_flow", 8], [EAGER_FLOW_ROOT, "print_input_flex", 2]],
     )
-    def test_batch_run_flow_logs(self, flow_root_dir, flow_folder_name, line_number):
+    def test_batch_run_flow_logs(self, flow_root_dir, flow_folder_name, max_line_number):
         logs_directory = Path(mkdtemp())
         bulk_run_log_path = str(logs_directory / "test_bulk_run.log")
         bulk_run_flow_logs_folder = str(logs_directory / "test_bulk_run_flow_logs_folder")
@@ -133,7 +133,11 @@ class TestExecutorLogs:
                 assert "execution          WARNING" in log_content
                 assert "execution.flow     INFO" in log_content
                 assert f"in line {i} (index starts from 0)" in log_content
-                assert line_number == count_lines(flow_log_file)
+                # Some monitor logs may not be printed in CI test.
+                # Assert max line number to avoid printing too many noisy logs.
+                assert max_line_number >= count_lines(
+                    flow_log_file
+                ), f"log line count is incorrect, content is {log_content}"
 
     @pytest.mark.parametrize(
         "folder_name",

--- a/src/promptflow/tests/executor/e2etests/test_logs.py
+++ b/src/promptflow/tests/executor/e2etests/test_logs.py
@@ -113,10 +113,10 @@ class TestExecutorLogs:
             assert 40 <= line_count <= 50
 
     @pytest.mark.parametrize(
-        "flow_root_dir, flow_folder_name, max_line_number",
+        "flow_root_dir, flow_folder_name, line_number",
         [[FLOW_ROOT, "print_input_flow", 8], [EAGER_FLOW_ROOT, "print_input_flex", 2]],
     )
-    def test_batch_run_flow_logs(self, flow_root_dir, flow_folder_name, max_line_number):
+    def test_batch_run_flow_logs(self, flow_root_dir, flow_folder_name, line_number):
         logs_directory = Path(mkdtemp())
         bulk_run_log_path = str(logs_directory / "test_bulk_run.log")
         bulk_run_flow_logs_folder = str(logs_directory / "test_bulk_run_flow_logs_folder")
@@ -135,7 +135,7 @@ class TestExecutorLogs:
                 assert f"in line {i} (index starts from 0)" in log_content
                 # Some monitor logs may not be printed in CI test.
                 # Assert max line number to avoid printing too many noisy logs.
-                assert max_line_number >= count_lines(
+                assert line_number == count_lines(
                     flow_log_file
                 ), f"log line count is incorrect, content is {log_content}"
 


### PR DESCRIPTION
# Description
1. Record KeyboardInterrupt exception for span (otlp's code doesn't handle BaseException but only Exception)
2. Raise KeyboardInterrupt in FlowNodesScheduler
3. Remove `with ThreadPoolExecutor` to guarantee KeyboardInterrupt could be received by outside.

Why make this change: **we want to support cancellation for span.**

We have 2 schedulers, one is FlowNodesScheduler, another is AsyncNodesScheduler.

For most cases, we are using FlowNodesScheduler.
In FlowNodesScheduler, there is `with ThreadPoolExecutor`, which will wait all running threads finish, no matter what exception is raised. That's why our cancellation is blocked.
![image](https://github.com/microsoft/promptflow/assets/17527303/b6a1a63a-8425-445c-95ec-bf4d2d833787)

So, in this PR, remove the `with ThreadPoolExecutor` to make the KeyboardInterrupt could be received by outside.

Why also change other tests:
For now, our exception could be received by outside immediately, the exception type and execution time are affected.

For test_batch_timeout, situation is very complex.
The test set 5 seconds batch run timeout and 600 seconds line run timeout.
But actually, for batch run execution, line run timeout is calculated by batch run timeout. So, 600 seconds won't take effect, the real line run timeout is less than 5 seconds.
But before this change, even we raise line run timeout exception, we can't exit ThreadPoolExecutor to finish line run.
From process perspective, the line run has never finish, so assign one `BatchExecutionTimeoutError`.
After this change, line run timeout exception could be raised out soon, so the behavior is changed.


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
