### PR TITLE
Set PF_HTTP_CONNECTION_PROVIDER_ENDPOINT to env in retrieve_tool_func_result

### DIFF
--- a/src/promptflow-core/promptflow/executor/_service/apis/batch.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/batch.py
@@ -29,7 +29,7 @@ def initialize(request: InitializationRequest):
         operation_context = update_and_get_operation_context(request.operation_context)
         service_logger.info(f"Received batch init request, executor version: {operation_context.get_user_agent()}.")
         # resolve environment variables
-        set_environment_variables(request)
+        set_environment_variables(request.environment_variables)
         # init batch coordinator to validate flow and create process pool
         batch_coordinator = BatchCoordinator(
             working_dir=request.working_dir,

--- a/src/promptflow-core/promptflow/executor/_service/apis/execution.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/execution.py
@@ -17,7 +17,6 @@ from promptflow.executor._service.utils.process_utils import invoke_sync_functio
 from promptflow.executor._service.utils.service_utils import (
     enable_async_execution,
     get_log_context,
-    set_environment_variables,
     update_and_get_operation_context,
 )
 from promptflow.executor.flow_executor import FlowExecutor, execute_flow

--- a/src/promptflow-core/promptflow/executor/_service/apis/execution.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/execution.py
@@ -36,7 +36,11 @@ async def flow_execution(request: FlowExecutionRequest):
         )
         try:
             result = await invoke_sync_function_in_process(
-                flow_test, args=(request,), run_id=request.run_id, context_dict=request.operation_context
+                flow_test,
+                args=(request,),
+                run_id=request.run_id,
+                context_dict=request.operation_context,
+                environment_variables=request.environment_variables,
             )
             service_logger.info(f"Completed flow execution request, flow run id: {request.run_id}.")
             return result
@@ -58,7 +62,11 @@ async def node_execution(request: NodeExecutionRequest):
         )
         try:
             result = await invoke_sync_function_in_process(
-                single_node_run, args=(request,), run_id=request.run_id, context_dict=request.operation_context
+                single_node_run,
+                args=(request,),
+                run_id=request.run_id,
+                context_dict=request.operation_context,
+                environment_variables=request.environment_variables,
             )
             service_logger.info(f"Completed node execution request, node name: {request.node_name}.")
             return result
@@ -80,8 +88,6 @@ def cancel_execution(request: CancelExecutionRequest):
 def flow_test(request: FlowExecutionRequest):
     # validate request
     request.validate_request()
-    # resolve environment variables
-    set_environment_variables(request)
     enable_async_execution()
     # execute flow
     storage = DefaultRunStorage(base_dir=request.working_dir, sub_dir=request.output_dir)
@@ -101,8 +107,6 @@ def flow_test(request: FlowExecutionRequest):
 def single_node_run(request: NodeExecutionRequest):
     # validate request
     request.validate_request()
