### PR TITLE
[trace][bugfix] Add `@trace` for prompty `__call__`

### DIFF
--- a/src/promptflow-core/promptflow/core/_flow.py
+++ b/src/promptflow-core/promptflow/core/_flow.py
@@ -432,6 +432,7 @@ class AsyncPrompty(Prompty):
 
     """
 
+    @trace
     async def __call__(self, *args, **kwargs) -> Mapping[str, Any]:
         """Calling prompty as a function in async, the inputs should be provided with key word arguments.
         Returns the output of the prompty.

--- a/src/promptflow-core/promptflow/core/_flow.py
+++ b/src/promptflow-core/promptflow/core/_flow.py
@@ -24,6 +24,7 @@ from promptflow.core._prompty_utils import (
 )
 from promptflow.core._utils import load_inputs_from_sample
 from promptflow.exceptions import UserErrorException
+from promptflow.tracing import trace
 from promptflow.tracing._experimental import enrich_prompt_template
 from promptflow.tracing._trace import _traced
 
@@ -373,6 +374,7 @@ class Prompty(FlowBase):
             raise MissingRequiredInputError(f"Missing required inputs: {missing_inputs}")
         return resolved_inputs
 
+    @trace
     def __call__(self, *args, **kwargs):
         """Calling flow as a function, the inputs should be provided with key word arguments.
         Returns the output of the prompty.


### PR DESCRIPTION
# Description

Add `@trace` for `Prompty.__call__`, so that each prompty function can be one trace.

![image](https://github.com/microsoft/promptflow/assets/38847871/ca6f33ca-45bc-4097-8b35-210e5da34e49)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
