### PR TITLE
[trace][bugfix] Use local import to avoid circular import in config and trace

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_configuration.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_configuration.py
@@ -18,7 +18,6 @@ from promptflow._sdk._constants import (
     HOME_PROMPT_FLOW_DIR,
     SERVICE_CONFIG_FILE,
 )
-from promptflow._sdk._tracing import TraceDestinationConfig
 from promptflow._sdk._utils import call_from_extension, gen_uuid_by_compute_info, read_write_by_user
 from promptflow._utils.logger_utils import get_cli_sdk_logger
 from promptflow._utils.yaml_utils import dump_yaml, load_yaml
@@ -205,6 +204,8 @@ class Configuration(object):
         return provider
 
     def get_trace_destination(self, path: Optional[Path] = None) -> Optional[str]:
+        from promptflow._sdk._tracing import TraceDestinationConfig
+
         value = self.get_config(key=self.TRACE_DESTINATION)
         logger.info("pf.config.trace.destination: %s", value)
         if TraceDestinationConfig.need_to_resolve(value):
@@ -254,6 +255,8 @@ class Configuration(object):
                     "please use its child folder, e.g. '${flow_directory}/.runs'."
                 )
         elif key == Configuration.TRACE_DESTINATION:
+            from promptflow._sdk._tracing import TraceDestinationConfig
+
             TraceDestinationConfig.validate(value)
         return
 


### PR DESCRIPTION
# Description

It's better to use local import in conf file.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
