### PR TITLE
Handle exception separately for each span

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/summary.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/cosmosdb/summary.py
@@ -41,7 +41,7 @@ class SummaryLine:
     start_time: str = None
     end_time: str = None
     status: str = None
-    latency: float = 0.0
+    latency: float = None
     name: str = None
     kind: str = None
     created_by: typing.Dict = field(default_factory=dict)

--- a/src/promptflow-devkit/promptflow/_sdk/_tracing.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing.py
@@ -697,31 +697,37 @@ def _try_write_trace_to_cosmosdb(
         # We assign it to LineSummary and Span and use it as partition key.
         collection_id = collection_db.collection_id
 
+        failed_span_count = 0
         for span in all_spans:
-            span_client = get_client(
-                CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name, credential
-            )
-            result = SpanCosmosDB(span, collection_id, created_by).persist(
-                span_client, blob_container_client, blob_base_uri
-            )
-            # None means the span already exists, then we don't need to persist the summary also.
-            if result is not None:
-                line_summary_client = get_client(
-                    CosmosDBContainerName.LINE_SUMMARY,
-                    subscription_id,
-                    resource_group_name,
-                    workspace_name,
-                    credential,
+            try:
+                span_client = get_client(
+                    CosmosDBContainerName.SPAN, subscription_id, resource_group_name, workspace_name, credential
                 )
-                Summary(span, collection_id, created_by, logger).persist(line_summary_client)
-        collection_db.update_collection_updated_at_info(collection_client)
+                result = SpanCosmosDB(span, collection_id, created_by).persist(
+                    span_client, blob_container_client, blob_base_uri
+                )
+                # None means the span already exists, then we don't need to persist the summary also.
+                if result is not None:
+                    line_summary_client = get_client(
+                        CosmosDBContainerName.LINE_SUMMARY,
+                        subscription_id,
+                        resource_group_name,
+                        workspace_name,
+                        credential,
+                    )
+                    Summary(span, collection_id, created_by, logger).persist(line_summary_client)
+            except Exception as e:
+                failed_span_count += 1
+                stack_trace = traceback.format_exc()
+                logger.error(f"Failed to process span: {span.span_id}, error: {e}, stack trace: {stack_trace}")
+        if failed_span_count < len(all_spans):
+            collection_db.update_collection_updated_at_info(collection_client)
         logger.info(
             (
-                f"Finish writing trace to cosmosdb, total spans count: {len(all_spans)}."
-                f" Duration {datetime.now() - start_time}."
+                f"Finish writing trace to cosmosdb, total spans count: {len(all_spans)}, "
+                f"failed spans count: {failed_span_count}. Duration {datetime.now() - start_time}."
             )
         )
-
     except Exception as e:
         stack_trace = traceback.format_exc()
         logger.error(f"Failed to write trace to cosmosdb: {e}, stack trace is {stack_trace}")


### PR DESCRIPTION
# Description

1. Handle exception separately for each span, we don't want failure of one span make the whole batch spans fail
2. Change default value of latency to None. Current value is 0.0, which is misleading for UX rendering.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
