### PR TITLE
Redefine Span Relationship in Generator Tracing

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -179,14 +179,14 @@ def enrich_span_with_llm_if_needed(span, original_span, inputs, generator_output
 
 
 def traced_generator(original_span: ReadableSpan, inputs, generator):
-    context = original_span.get_span_context()
-    link = Link(context)
+    # trace context
+    original_context = otel_trace.set_span_in_context(original_span)
     # If start_trace is not called, the name of the original_span will be empty.
     # need to get everytime to ensure tracer is latest
     otel_tracer = otel_trace.get_tracer("promptflow")
     with otel_tracer.start_as_current_span(
         f"Iterated({original_span.name})",
-        links=[link],
+        context=original_context,
     ) as span, _record_keyboard_interrupt_to_span(span):
         enrich_span_with_original_attributes(span, original_span.attributes)
         # Enrich the new span with input before generator iteration to prevent loss of input information.


### PR DESCRIPTION
# Description

This pull request enhances the span relationship in generator tracing. The change ensures that the span capturing the iteration process of a generator is a child of the span in which the generator is produced. Previously, this relationship was established using a span link field, but now it is related through context parent-child relations. This modification helps track the execution procedure more effectively.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
