### PR TITLE
[Executor] Add timeout task to async scheduler to achieve timeout feature.

### DIFF
--- a/src/promptflow-core/promptflow/executor/flow_executor.py
+++ b/src/promptflow-core/promptflow/executor/flow_executor.py
@@ -1197,7 +1197,7 @@ class FlowExecutor:
         batch_nodes = [node for node in self._flow.nodes if not node.aggregation]
         flow_logger.info("Start executing nodes in async mode.")
         scheduler = AsyncNodesScheduler(self._tools_manager, self._node_concurrency)
-        nodes_outputs, bypassed_nodes = await scheduler.execute(batch_nodes, inputs, context)
+        nodes_outputs, bypassed_nodes = await scheduler.execute(batch_nodes, inputs, context, self._line_timeout_sec)
         outputs = self._extract_outputs(nodes_outputs, bypassed_nodes, inputs)
         return outputs, nodes_outputs
 


### PR DESCRIPTION
# Description
Improve the timeout handling of async scheduler.

Before:
The async nodes would be keep running until the process is killed.

After:
The async function would got an asyncio.CanceledError, then the line raises LineExecutionTimeoutError.

This pull request introduces changes in the `src/promptflow-core/promptflow/executor/_async_nodes_scheduler.py` and `src/promptflow-core/promptflow/executor/flow_executor.py` files to handle line execution timeouts. The `Optional` type has been imported and a `timeout_seconds` parameter has been added to the `execute` and `_execute_with_thread_pool` methods. A timeout mechanism has been implemented in `_execute_with_thread_pool` to cancel tasks that exceed the specified timeout. A `cancel_tasks` method has also been added to cancel tasks and yield control to the event loop for cleanup. The `LineExecutionTimeoutError` exception is raised when a timeout occurs.

Changes to handle line execution timeouts:

* [`src/promptflow-core/promptflow/executor/_async_nodes_scheduler.py`](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901L14-R14): Imported `Optional` type and added `timeout_seconds` parameter to `execute` and `_execute_with_thread_pool` methods. Implemented timeout mechanism in `_execute_with_thread_pool` and added `cancel_tasks` method to cancel tasks and yield control to the event loop for cleanup. Raised `LineExecutionTimeoutError` when timeout occurs. [[1]](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901L14-R14) [[2]](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901L23-R23) [[3]](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901R47) [[4]](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901L78-R79) [[5]](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901R92-R106) [[6]](diffhunk://#diff-cd6772e1603e398a564a4d2768ee2f7ffdf7c5e3e0bb7cda5bf19e560f143901R116-R124)
* [`src/promptflow-core/promptflow/executor/flow_executor.py`](diffhunk://#diff-bec06607cb28fd791b8ed11bb488979344ca342be5f1c67ba6dd663d5e12240fL1200-R1200): Passed `self._line_timeout_sec` as `timeout_seconds` to `scheduler.execute` method.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
