### PR TITLE
[Draft] Add EvaluationContext for joining evaluation spans

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_eval_context.py
+++ b/src/promptflow-tracing/promptflow/tracing/_eval_context.py
@@ -1,0 +1,58 @@
+import contextlib
+from typing import Optional
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.trace import format_span_id, format_trace_id
+
+from ._operation_context import OperationContext
+from ._trace import get_last_span
+
+
+@contextlib.contextmanager
+def evaluation_context(span: Optional[ReadableSpan] = None):
+    if span is None:
+        span = get_last_span()
+    if not isinstance(span, ReadableSpan):
+        yield
+        return
+    trace_id = f"0x{format_trace_id(span.context.trace_id)}"
+    line_run_id = span.attributes.get("line_run_id") or trace_id
+    ctx = OperationContext.get_instance()
+    ctx._add_otel_attributes("referenced.line_run_id", line_run_id)
+    try:
+        yield
+    finally:
+        ctx._remove_otel_attributes(["referenced.line_run_id"])
+
+
+class EvaluationContext:
+    def __init__(self, span: Optional[ReadableSpan] = None):
+        self._span_to_evaluate = span
+        self._otel_attributes = {}
+        if span is None:
+            span = get_last_span()
+        if span is None:
+            return
+        trace_id = f"0x{format_trace_id(span.context.trace_id)}"
+        self._otel_attributes = {
+            "referenced.line_run_id": span.attributes.get("line_run_id") or trace_id,
+            "referenced.trace_id": trace_id,
+            "referenced.span_id": f"0x{format_span_id(span.context.span_id)}",
+        }
+        self._original_attributes = {}
+        self._original_ctx = OperationContext.get_instance()
+
+    def __enter__(self):
+        #  Add the OTel attributes to the current context
+        self._original_ctx = OperationContext.get_instance()
+        self._original_attributes = self._original_ctx._get_otel_attributes().copy()
+        for key, value in self._otel_attributes.items():
+            self._original_ctx._add_otel_attributes(key, value)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        #  Restore the original context
+        self._original_ctx._remove_otel_attributes(list(self._otel_attributes.keys()))
+        for key, value in self._original_attributes.items():
+            self._original_ctx._add_otel_attributes(key, value)
+        return False  # Propagate exceptions, if any

--- a/src/promptflow-tracing/promptflow/tracing/_experimental/__init__.py
+++ b/src/promptflow-tracing/promptflow/tracing/_experimental/__init__.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+from .._eval_context import EvaluationContext
 from .._trace import enrich_prompt_template
 
-__all__ = ["enrich_prompt_template"]
+__all__ = ["enrich_prompt_template", "EvaluationContext"]

--- a/src/promptflow-tracing/tests/unittests/test_eval_utils.py
+++ b/src/promptflow-tracing/tests/unittests/test_eval_utils.py
@@ -1,0 +1,54 @@
+import pytest
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import format_span_id, format_trace_id, get_current_span, get_tracer, set_tracer_provider
+
+from promptflow.tracing import trace
+from promptflow.tracing._experimental import EvaluationContext
+
+
+def prepare_memory_exporter():
+    provider = TracerProvider()
+    exporter = InMemorySpanExporter()
+    processor = SimpleSpanProcessor(exporter)
+    provider.add_span_processor(processor)
+    set_tracer_provider(provider)
+    return exporter
+
+
+@trace
+def do_nothing():
+    pass
+
+
+@trace
+def assert_eval_span(last: ReadableSpan):
+    current_span = get_current_span()
+    assert isinstance(current_span, ReadableSpan)
+    attrs = current_span.attributes
+    last_ctx = last.get_span_context()
+    trace_id = f"0x{format_trace_id(last_ctx.trace_id)}"
+    span_id = f"0x{format_span_id(last_ctx.span_id)}"
+    for key, value in [
+        ("referenced.trace_id", trace_id),
+        ("referenced.span_id", span_id),
+        # For the span without line_run_id, it should use trace_id as line_run_id
+        ("referenced.line_run_id", trace_id),
+    ]:
+        value_in_attrs = attrs.get(key)
+        assert value_in_attrs == value, f"Expect {value} but got {value_in_attrs} for key {key}"
+
+
+@pytest.mark.unittest
+def test_evaluation_context():
+    prepare_memory_exporter()
+    tracer = get_tracer(__name__)
+    with tracer.start_as_current_span("test_span") as span:
+        last = span
+        # Currently only when traced function is called in the same thread
+        # the context can be correctly set
+        # TODO: Even the user doesn't use @trace, we should still be able to set the context
+        do_nothing()
+    with EvaluationContext():
+        assert_eval_span(last)


### PR DESCRIPTION
# Description

This pull request introduces several changes to the `src/promptflow-tracing` package, particularly to the `promptflow/tracing/_eval_context.py`, `promptflow/tracing/_experimental/__init__.py`, and `promptflow/tracing/_trace.py` files. The changes mainly focus on enhancing the tracing functionality by adding an `EvaluationContext` class and a `LastSpanExporter` class, and modifying the `wrapped` function. A test for the `EvaluationContext` class has also been added.

Enhancements to tracing functionality:

* [`src/promptflow-tracing/promptflow/tracing/_eval_context.py`](diffhunk://#diff-852e4e34f2f686065ae1753ba9cf6484f27f1534f1d220bac3fdee7542ba96d7R1-R58): Introduced a new `EvaluationContext` class and a `evaluation_context` context manager function. These additions help manage the context for tracing evaluations, with the `EvaluationContext` class handling the addition and removal of OpenTelemetry (OTel) attributes to the current context.

* [`src/promptflow-tracing/promptflow/tracing/_experimental/__init__.py`](diffhunk://#diff-1802544457e64dd94fdc08a2fb09318a23561fcdd37dbd72ec5d568c3edf3ea7R5-R8): Added `EvaluationContext` to the list of exported objects, making it accessible to other modules.

* [`src/promptflow-tracing/promptflow/tracing/_trace.py`](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcL12-R16): Introduced a new `LastSpanExporter` class, which holds the last span exported and adds itself to the tracer. This class is used in the `wrapped` function to add the `LastSpanExporter` to the tracer. Additionally, a `get_last_span` function has been added to retrieve the last span. [[1]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcL12-R16) [[2]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcR386) [[3]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcR453) [[4]](diffhunk://#diff-580941184737186a94e3e9c06e467e86c06ce846d30ffa42c1c43b45812ddcdcR517-R520)

Test addition:

* [`src/promptflow-tracing/tests/unittests/test_eval_utils.py`](diffhunk://#diff-debd8b997faa1f46dc38a52544800d6a49e9af48bbacb0f67b892088e6ad5fb7R1-R54): Added a new test for the `EvaluationContext` class. The test checks whether the context is correctly set when a traced function is called.
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
