### PR TITLE
[devkit][trace] Handle inputs/output in span attributes & non-JSON string inputs/output

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/entities/_trace.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_trace.py
@@ -342,22 +342,24 @@ class LineRun:
         except json.JSONDecodeError:
             return value
 
-    def _get_inputs_from_span(self, span: Span) -> typing.Optional[typing.Dict]:
+    @staticmethod
+    def _get_inputs_from_span(span: Span) -> typing.Optional[typing.Dict]:
         for event in span.events:
             if event[SpanEventFieldName.NAME] == SPAN_EVENTS_NAME_PF_INPUTS:
                 return json.loads(event[SpanEventFieldName.ATTRIBUTES][SPAN_EVENTS_ATTRIBUTE_PAYLOAD])
         # 3rd-party traces may not follow prompt flow way to persist inputs in events
         if SpanAttributeFieldName.INPUTS in span.attributes:
-            return self._parse_io_from_span_attributes(span.attributes[SpanAttributeFieldName.INPUTS])
+            return LineRun._parse_io_from_span_attributes(span.attributes[SpanAttributeFieldName.INPUTS])
         return None
 
-    def _get_outputs_from_span(self, span: Span) -> typing.Optional[typing.Dict]:
+    @staticmethod
+    def _get_outputs_from_span(span: Span) -> typing.Optional[typing.Dict]:
         for event in span.events:
             if event[SpanEventFieldName.NAME] == SPAN_EVENTS_NAME_PF_OUTPUT:
                 return json.loads(event[SpanEventFieldName.ATTRIBUTES][SPAN_EVENTS_ATTRIBUTE_PAYLOAD])
         # 3rd-party traces may not follow prompt flow way to persist output in events
         if SpanAttributeFieldName.OUTPUT in span.attributes:
-            return self._parse_io_from_span_attributes(span.attributes[SpanAttributeFieldName.OUTPUT])
+            return LineRun._parse_io_from_span_attributes(span.attributes[SpanAttributeFieldName.OUTPUT])
         return None
 
     @staticmethod


### PR DESCRIPTION
# Description

For traces whose inputs and output locate in span attributes, we should support extract them for line run entity, as it's still OpenTelemetry specification. Also, this PR targets to support those non-JSON string inputs/output (user generates span with `span.set_attributes("inputs", str(dict(x=1)))`)

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
