### PR TITLE
[Executor] Convert sync generator to async generator

### DIFF
--- a/src/promptflow-core/promptflow/_utils/async_utils.py
+++ b/src/promptflow-core/promptflow/_utils/async_utils.py
@@ -6,7 +6,7 @@ import asyncio
 import functools
 import signal
 import threading
-from types import GeneratorType
+from typing import Iterator
 
 from promptflow.tracing import ThreadPoolExecutorWithContext
 
@@ -112,7 +112,7 @@ def sync_to_async(func):
     return wrapper
 
 
-async def sync_generator_to_async(g: GeneratorType):
+async def sync_iterator_to_async(g: Iterator):
     with ThreadPoolExecutorWithContext(max_workers=1) as pool:
         loop = asyncio.get_running_loop()
         # Use object() as a default value to distinguish from None

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -14,8 +14,7 @@ import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from threading import current_thread
-from types import AsyncGeneratorType, GeneratorType
-from typing import Any, Callable, Dict, List, Mapping, Optional, Tuple, Union
+from typing import Any, AsyncIterator, Callable, Dict, Iterator, List, Mapping, Optional, Tuple, Union
 
 import opentelemetry.trace as otel_trace
 from opentelemetry.trace.span import Span, format_trace_id
@@ -29,7 +28,7 @@ from promptflow._core.metric_logger import add_metric_logger, remove_metric_logg
 from promptflow._core.run_tracker import RunTracker
 from promptflow._core.tool import STREAMING_OPTION_PARAMETER_ATTR
 from promptflow._core.tools_manager import ToolsManager
-from promptflow._utils.async_utils import async_run_allowing_running_loop, sync_generator_to_async
+from promptflow._utils.async_utils import async_run_allowing_running_loop, sync_iterator_to_async
 from promptflow._utils.context_utils import _change_working_dir
 from promptflow._utils.execution_utils import (
     apply_default_value_for_input,
@@ -724,7 +723,7 @@ class FlowExecutor:
                 node_concurrency,
                 allow_generator_output,
                 line_timeout_sec,
-                convert_generator=False,
+                sync_iterator_to_async=False,
             )
         # TODO: Call exec_line_async in exec_line when async is mature.
         self._node_concurrency = node_concurrency
@@ -755,7 +754,7 @@ class FlowExecutor:
         node_concurrency=DEFAULT_CONCURRENCY_FLOW,
         allow_generator_output: bool = False,
         line_timeout_sec: Optional[int] = None,
-        convert_generator: bool = True,
+        sync_iterator_to_async: bool = True,
     ) -> LineResult:
         """Execute a single line of the flow.
 
@@ -771,8 +770,8 @@ class FlowExecutor:
         :type node_concurrency: int
         :param allow_generator_output: Whether to allow generator output.
         :type allow_generator_output: bool
-        :param convert_generator: Whether to convert generator output to async generator.
-        :type convert_generator: bool
+        :param sync_iterator_to_async: Whether to convert sync iterator output to async iterator.
+        :type sync_iterator_to_async: bool
         :return: The result of executing the line.
         :rtype: ~promptflow.executor._result.LineResult
         """
@@ -790,8 +789,8 @@ class FlowExecutor:
                 validate_inputs=validate_inputs,
                 allow_generator_output=allow_generator_output,
             )
-            if convert_generator:
-                line_result.output = self._convert_generators_to_async(line_result.output)
+            if sync_iterator_to_async:
+                line_result.output = self._convert_iterators_to_async(line_result.output)
         #  Return line result with index
         if index is not None and isinstance(line_result.output, dict):
             line_result.output[LINE_NUMBER_KEY] = index
@@ -896,10 +895,10 @@ class FlowExecutor:
             enrich_span_with_input(span, inputs)
             yield span
 
-    def _convert_generators_to_async(self, output: dict):
+    def _convert_iterators_to_async(self, output: dict):
         for k, v in output.items():
