### PR TITLE
Fix test_retrieve_tool_func_result_error failure in python version >= 3.11

### DIFF
--- a/src/promptflow-core/promptflow/_utils/tool_utils.py
+++ b/src/promptflow-core/promptflow/_utils/tool_utils.py
@@ -301,7 +301,7 @@ def validate_tool_func_result(func_call_scenario: str, result):
     if func_call_scenario == ToolFuncCallScenario.REVERSE_GENERATED_BY:
         if not isinstance(result, Dict):
             raise RetrieveToolFuncResultValidationError(
-                f"ToolFuncCallScenario {func_call_scenario} response must be a dict. " f"{result} is not a dict."
+                f"ToolFuncCallScenario {func_call_scenario.value} response must be a dict. " f"{result} is not a dict."
             )
     elif func_call_scenario == ToolFuncCallScenario.DYNAMIC_LIST:
         validate_dynamic_list_func_response_type(result, f"ToolFuncCallScenario {func_call_scenario}")

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -358,7 +358,7 @@ class TestToolsManager:
                 ToolFuncCallScenario.REVERSE_GENERATED_BY,
                 "my_tool_package.tools.tool_with_generated_by_input.generated_by_func",
                 {"index_type": "Azure Cognitive Search"},
-                "ToolFuncCallScenario reverse_generated_by response must be a dict.",
+                "response must be a dict.",
             ),
         ],
     )
@@ -379,8 +379,9 @@ class TestToolsManager:
 
     def test_register_apis(self):
         from typing import Union
-        from promptflow._core.tools_manager import register_apis, connection_type_to_api_mapping
+
         from promptflow._core.tool import ToolProvider
+        from promptflow._core.tools_manager import connection_type_to_api_mapping, register_apis
         from promptflow.connections import AzureOpenAIConnection, OpenAIConnection, ServerlessConnection
 
         class MockAI1(ToolProvider):

--- a/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
+++ b/src/promptflow/tests/executor/unittests/_core/test_tools_manager.py
@@ -358,7 +358,7 @@ class TestToolsManager:
                 ToolFuncCallScenario.REVERSE_GENERATED_BY,
                 "my_tool_package.tools.tool_with_generated_by_input.generated_by_func",
                 {"index_type": "Azure Cognitive Search"},
-                "response must be a dict.",
+                "ToolFuncCallScenario reverse_generated_by response must be a dict.",
             ),
         ],
     )


### PR DESCRIPTION
Currently this test will fail in python version >= 3.11, the reason is because: 
![image](https://github.com/microsoft/promptflow/assets/49388944/35195bc0-1a46-4969-bb28-e1ee1e196829)
So the error message in python version >= 3.11 will be:
'Unable to retrieve tool func result due to \'ToolFuncCallScenario **ToolFuncCallScenario.REVERSE_GENERATED_BY** response must be a dict. {"index_type": "Azure Cognitive Search", "index": "index_1"} is not a dict.\'. \nPlease contact the tool author/support team for troubleshooting assistance.'

But in the python version < 3.11, the error message will be:
'Unable to retrieve tool func result due to \'ToolFuncCallScenario **reverse_generated_by** response must be a dict. {"index_type": "Azure Cognitive Search", "index": "index_1"} is not a dict.\'. \nPlease contact the tool author/support team for troubleshooting assistance.'

In order to keep the test stable in different python environment, so change the error message from:
f"ToolFuncCallScenario {func_call_scenario} response must be a dict. " f"{result} is not a dict."
to 
f"ToolFuncCallScenario {func_call_scenario.**value**} response must be a dict. " f"{result} is not a dict."