### PR TITLE
Handle AsyncGeneratorProxy in Tracer's to_serializable method

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_tracer.py
+++ b/src/promptflow-tracing/promptflow/tracing/_tracer.py
@@ -66,7 +66,7 @@ class Tracer(ThreadLocalSingleton):
     def to_serializable(obj):
         if isinstance(obj, dict) and all(isinstance(k, str) for k in obj.keys()):
             return {k: Tracer.to_serializable(v) for k, v in obj.items()}
-        if isinstance(obj, GeneratorProxy):
+        if isinstance(obj, (GeneratorProxy, AsyncGeneratorProxy)):
             return obj
         try:
             obj = serialize(obj)


### PR DESCRIPTION
# Description

This PR addresses a bug in the `to_serializable` method of the `Tracer` class. Previously, the method only checked for instances of `GeneratorProxy` to keep their original object instead of serializing them. This caused issues when the output was an instance of `AsyncGeneratorProxy`, as it was not properly handled.

The changes made in this PR ensure that `AsyncGeneratorProxy` instances are also kept in their original form, allowing for proper tracking of generated items in `run_info`.

This fix enhances the robustness of the tracing functionality and ensures consistent behavior for both synchronous and asynchronous generator proxies.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
