### PR TITLE
hotfix: extra string at the beginning of yaml in snapshot

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -217,7 +217,8 @@
     "dcid",
     "piezo",
     "Piezo",
-    "cmpop"
+    "cmpop",
+    "omap"
   ],
   "flagWords": [
     "Prompt Flow"

--- a/src/promptflow-core/promptflow/_utils/flow_utils.py
+++ b/src/promptflow-core/promptflow/_utils/flow_utils.py
@@ -6,7 +6,6 @@ import itertools
 import json
 import os
 import re
-from collections import OrderedDict
 from os import PathLike
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -22,7 +21,7 @@ from promptflow._constants import (
 )
 from promptflow._core._errors import MetaFileNotFound, MetaFileReadError
 from promptflow._utils.logger_utils import LoggerFactory
-from promptflow._utils.utils import strip_quotation
+from promptflow._utils.utils import convert_ordered_dict_to_dict, strip_quotation
 from promptflow._utils.yaml_utils import dump_yaml, load_yaml
 from promptflow.contracts.flow import Flow as ExecutableFlow
 from promptflow.exceptions import ErrorTarget, UserErrorException, ValidationException
@@ -157,10 +156,9 @@ def dump_flow_dag(flow_dag: dict, flow_path: Path):
     """Dump flow dag to given flow path."""
     flow_dir, flow_filename = resolve_flow_path(flow_path, check_flow_exist=False)
     flow_path = flow_dir / flow_filename
-    if isinstance(flow_dag, OrderedDict):
-        flow_dag = dict(flow_dag)
     with open(flow_path, "w", encoding=DEFAULT_ENCODING) as f:
-        dump_yaml(flow_dag, f)
+        # directly dumping ordered dict will bring !!omap tag in yaml
+        dump_yaml(convert_ordered_dict_to_dict(flow_dag, remove_empty=False), f)
     return flow_path
 
 

--- a/src/promptflow-core/promptflow/_utils/flow_utils.py
+++ b/src/promptflow-core/promptflow/_utils/flow_utils.py
@@ -6,6 +6,7 @@ import itertools
 import json
 import os
 import re
+from collections import OrderedDict
 from os import PathLike
 from pathlib import Path
 from typing import Optional, Tuple, Union
@@ -156,6 +157,8 @@ def dump_flow_dag(flow_dag: dict, flow_path: Path):
     """Dump flow dag to given flow path."""
     flow_dir, flow_filename = resolve_flow_path(flow_path, check_flow_exist=False)
     flow_path = flow_dir / flow_filename
+    if isinstance(flow_dag, OrderedDict):
+        flow_dag = dict(flow_dag)
     with open(flow_path, "w", encoding=DEFAULT_ENCODING) as f:
         dump_yaml(flow_dag, f)
     return flow_path

--- a/src/promptflow-core/promptflow/_utils/utils.py
+++ b/src/promptflow-core/promptflow/_utils/utils.py
@@ -434,3 +434,48 @@ def strip_quotation(value):
         return value[1:-1]
     else:
         return value
+
+
+def is_empty_target(obj: Optional[Dict]) -> bool:
+    """Determines if it's empty target
+
+    :param obj: The object to check
+    :type obj: Optional[Dict]
+    :return: True if obj is None or an empty Dict
+    :rtype: bool
+    """
+    return (
+        obj is None
+        # some objs have overloaded "==" and will cause error. e.g CommandComponent obj
+        or (isinstance(obj, dict) and len(obj) == 0)
+    )
+
+
+def convert_ordered_dict_to_dict(target_object: Union[Dict, List], remove_empty: bool = True) -> Union[Dict, List]:
+    """Convert ordered dict to dict. Remove keys with None value.
+    This is a workaround for rest request must be in dict instead of
+    ordered dict.
+
+    :param target_object: The object to convert
+    :type target_object: Union[Dict, List]
+    :param remove_empty: Whether to omit values that are None or empty dictionaries. Defaults to True.
+    :type remove_empty: bool
+    :return: Converted ordered dict with removed None values
+    :rtype: Union[Dict, List]
+    """
+    # OrderedDict can appear nested in a list
+    if isinstance(target_object, list):
+        new_list = []
+        for item in target_object:
+            item = convert_ordered_dict_to_dict(item, remove_empty=remove_empty)
+            if not is_empty_target(item) or not remove_empty:
+                new_list.append(item)
+        return new_list
+    if isinstance(target_object, dict):
+        new_dict = {}
+        for key, value in target_object.items():
+            value = convert_ordered_dict_to_dict(value, remove_empty=remove_empty)
+            if not is_empty_target(value) or not remove_empty:
+                new_dict[key] = value
+        return new_dict
+    return target_object

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_run.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_run.py
@@ -1376,6 +1376,8 @@ class TestFlowRun:
         yaml_dict = load_yaml(local_storage._dag_path)
         assert yaml_dict == expected_snapshot_yaml
 
+        assert not local_storage._dag_path.read_text().startswith("!!omap")
+
         # actual result will be entry2:my_flow2
         details = pf.get_details(run.name)
         # convert DataFrame to dict


### PR DESCRIPTION
# Description

Fix a bug that !!omap tag will generated at the beginning of `flow.flex.yaml` in snapshot and break local to cloud

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
