### PR TITLE
[Internal] Fix the bug that Ctrl+C doesn't returns flow result.

### DIFF
--- a/src/promptflow-core/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow-core/promptflow/executor/_async_nodes_scheduler.py
@@ -6,7 +6,6 @@ import asyncio
 import contextvars
 import inspect
 import os
-import signal
 import threading
 import time
 import traceback
@@ -46,14 +45,7 @@ class AsyncNodesScheduler:
         inputs: Dict[str, Any],
         context: FlowExecutionContext,
     ) -> Tuple[dict, dict]:
-        # TODO: Provide cancel API
-        if threading.current_thread() is threading.main_thread():
-            signal.signal(signal.SIGINT, signal_handler)
-            signal.signal(signal.SIGTERM, signal_handler)
-        else:
-            flow_logger.info(
-                "Current thread is not main thread, skip signal handler registration in AsyncNodesScheduler."
-            )
+        flow_logger.info("Current thread is not main thread, skip signal handler registration in AsyncNodesScheduler.")
         # Semaphore should be created in the loop, otherwise it will not work.
         loop = asyncio.get_running_loop()
         self._semaphore = asyncio.Semaphore(self._node_concurrency)
@@ -83,7 +75,11 @@ class AsyncNodesScheduler:
         # This is because it will always call `executor.shutdown()` when exiting the `with` block.
         # Then the event loop will wait for all tasks to be completed before raising the cancellation error.
         # See reference: https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.Executor
-        outputs = await self._execute_with_thread_pool(executor, nodes, inputs, context)
+        try:
+            outputs = await self._execute_with_thread_pool(executor, nodes, inputs, context)
+        except asyncio.CancelledError:
+            await self.cancel()
+            raise
         executor.shutdown()
         return outputs
 
@@ -174,15 +170,11 @@ class AsyncNodesScheduler:
         # The task will not be executed before calling create_task.
         return await asyncio.get_running_loop().run_in_executor(executor, context.invoke_tool, node, f, kwargs)
 
-
-def signal_handler(sig, frame):
-    """
-    Start a thread to monitor coroutines after receiving signal.
-    """
-    flow_logger.info(f"Received signal {sig}({signal.Signals(sig).name}), start coroutine monitor thread.")
-    loop = asyncio.get_running_loop()
-    monitor = ThreadWithContextVars(target=monitor_coroutine_after_cancellation, args=(loop,))
-    monitor.start()
+    async def cancel(self):
+        flow_logger.info("Cancel requested, monitoring coroutines after cancellation.")
+        loop = asyncio.get_running_loop()
+        monitor = ThreadWithContextVars(target=monitor_coroutine_after_cancellation, args=(loop,))
+        monitor.start()
 
 
 def log_stack_recursively(task: asyncio.Task, elapse_time: float):

--- a/src/promptflow-core/promptflow/executor/_async_nodes_scheduler.py
+++ b/src/promptflow-core/promptflow/executor/_async_nodes_scheduler.py
@@ -54,7 +54,6 @@ class AsyncNodesScheduler:
             flow_logger.info(
                 "Current thread is not main thread, skip signal handler registration in AsyncNodesScheduler."
             )
-
         # Semaphore should be created in the loop, otherwise it will not work.
         loop = asyncio.get_running_loop()
         self._semaphore = asyncio.Semaphore(self._node_concurrency)
@@ -62,7 +61,11 @@ class AsyncNodesScheduler:
             monitor = ThreadWithContextVars(
                 target=monitor_long_running_coroutine,
                 args=(
-                    interval, loop, self._task_start_time, self._task_last_log_time, self._dag_manager_completed_event
+                    interval,
+                    loop,
+                    self._task_start_time,
+                    self._task_last_log_time,
+                    self._dag_manager_completed_event,
                 ),
                 daemon=True,
             )
@@ -180,7 +183,6 @@ def signal_handler(sig, frame):
     loop = asyncio.get_running_loop()
     monitor = ThreadWithContextVars(target=monitor_coroutine_after_cancellation, args=(loop,))
     monitor.start()
-    raise KeyboardInterrupt
 
 
 def log_stack_recursively(task: asyncio.Task, elapse_time: float):

--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -1093,15 +1093,12 @@ class FlowExecutor:
                 context,
                 allow_generator_output,
             )
-        except KeyboardInterrupt as ex:
-            # Run will be cancelled when the process receives a SIGINT signal.
-            # KeyboardInterrupt will be raised after asyncio finishes its signal handling
-            # End run with the KeyboardInterrupt exception, so that its status will be Canceled
-            flow_logger.info("Received KeyboardInterrupt, cancel the run.")
-            # Update the run info of those running nodes to a canceled status.
+        except asyncio.CancelledError as ex:
+            flow_logger.info("Received cancelled error, cancel the run.")
             run_tracker.cancel_node_runs(run_id)
             run_tracker.end_run(line_run_id, ex=ex)
-            raise
+            if self._raise_ex:
+                raise
         except Exception as e:
             run_tracker.end_run(line_run_id, ex=e)
             if self._raise_ex:


### PR DESCRIPTION
# Description

Fix the bug that Ctrl+C doesn't returns flow result because the signal handler would raise an exception while asyncio.run cannot handle it correctly.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
