### PR TITLE
[Internal] Use sys.executable to make sure dev setup use current env.

### DIFF
--- a/scripts/dev-setup/main.py
+++ b/scripts/dev-setup/main.py
@@ -6,6 +6,7 @@ import argparse
 import os
 import site
 import typing
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -76,7 +77,7 @@ def install_pkg_editable(pkg: str, verbose: bool, is_vscode: bool = False) -> No
 
         # pip install -e . from pyproject.toml/setup.py
         print_blue(f"- Installing {pkg} from source")
-        cmd = ["pip", "install", "--editable", f".{extras}"]
+        cmd = [sys.executable, "-m", "pip", "install", "--editable", f".{extras}"]
         run_cmd(cmd, verbose=verbose)
 
         # dev and test dependencies


### PR DESCRIPTION
# Description
Currently there are some corner case scenarios that `pip` is not in the subprocess environment. To avoid this issue, we directly use sys.executable to make sure we can use correct pip in the subprocess.

This pull request includes changes to the `scripts/dev-setup/main.py` file to improve the package installation process. The changes involve importing the `sys` module and modifying the `install_pkg_editable` function.

Key changes include:

* [`scripts/dev-setup/main.py`](diffhunk://#diff-a1c6a9229287822b824885bf66249fc20a47e850b3eb233bb2e9f63f65e4f41eR9): Imported the `sys` module to use the Python interpreter's executable for package installation.
* `def install_pkg_editable(pkg: str, verbose: bool, is_vscode: bool = False) -> No` in `scripts/dev-setup/main.py`: Modified the command used for package installation to use `sys.executable` instead of directly calling `pip`. This ensures that the correct Python interpreter is used for the installation process.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
