### PR TITLE
Catch asyncio.CancelledError for cancelling async function.

### DIFF
--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -863,7 +863,7 @@ class FlowExecutor:
         context: FlowExecutionContext,
         stream=False,
     ):
-        with self._start_flow_span(inputs) as span, self._record_keyboard_interrupt_to_span(span):
+        with self._start_flow_span(inputs) as span, self._record_cancellation_exceptions_to_span(span):
             output, nodes_outputs = await self._traverse_nodes_async(inputs, context)
             #  TODO: Also stringify async generator output
             output = self._stringify_generator_output(output) if not stream else output
@@ -878,17 +878,17 @@ class FlowExecutor:
         context: FlowExecutionContext,
         stream=False,
     ):
-        with self._start_flow_span(inputs) as span, self._record_keyboard_interrupt_to_span(span):
+        with self._start_flow_span(inputs) as span, self._record_cancellation_exceptions_to_span(span):
             output, nodes_outputs = self._traverse_nodes(inputs, context)
             output = self._stringify_generator_output(output) if not stream else output
             self._exec_post_process(inputs, output, nodes_outputs, run_info, run_tracker, span, stream)
             return output, extract_aggregation_inputs(self._flow, nodes_outputs)
 
     @contextlib.contextmanager
-    def _record_keyboard_interrupt_to_span(self, span: Span):
+    def _record_cancellation_exceptions_to_span(self, span: Span):
         try:
             yield
-        except KeyboardInterrupt as ex:
+        except (KeyboardInterrupt, asyncio.CancelledError) as ex:
             if span.is_recording():
                 span.record_exception(ex)
                 span.set_status(StatusCode.ERROR, "Execution cancelled.")

--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+import asyncio
 import contextlib
 import functools
 import inspect
@@ -29,10 +30,10 @@ IS_LEGACY_OPENAI = version("openai").startswith("0.")
 
 
 @contextlib.contextmanager
-def _record_keyboard_interrupt_to_span(span: Span):
+def _record_cancellation_exceptions_to_span(span: Span):
     try:
         yield
-    except KeyboardInterrupt as ex:
+    except (KeyboardInterrupt, asyncio.CancelledError) as ex:
         if span.is_recording():
             span.record_exception(ex)
             span.set_status(StatusCode.ERROR, "Execution cancelled.")
@@ -187,7 +188,7 @@ def traced_generator(original_span: ReadableSpan, inputs, generator):
     with otel_tracer.start_as_current_span(
         f"Iterated({original_span.name})",
         links=[link],
-    ) as span, _record_keyboard_interrupt_to_span(span):
+    ) as span, _record_cancellation_exceptions_to_span(span):
         enrich_span_with_original_attributes(span, original_span.attributes)
         # Enrich the new span with input before generator iteration to prevent loss of input information.
         # The input is as an event within this span.
@@ -211,7 +212,7 @@ async def traced_async_generator(original_span: ReadableSpan, inputs, generator)
     with otel_tracer.start_as_current_span(
         f"Iterated({original_span.name})",
         links=[link],
-    ) as span, _record_keyboard_interrupt_to_span(span):
+    ) as span, _record_cancellation_exceptions_to_span(span):
         enrich_span_with_original_attributes(span, original_span.attributes)
         # Enrich the new span with input before generator iteration to prevent loss of input information.
         # The input is as an event within this span.
@@ -388,7 +389,7 @@ def _traced_async(
         span_name = get_node_name_from_context(used_for_span_name=True) or trace.name
         # need to get everytime to ensure tracer is latest
         otel_tracer = otel_trace.get_tracer("promptflow")
-        with otel_tracer.start_as_current_span(span_name) as span, _record_keyboard_interrupt_to_span(span):
+        with otel_tracer.start_as_current_span(span_name) as span, _record_cancellation_exceptions_to_span(span):
             # Store otel trace id in context for correlation
             OperationContext.get_instance()["otel_trace_id"] = f"0x{format_trace_id(span.get_span_context().trace_id)}"
             enrich_span_with_trace(span, trace)
@@ -454,7 +455,7 @@ def _traced_sync(
         span_name = get_node_name_from_context(used_for_span_name=True) or trace.name
         # need to get everytime to ensure tracer is latest
         otel_tracer = otel_trace.get_tracer("promptflow")
-        with otel_tracer.start_as_current_span(span_name) as span, _record_keyboard_interrupt_to_span(span):
+        with otel_tracer.start_as_current_span(span_name) as span, _record_cancellation_exceptions_to_span(span):
             # Store otel trace id in context for correlation
             OperationContext.get_instance()["otel_trace_id"] = f"0x{format_trace_id(span.get_span_context().trace_id)}"
             enrich_span_with_trace(span, trace)


### PR DESCRIPTION
# Description

For async script, system will raise asyncio.CancelledError.
We need to catch it and mark span as cancelled like KeyboardInterrupt.
(For async flow, we register signal and raise KeyboardInterrupt)

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