-    # resolve environment variables
-    set_environment_variables(request)
     storage = DefaultRunStorage(base_dir=request.working_dir, sub_dir=request.output_dir)
     with _change_working_dir(request.working_dir), get_log_context(request):
         return FlowExecutor.load_and_exec_node(

--- a/src/promptflow-core/promptflow/executor/_service/apis/tool.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/tool.py
@@ -29,8 +29,17 @@ async def retrieve_tool_func_result(request: RetrieveToolFuncResultRequest):
     args = (request.func_call_scenario, request.func_path, request.func_kwargs, request.ws_triple)
     # To support dynamic list, runtime put PF_HTTP_CONNECTION_PROVIDER_ENDPOINT in request.environment_variables,
     # executor should set it to environment variables in subprocess for init http connection provider later.
-    environment_variables = request.environment_variables if request.environment_variables and isinstance(request.environment_variables, dict) else None
-    return await invoke_sync_function_in_process(retrieve_tool_func_result, args=args, wait_timeout=SHORT_WAIT_TIMEOUT, environment_variables=environment_variables)
+    environment_variables = (
+        request.environment_variables
+        if request.environment_variables and isinstance(request.environment_variables, dict)
+        else None
+    )
+    return await invoke_sync_function_in_process(
+        retrieve_tool_func_result,
+        args=args,
+        wait_timeout=SHORT_WAIT_TIMEOUT,
+        environment_variables=environment_variables,
+    )
 
 
 @router.post("/meta")

--- a/src/promptflow-core/promptflow/executor/_service/apis/tool.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/tool.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+import os
 from fastapi import APIRouter
 
 from promptflow._core.tool_meta_generator import generate_tool_meta_in_subprocess
@@ -24,6 +25,11 @@ def list_package_tools():
 
 @router.post("/retrieve_tool_func_result")
 async def retrieve_tool_func_result(request: RetrieveToolFuncResultRequest):
+    # Now runtime put PF_HTTP_CONNECTION_PROVIDER_ENDPOINT in request.environment_variables.
+    # It is used to init a http connection provider to get connection in dynamic list scenario.
+    if request.environment_variables and isinstance(request.environment_variables, dict):
+        os.environ.update(request.environment_variables)
+
     from promptflow._core.tools_manager import retrieve_tool_func_result
 
     args = (request.func_call_scenario, request.func_path, request.func_kwargs, request.ws_triple)

--- a/src/promptflow-core/promptflow/executor/_service/apis/tool.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/tool.py
@@ -29,16 +29,11 @@ async def retrieve_tool_func_result(request: RetrieveToolFuncResultRequest):
     args = (request.func_call_scenario, request.func_path, request.func_kwargs, request.ws_triple)
     # To support dynamic list, runtime put PF_HTTP_CONNECTION_PROVIDER_ENDPOINT in request.environment_variables,
     # executor should set it to environment variables in subprocess for init http connection provider later.
-    environment_variables = (
-        request.environment_variables
-        if request.environment_variables and isinstance(request.environment_variables, dict)
-        else None
-    )
     return await invoke_sync_function_in_process(
         retrieve_tool_func_result,
         args=args,
         wait_timeout=SHORT_WAIT_TIMEOUT,
-        environment_variables=environment_variables,
+        environment_variables=request.environment_variables,
     )
 
 

--- a/src/promptflow-core/promptflow/executor/_service/apis/tool.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/tool.py
@@ -2,7 +2,6 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
-import os
 from fastapi import APIRouter
 
 from promptflow._core.tool_meta_generator import generate_tool_meta_in_subprocess

--- a/src/promptflow-core/promptflow/executor/_service/apis/tool.py
+++ b/src/promptflow-core/promptflow/executor/_service/apis/tool.py
@@ -25,15 +25,13 @@ def list_package_tools():
 
 @router.post("/retrieve_tool_func_result")
 async def retrieve_tool_func_result(request: RetrieveToolFuncResultRequest):
-    # Now runtime put PF_HTTP_CONNECTION_PROVIDER_ENDPOINT in request.environment_variables.
-    # It is used to init a http connection provider to get connection in dynamic list scenario.
-    if request.environment_variables and isinstance(request.environment_variables, dict):
-        os.environ.update(request.environment_variables)
-
     from promptflow._core.tools_manager import retrieve_tool_func_result
 
     args = (request.func_call_scenario, request.func_path, request.func_kwargs, request.ws_triple)
-    return await invoke_sync_function_in_process(retrieve_tool_func_result, args=args, wait_timeout=SHORT_WAIT_TIMEOUT)
+    # To support dynamic list, runtime put PF_HTTP_CONNECTION_PROVIDER_ENDPOINT in request.environment_variables,
+    # executor should set it to environment variables in subprocess for init http connection provider later.
+    environment_variables = request.environment_variables if request.environment_variables and isinstance(request.environment_variables, dict) else None
+    return await invoke_sync_function_in_process(retrieve_tool_func_result, args=args, wait_timeout=SHORT_WAIT_TIMEOUT, environment_variables=environment_variables)
 
 
 @router.post("/meta")

--- a/src/promptflow-core/promptflow/executor/_service/contracts/tool_request.py
+++ b/src/promptflow-core/promptflow/executor/_service/contracts/tool_request.py
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------
 
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Mapping, Optional
 
 from promptflow.executor._service.contracts.base_request import BaseRequest
 
@@ -22,3 +22,4 @@ class RetrieveToolFuncResultRequest(BaseRequest):
     func_kwargs: Mapping[str, Any]
     func_call_scenario: str = None
     ws_triple: Mapping[str, str] = None
+    environment_variables: Optional[Mapping[str, Any]] = None

--- a/src/promptflow-core/promptflow/executor/_service/utils/process_utils.py
+++ b/src/promptflow-core/promptflow/executor/_service/utils/process_utils.py
@@ -38,7 +38,7 @@ async def invoke_sync_function_in_process(
         error_dict = manager.dict()
 
         p = multiprocessing.Process(
-            target=_set_environment_variable_then_execute_target_function,
+            target=_set_environment_variables_then_execute_target_function,
             args=(target_function, args, kwargs, return_dict, error_dict, context_dict, environment_variables),
         )
         p.start()
@@ -82,7 +82,7 @@ async def invoke_sync_function_in_process(
                 ProcessManager().remove_process(run_id)
 
 
-def _set_environment_variable_then_execute_target_function(
+def _set_environment_variables_then_execute_target_function(
     target_function: Callable,
     args: tuple,
     kwargs: dict,

--- a/src/promptflow-core/promptflow/executor/_service/utils/service_utils.py
+++ b/src/promptflow-core/promptflow/executor/_service/utils/service_utils.py
@@ -68,9 +68,9 @@ def generate_error_response(ex: Union[dict, Exception]):
     return ErrorResponse.from_error_dict(error_dict)
 
 
-def set_environment_variables(request: BaseExecutionRequest):
-    if isinstance(request.environment_variables, dict) and request.environment_variables:
-        os.environ.update(request.environment_variables)
+def set_environment_variables(environment_variables: Mapping[str, Any]):
+    if isinstance(environment_variables, dict) and environment_variables:
+        os.environ.update(environment_variables)
 
 
 def enable_async_execution():

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
@@ -79,7 +79,9 @@ class TestProcessUtils:
         return_dict = {}
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
-            _set_environment_variables_then_execute_target_function(target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT)
+            _set_environment_variables_then_execute_target_function(
+                target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT
+            )
             mock_logger.info.assert_called_once()
 
     @pytest.mark.asyncio
@@ -88,7 +90,9 @@ class TestProcessUtils:
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
             with pytest.raises(JsonSerializedPromptflowException) as exc_info:
-                _set_environment_variables_then_execute_target_function(target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT)
+                _set_environment_variables_then_execute_target_function(
+                    target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT
+                )
             assert json.loads(exc_info.value.message)["message"] == "Test exception"
             mock_logger.info.assert_called_once()
 

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
@@ -10,7 +10,7 @@ from promptflow._utils.exception_utils import JsonSerializedPromptflowException
 from promptflow.exceptions import ErrorTarget
 from promptflow.executor._service._errors import ExecutionTimeoutError
 from promptflow.executor._service.utils.process_utils import (
-    _execute_target_function,
+    _set_environment_variables_then_execute_target_function,
     exception_wrapper,
     invoke_sync_function_in_process,
 )
@@ -79,7 +79,7 @@ class TestProcessUtils:
         return_dict = {}
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
-            _execute_target_function(target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT)
+            _set_environment_variables_then_execute_target_function(target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT)
             mock_logger.info.assert_called_once()
 
     @pytest.mark.asyncio
@@ -88,7 +88,7 @@ class TestProcessUtils:
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
             with pytest.raises(JsonSerializedPromptflowException) as exc_info:
-                _execute_target_function(target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT)
+                _set_environment_variables_then_execute_target_function(target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT)
             assert json.loads(exc_info.value.message)["message"] == "Test exception"
             mock_logger.info.assert_called_once()
 

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
@@ -1,4 +1,5 @@
 import json
+import os
 import sys
 import time
 from unittest.mock import patch
@@ -72,6 +73,23 @@ class TestProcessUtils:
             assert exc_info.value.message == "Unexpected error occurred while executing the request"
             assert exc_info.value.target == ErrorTarget.EXECUTOR
             mock_logger.info.assert_called_once()
+            mock_logger.error.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_invoke_sync_function_in_process_set_env(self):
+        def target_function_get_env(environment_variable: str):
+            return os.getenv(environment_variable)
+
+        with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
+            environment_variables = {"test_env_name": "test_env_value"}
+            result = await invoke_sync_function_in_process(
+                target_function_get_env,
+                args=("test_env_name",),
+                context_dict=MOCK_CONTEXT_DICT,
+                environment_variables=environment_variables
+            )
+            assert result == "test_env_value"
+            assert mock_logger.info.call_count == 2
             mock_logger.error.assert_not_called()
 
     @pytest.mark.asyncio

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
@@ -10,7 +10,7 @@ from promptflow._utils.exception_utils import JsonSerializedPromptflowException
 from promptflow.exceptions import ErrorTarget
 from promptflow.executor._service._errors import ExecutionTimeoutError
 from promptflow.executor._service.utils.process_utils import (
-    _set_environment_variables_then_execute_target_function,
+    _execute_target_function,
     exception_wrapper,
     invoke_sync_function_in_process,
 )
@@ -79,9 +79,7 @@ class TestProcessUtils:
         return_dict = {}
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
-            _set_environment_variables_then_execute_target_function(
-                target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT, None
-            )
+            _execute_target_function(target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT, None)
             mock_logger.info.assert_called_once()
 
     @pytest.mark.asyncio
@@ -90,9 +88,7 @@ class TestProcessUtils:
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
             with pytest.raises(JsonSerializedPromptflowException) as exc_info:
-                _set_environment_variables_then_execute_target_function(
-                    target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT, None
-                )
+                _execute_target_function(target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT, None)
             assert json.loads(exc_info.value.message)["message"] == "Test exception"
             mock_logger.info.assert_called_once()
 

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_process_utils.py
@@ -80,7 +80,7 @@ class TestProcessUtils:
         error_dict = {}
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
             _set_environment_variables_then_execute_target_function(
-                target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT
+                target_function, (1,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT, None
             )
             mock_logger.info.assert_called_once()
 
@@ -91,7 +91,7 @@ class TestProcessUtils:
         with patch("promptflow.executor._service.utils.process_utils.service_logger") as mock_logger:
             with pytest.raises(JsonSerializedPromptflowException) as exc_info:
                 _set_environment_variables_then_execute_target_function(
-                    target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT
+                    target_function, (0,), {}, return_dict, error_dict, MOCK_CONTEXT_DICT, None
                 )
             assert json.loads(exc_info.value.message)["message"] == "Test exception"
             mock_logger.info.assert_called_once()

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_service_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_service_utils.py
@@ -10,7 +10,7 @@ from promptflow._utils.logger_utils import bulk_logger, flow_logger, logger, ser
 from promptflow._version import VERSION as PF_VERSION
 from promptflow.core._version import __version__ as PF_CORE_VERSION
 from promptflow.executor._service._errors import ExecutionTimeoutError
-from promptflow.executor._service.contracts.execution_request import BaseExecutionRequest, FlowExecutionRequest
+from promptflow.executor._service.contracts.execution_request import FlowExecutionRequest
 from promptflow.executor._service.utils.service_utils import (
     generate_error_response,
     get_commit_id,

--- a/src/promptflow/tests/executor/unittests/executor/_service/utils/test_service_utils.py
+++ b/src/promptflow/tests/executor/unittests/executor/_service/utils/test_service_utils.py
@@ -103,9 +103,8 @@ class TestServiceUtils:
         assert json_ser_error_response.innermost_error_code == "ExecutionTimeoutError"
 
     def test_set_environment_variables(self):
-        execution_request = BaseExecutionRequest(**MOCK_REQUEST)
-        execution_request.environment_variables = {
+        environment_variables = {
             "PF_TEST_ENV": "dummy_value",
         }
-        set_environment_variables(execution_request)
+        set_environment_variables(environment_variables)
         assert os.environ.get("PF_TEST_ENV") == "dummy_value"


### PR DESCRIPTION
# Description

Now runtime put `PF_HTTP_CONNECTION_PROVIDER_ENDPOINT` in request.environment_variables, executor should set it in env to init a http connection provider. This is used for get connection in dynamic list scenario.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
