### PR TITLE
Add environment into flow.dag.yaml for eval-chat-math flow

### DIFF
--- a/examples/flows/evaluation/eval-chat-math/flow.dag.yaml
+++ b/examples/flows/evaluation/eval-chat-math/flow.dag.yaml
@@ -1,3 +1,4 @@
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/Flow.schema.json
 inputs:
   groundtruth:
     type: string
@@ -31,4 +32,5 @@ nodes:
   aggregation: true
   use_variants: false
 node_variants: {}
-$schema: https://azuremlschemas.azureedge.net/promptflow/latest/Flow.schema.json
+environment:
+  python_requirements_txt: requirements.txt


### PR DESCRIPTION
Add environment into flow.dag.yaml for eval-chat-math flow:
run link in portal: https://ml.azure.com/prompts/bulkrun/eval_chat_math_variant_0_20240430_143934_923359/details?wsid=/subscriptions/96aede12-2f73-41cb-b983-6d11a904839b/resourcegroups/promptflow/providers/Microsoft.MachineLearningServices/workspaces/promptflow-eastus-dev&tid=72f988bf-86f1-41af-91ab-2d7cd011db47