### PR TITLE
[Internal] Remove env var param from experiment api

### DIFF
--- a/scripts/docs/conf.py
+++ b/scripts/docs/conf.py
@@ -112,8 +112,8 @@ html_theme_options = {
     "show_toc_level": 1,
     "navbar_align": "left",  # [left, content, right] For testing that the navbar items align properly
     "navbar_center": ["navbar-nav"],
-    "announcement": "<b>[IMPORTANT]</b> Please uninstall existing promptflow and sub packages before you install "
-    "promptflow==1.8.0. Reach "
+    "announcement": "<b>[IMPORTANT]</b> Please uninstall existing promptflow and sub packages before you "
+    "upgrade from promptflow<=1.7.0 to newer version. Reach "
     "<a href='https://microsoft.github.io/promptflow/how-to-guides/faq.html#promptflow-1-8-0-upgrade-guide'>"
     "here</a> for more details.",
     "show_nav_level": 1,

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_experiment_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_experiment_operations.py
@@ -153,15 +153,13 @@ class ExperimentOperations(TelemetryMixin):
         return self.get(experiment.name)
 
     @monitor_operation(activity_name="pf.experiment.test", activity_type=ActivityType.PUBLICAPI)
-    def test(self, experiment: Experiment, inputs=None, environment_variables=None, **kwargs) -> Experiment:
+    def test(self, experiment: Union[Path, str], inputs=None, **kwargs) -> Experiment:
         """Test an experiment.
 
         :param experiment: Experiment yaml file path.
         :type experiment: Union[Path, str]
         :param inputs: Input parameters for flow.
         :type inputs: dict
-        :param environment_variables: Environment variables for flow.
-        :type environment_variables: dict
         """
         from promptflow._sdk._orchestrator.experiment_orchestrator import ExperimentOrchestrator
 
@@ -173,7 +171,6 @@ class ExperimentOperations(TelemetryMixin):
         return ExperimentOrchestrator(client=self._client, experiment=None).test(
             experiment_template,
             inputs=inputs,
-            environment_variables=environment_variables,
             output_path=output_path,
             session=session,
             **kwargs,

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_experiment.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_experiment.py
@@ -260,6 +260,7 @@ class TestExperiment:
                     experiment=template_path,
                     session=session,
                     inputs={"url": "https://www.youtube.com/watch?v=kYqRtjDBci8", "answer": "Channel"},
+                    environment_variables={"PF_TEST_FLOW_TEST_WITH_EXPERIMENT": "1"},
                 )
                 futures.wait([task], return_when=futures.ALL_COMPLETED)
                 result = task.result()
@@ -267,6 +268,7 @@ class TestExperiment:
             # Assert line run id is set by executor when running test
             assert PF_TRACE_CONTEXT in os.environ
             attributes = json.loads(os.environ[PF_TRACE_CONTEXT]).get("attributes")
+            assert os.environ.get("PF_TEST_FLOW_TEST_WITH_EXPERIMENT") == "1"
             assert attributes.get("experiment") == template_path.resolve().absolute().as_posix()
             assert attributes.get("referenced.line_run_id", "").startswith("main")
             expected_output_path = (


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.

Only flow test with experiment can pass env var in.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
