### PR TITLE
feat: support init signature override for flex flow

### DIFF
--- a/src/promptflow-core/promptflow/core/_model_configuration.py
+++ b/src/promptflow-core/promptflow/core/_model_configuration.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Union
 
 from promptflow._constants import ConnectionType
+from promptflow.contracts.flow import InitParamType
 from promptflow.core._connection import AzureOpenAIConnection, OpenAIConnection
 from promptflow.core._errors import InvalidConnectionError
 
@@ -117,6 +118,6 @@ class PromptyModelConfiguration:
 
 
 MODEL_CONFIG_NAME_2_CLASS = {
-    AzureOpenAIModelConfiguration.__name__: AzureOpenAIModelConfiguration,
-    OpenAIModelConfiguration.__name__: OpenAIModelConfiguration,
+    InitParamType.AZURE_OPEN_API_MODEL_CONFIGURATION: AzureOpenAIModelConfiguration,
+    InitParamType.OPEN_AI_MODEL_CONFIGURATION: OpenAIModelConfiguration,
 }

--- a/src/promptflow-devkit/promptflow/_sdk/schemas/_flow.py
+++ b/src/promptflow-devkit/promptflow/_sdk/schemas/_flow.py
@@ -4,13 +4,13 @@
 
 from marshmallow import ValidationError, fields, validate, validates_schema
 
-from promptflow._constants import LANGUAGE_KEY, ConnectionType, FlowLanguage
+from promptflow._constants import LANGUAGE_KEY, FlowLanguage
 from promptflow._proxy import ProxyFactory
 from promptflow._sdk._constants import FlowType
 from promptflow._sdk.schemas._base import PatchedSchemaMeta, YamlFileSchema
 from promptflow._sdk.schemas._fields import NestedField
+from promptflow.contracts.flow import InitParamType
 from promptflow.contracts.tool import ValueType
-from promptflow.core._model_configuration import MODEL_CONFIG_NAME_2_CLASS
 
 
 class FlowInputSchema(metaclass=PatchedSchemaMeta):
@@ -62,7 +62,7 @@ class FlowSchema(BaseFlowSchema):
     node_variants = fields.Dict(keys=fields.Str(), values=fields.Dict())
 
 
-ALLOWED_TYPES = [
+ALLOWED_PRIMITIVE_TYPES = [
     ValueType.STRING.value,
     ValueType.INT.value,
     ValueType.DOUBLE.value,
@@ -71,32 +71,41 @@ ALLOWED_TYPES = [
     ValueType.OBJECT.value,
 ]
 
+ALLOWED_INIT_PARAM_TYPES = [
+    InitParamType.AZURE_OPEN_API_MODEL_CONFIGURATION.value,
+    InitParamType.OPEN_AI_MODEL_CONFIGURATION.value,
+    InitParamType.AZURE_OPEN_AI_CONNECTION.value,
+    InitParamType.OPEN_AI_CONNECTION.value,
+    InitParamType.QDRANT_CONNECTION.value,
+    InitParamType.COGNITIVE_SEARCH_CONNECTION.value,
+    InitParamType.SERP_CONNECTION.value,
+    InitParamType.AZURE_CONTENT_SAFETY_CONNECTION.value,
+    InitParamType.FORM_RECOGNIZER_CONNECTION.value,
+    InitParamType.WEAVIATE_CONNECTION.value,
+    InitParamType.SERVERLESS_CONNECTION.value,
+    InitParamType.CUSTOM_CONNECTION.value,
+]
+
 
 class FlexFlowInputSchema(FlowInputSchema):
     type = fields.Str(
         required=True,
         # TODO 3062609: Flex flow GPT-V support
-        validate=validate.OneOf(ALLOWED_TYPES),
+        validate=validate.OneOf(ALLOWED_PRIMITIVE_TYPES),
     )
 
 
 class FlexFlowInitSchema(FlowInputSchema):
     type = fields.Str(
         required=True,
-        validate=validate.OneOf(
-            ALLOWED_TYPES
-            + list(
-                map(lambda x: f"{x.value}Connection", filter(lambda x: x != ConnectionType._NOT_SET, ConnectionType))
-            )
-            + list(MODEL_CONFIG_NAME_2_CLASS.keys())
-        ),
+        validate=validate.OneOf(ALLOWED_PRIMITIVE_TYPES + ALLOWED_INIT_PARAM_TYPES),
     )
 
 
 class FlexFlowOutputSchema(FlowOutputSchema):
     type = fields.Str(
         required=True,
-        validate=validate.OneOf(ALLOWED_TYPES),
+        validate=validate.OneOf(ALLOWED_PRIMITIVE_TYPES),
     )
 
 

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -15,7 +15,6 @@ from marshmallow import ValidationError
 
 from promptflow._sdk._constants import LOGGER_NAME
 from promptflow._sdk._pf_client import PFClient
-from promptflow._sdk.entities import AzureOpenAIConnection, CustomConnection, OpenAIConnection
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow.core import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
 from promptflow.core._utils import init_executable
@@ -557,21 +556,8 @@ class TestFlowTest:
             ),
             pytest.param(
                 "AzureOpenAIConnection",
-                AzureOpenAIConnection(api_base="fake_base_url", api_key="fake_key"),
+                "azure_open_ai_connection",
                 id="AzureOpenAIConnection",
-            ),
-            pytest.param(
-                "OpenAIConnection",
-                OpenAIConnection(api_key="fake_key", base_url="fake_base_url"),
-                id="OpenAIConnection",
-            ),
-            pytest.param(
-                "CustomConnection",
-                CustomConnection(
-                    secrets={"api_key": "fake_key"},
-                    configs={"api_base": "fake_base_url"},
-                ),
-                id="CustomConnection",
             ),
         ],
     )
