### PR TITLE
Add execution target to distinguish dag or non-dag flow

### DIFF
--- a/src/promptflow-core/promptflow/executor/_prompty_executor.py
+++ b/src/promptflow-core/promptflow/executor/_prompty_executor.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+from promptflow._constants import FlowType
 from promptflow._utils.logger_utils import logger
 from promptflow.contracts.flow import PromptyFlow
 from promptflow.contracts.tool import InputDefinition
@@ -30,6 +31,8 @@ class PromptyExecutor(ScriptExecutor):
         logger.debug(f"Init params for prompty executor: {init_kwargs}")
         self.prompty = Prompty.load(source=flow_file, **self._init_kwargs)
         super().__init__(flow_file=flow_file, connections=connections, working_dir=working_dir, storage=storage)
+
+    _execution_target = FlowType.PROMPTY
 
     @property
     def has_aggregation_node(self):

--- a/src/promptflow-core/promptflow/executor/_script_executor.py
+++ b/src/promptflow-core/promptflow/executor/_script_executor.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from types import GeneratorType
 from typing import Any, Callable, Dict, List, Mapping, Optional, Union
 
-from promptflow._constants import LINE_NUMBER_KEY, MessageFormatType
+from promptflow._constants import LINE_NUMBER_KEY, FlowType, MessageFormatType
 from promptflow._core.log_manager import NodeLogManager
 from promptflow._core.run_tracker import RunTracker
 from promptflow._core.tool_meta_generator import PythonLoadError
@@ -96,6 +96,8 @@ class ScriptExecutor(FlowExecutor):
         log_manager.set_node_context(run_id, "Flex", line_number)
         with log_manager, self._update_operation_context(run_id, line_number):
             yield
+
+    _execution_target = FlowType.FLEX_FLOW
 
     def exec_line(
         self,

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -21,7 +21,7 @@ import opentelemetry.trace as otel_trace
 from opentelemetry.trace.span import Span, format_trace_id
 from opentelemetry.trace.status import StatusCode
 
-from promptflow._constants import LINE_NUMBER_KEY
+from promptflow._constants import LINE_NUMBER_KEY, FlowType
 from promptflow._core._errors import NotSupported, UnexpectedError
 from promptflow._core.cache_manager import AbstractCacheManager
 from promptflow._core.flow_execution_context import FlowExecutionContext
@@ -65,6 +65,8 @@ from promptflow.tracing._operation_context import OperationContext
 from promptflow.tracing._start_trace import setup_exporter_from_environ
 from promptflow.tracing._trace import enrich_span_with_context, enrich_span_with_input, enrich_span_with_trace_type
 from promptflow.tracing.contracts.trace import TraceType
+
+DEFAULT_TRACING_KEYS = {"run_mode", "root_run_id", "flow_id", "batch_input_source", "execution_target"}
 
 
 class FlowExecutor:
@@ -162,6 +164,10 @@ class FlowExecutor:
         self._node_concurrency = DEFAULT_CONCURRENCY_BULK
         self._message_format = flow.message_format
         self._multimedia_processor = MultimediaProcessor.create(flow.message_format)
+
+    # This field is used to distinguish the execution target of the flow.
+    # Candidate value for executors are dag, flex adn prompty.
+    _execution_target = FlowType.DAG_FLOW
 
     @classmethod
     def create(
@@ -346,7 +352,8 @@ class FlowExecutor:
             original_context = operation_context.copy()
             try:
                 append_promptflow_package_ua(operation_context)
-                operation_context.set_default_tracing_keys({"run_mode", "root_run_id", "flow_id", "batch_input_source"})
+                operation_context.set_execution_target(cls._execution_target)
+                operation_context.set_default_tracing_keys(DEFAULT_TRACING_KEYS)
                 operation_context["run_mode"] = RunMode.SingleNode.name
                 # Inject OpenAI API to make sure traces and headers injection works and
                 # update OpenAI API configs from environment variables.
@@ -777,7 +784,8 @@ class FlowExecutor:
             values_for_otel = {"line_run_id": run_id}
         try:
             append_promptflow_package_ua(operation_context)
-            operation_context.set_default_tracing_keys({"run_mode", "root_run_id", "flow_id", "batch_input_source"})
+            operation_context.set_execution_target(execution_target=self._execution_target)
+            operation_context.set_default_tracing_keys(DEFAULT_TRACING_KEYS)
             operation_context.run_mode = original_mode
             operation_context.update(values_for_context)
             for k, v in values_for_otel.items():
@@ -806,7 +814,8 @@ class FlowExecutor:
             )
         try:
             append_promptflow_package_ua(operation_context)
-            operation_context.set_default_tracing_keys({"run_mode", "root_run_id", "flow_id", "batch_input_source"})
+            operation_context.set_execution_target(self._execution_target)
+            operation_context.set_default_tracing_keys(DEFAULT_TRACING_KEYS)
             operation_context.run_mode = original_mode
             operation_context.update(values_for_context)
             for k, v in values_for_otel.items():

--- a/src/promptflow-tracing/promptflow/tracing/_operation_context.py
+++ b/src/promptflow-tracing/promptflow/tracing/_operation_context.py
@@ -21,6 +21,7 @@ class OperationContext(Dict):
     _current_context = ContextVar(_CONTEXT_KEY, default=None)
     USER_AGENT_KEY = "user_agent"
     REQUEST_ID_KEY = "request_id"
+    EXECUTION_TARGET = "execution_target"
     _DEFAULT_TRACING_KEYS = "_default_tracing_keys"
     _OTEL_ATTRIBUTES = "_otel_attributes"
     _TRACKING_KEYS = "_tracking_keys"
@@ -174,6 +175,12 @@ class OperationContext(Dict):
             for key in keys:
                 if key not in self[self._TRACKING_KEYS]:
                     self[self._TRACKING_KEYS].add(key)
+
+    def set_execution_target(self, execution_target: str):
+        # Set in the context for getting tracking info
+        # Set in otel attributes for telemetry
+        self[OperationContext.EXECUTION_TARGET] = execution_target
+        self._add_otel_attributes(OperationContext.EXECUTION_TARGET, execution_target)
 
     def get_context_dict(self):
         """Get the context dictionary.


### PR DESCRIPTION
# Description

Add execution target to distinguish dag or non dag execution.
Will set different value for each executor
FlowExecutor: dag
ScriptExecutor: flex
PromptyExecutor: prompty

For now, when customer run `pf flow test` command to a python file, we will create flow.flex.yaml file for customer, and will report it as flex

Execution target filed will be used in
1. PowerBI AOAI token page
2. Trace telemetry

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
