### PR TITLE
[fundamental] Skip local trace setup in Azure test

### DIFF
--- a/src/promptflow-azure/tests/sdk_cli_azure_test/conftest.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/conftest.py
@@ -30,6 +30,7 @@ from promptflow._sdk.entities import Run
 from promptflow._utils.user_agent_utils import ClientUserAgentUtil
 from promptflow.azure import PFClient
 from promptflow.azure._entities._flow import Flow
+from promptflow.tracing._constants import PF_TRACING_SKIP_LOCAL_SETUP_ENVIRON
 
 try:
     from promptflow.recording.record_mode import is_in_ci_pipeline, is_live, is_record, is_replay
@@ -735,3 +736,9 @@ def construct_csharp_test_project(flow_name: str) -> CSharpProject:
 @pytest.fixture
 def csharp_test_project_basic() -> CSharpProject:
     return construct_csharp_test_project("Basic")
+
+
+@pytest.fixture(autouse=True)
+def disable_trace_setup():
+    os.environ[PF_TRACING_SKIP_LOCAL_SETUP_ENVIRON] = "true"
+    yield


### PR DESCRIPTION
# Description

In Azure test, we don't need to setup local trace, so add an environ to skip.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