@@ -590,5 +576,10 @@ class TestFlowTest:
             pf.test(
                 flow=flow_path,
                 inputs={"func_input": "input"},
+                init={"dynamic_param": param_value, "open_ai_model_config": config2},
+            )
+            pf.run(
+                flow=flow_path,
+                data=flow_path / "inputs.jsonl",
                 init={"dynamic_param": param_value, "open_ai_model_config": config2},
             )

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/class_with_model_config.py
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/class_with_model_config.py
@@ -1,0 +1,44 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+from typing import TypedDict
+
+from promptflow.core import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
+
+
+class FlowOutput(TypedDict):
+    obj_input: str
+    func_input: str
+    obj_id: str
+
+
+class MyFlow:
+    def __init__(
+        self,
+        dynamic_param,
+        open_ai_model_config: OpenAIModelConfiguration
+    ):
+        self.dynamic_param = dynamic_param
+        self.open_ai_model_config = open_ai_model_config
+
+    def __call__(self, func_input: str) -> FlowOutput:
+        return {
+            "open_ai_model_config_model": self.open_ai_model_config.model,
+            "open_ai_model_config_base_url": self.open_ai_model_config.base_url,
+            "open_ai_model_config_connection": self.open_ai_model_config.connection,
+            "func_input": func_input,
+            "obj_id": id(self),
+        }
+
+
+if __name__ == "__main__":
+    config1 = AzureOpenAIModelConfiguration(
+        azure_deployment="my_deployment",
+    )
+    config2 = OpenAIModelConfiguration(
+        model="my_model",
+    )
+    flow = MyFlow(dynamic_param=config1, open_ai_model_config=config2)
+    result = flow("func_input")
+    print(result)
+

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/flow.flex.yaml
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/flow.flex.yaml
@@ -1,0 +1,9 @@
+entry: class_with_model_config:MyFlow
+init:
+  dynamic_param:
+    type: AzureOpenAIModelConfiguration
+  open_ai_model_config:
+    type: OpenAIModelConfiguration
+environment:
+  image: promptflow.azurecr.io/promptflow-runtime:pr-1316971-v19
+  python_requirements_txt: requirements.txt

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/inputs.jsonl
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/inputs.jsonl
@@ -1,0 +1,2 @@
+{"func_input": "func_input1"}
+{"func_input": "func_input2"}

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/requirements.txt
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/requirements.txt
@@ -1,0 +1,1 @@
+promptflow

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/run.yaml
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/run.yaml
@@ -1,0 +1,5 @@
+description: sample bulk run
+flow: ./
+data: ./inputs.jsonl
+init:
+  obj_input: val

--- a/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/run.yaml
+++ b/src/promptflow/tests/test_configs/eager_flows/flow_with_signature_model_configuration/run.yaml
@@ -1,5 +1,0 @@
-description: sample bulk run
-flow: ./
-data: ./inputs.jsonl
-init:
-  obj_input: val


### PR DESCRIPTION
# Description

Support below case: 
There is no annotation for a complicated init param in original entry of a flex flow, while customer specify the type of init param in `flow.flex.yaml`.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