-            if isinstance(v, GeneratorType):
-                output[k] = sync_generator_to_async(v)
+            if isinstance(v, Iterator):
+                output[k] = sync_iterator_to_async(v)
         return output
 
     async def _exec_inner_with_trace_async(
@@ -954,7 +953,7 @@ class FlowExecutor:
         generator_output_nodes = [
             nodename
             for nodename, output in nodes_outputs.items()
-            if isinstance(output, GeneratorType) or isinstance(output, AsyncGeneratorType)
+            if isinstance(output, Iterator) or isinstance(output, AsyncIterator)
         ]
         # When stream is True, we allow generator output in the flow output
         run_tracker.allow_generator_types = stream
@@ -1214,9 +1213,9 @@ class FlowExecutor:
         return outputs, nodes_outputs
 
     @staticmethod
-    async def _merge_async_generator(async_gen: AsyncGeneratorType, outputs: dict, key: str):
+    async def _merge_async_iterator(async_it: AsyncIterator, outputs: dict, key: str):
         items = []
-        async for item in async_gen:
+        async for item in async_it:
             items.append(item)
         outputs[key] = "".join(str(item) for item in items)
 
@@ -1224,24 +1223,24 @@ class FlowExecutor:
         pool = ThreadPoolExecutorWithContext()
         tasks = []
         for k, v in outputs.items():
-            if isinstance(v, AsyncGeneratorType):
-                tasks.append(asyncio.create_task(self._merge_async_generator(v, outputs, k)))
-            elif isinstance(v, GeneratorType):
+            if isinstance(v, AsyncIterator):
+                tasks.append(asyncio.create_task(self._merge_async_iterator(v, outputs, k)))
+            elif isinstance(v, Iterator):
                 loop = asyncio.get_event_loop()
-                task = loop.run_in_executor(pool, self._merge_generator, v, outputs, k)
+                task = loop.run_in_executor(pool, self._merge_iterator, v, outputs, k)
                 tasks.append(task)
         if tasks:
             await asyncio.wait(tasks)
         return outputs
 
     @staticmethod
-    def _merge_generator(gen: GeneratorType, outputs: dict, key: str):
+    def _merge_iterator(gen: Iterator, outputs: dict, key: str):
         outputs[key] = "".join(str(item) for item in gen)
 
     def _stringify_generator_output(self, outputs: dict):
         for k, v in outputs.items():
-            if isinstance(v, GeneratorType):
-                self._merge_generator(v, outputs, k)
+            if isinstance(v, Iterator):
+                self._merge_iterator(v, outputs, k)
 
         return outputs
 
@@ -1378,7 +1377,7 @@ def _ensure_node_result_is_serializable(f):
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         result = f(*args, **kwargs)
-        if isinstance(result, GeneratorType):
+        if isinstance(result, Iterator):
             result = "".join(str(trunk) for trunk in result)
         return result
 


### PR DESCRIPTION
# Description

Quick fix for the issue #3069

This pull request primarily focuses on changes to the `promptflow-core` package to improve handling of synchronous and asynchronous iterators. The most significant changes include the creation of a new function `sync_iterator_to_async` in `async_utils.py` and its subsequent integration into the `flow_executor.py` module. 

Here are the key changes, grouped by theme:

**Addition of new utility function:**

* [`src/promptflow-core/promptflow/_utils/async_utils.py`](diffhunk://#diff-ebca5e7d6a45f737be917f296f2fb0a3480fa26bc378bde80f11368c9ac2c4fbR113-R124): A new function `sync_iterator_to_async` has been added. This function converts a synchronous iterator to an asynchronous one using a thread pool executor.

**Changes to the `flow_executor.py` module:**

* [`src/promptflow-core/promptflow/executor/flow_executor.py`](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL32-R31): The `sync_iterator_to_async` function has been imported from `async_utils.py` and integrated into several methods. [[1]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL32-R31) [[2]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fR726) [[3]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fR757) [[4]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fR792-R793) [[5]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fR898-R903)

* [`src/promptflow-core/promptflow/executor/flow_executor.py`](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL17-R17): The type `GeneratorType` has been replaced with `Iterator` and `AsyncGeneratorType` with `AsyncIterator` in several methods. This change reflects the shift towards using the more general `Iterator` and `AsyncIterator` types. [[1]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL17-R17) [[2]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL945-R956) [[3]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL1205-R1243) [[4]](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL1369-R1380)

These changes enhance the flexibility of the `promptflow-core` package by allowing it to handle both synchronous and asynchronous iterators effectively.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
