### PR TITLE
Add environment for build job so that we can only use one federated credential 

### DIFF
--- a/.github/workflows/tools_tests.yml
+++ b/.github/workflows/tools_tests.yml
@@ -6,13 +6,6 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - src/promptflow-tools/**
-      - scripts/tool/**
-      - .github/workflows/tools_tests.yml
   pull_request_target:
     paths:
       - src/promptflow-tools/**

--- a/.github/workflows/tools_tests.yml
+++ b/.github/workflows/tools_tests.yml
@@ -6,6 +6,13 @@ permissions:
   contents: read
 on:
   workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - src/promptflow-tools/**
+      - scripts/tool/**
+      - .github/workflows/tools_tests.yml
   pull_request_target:
     paths:
       - src/promptflow-tools/**
@@ -27,6 +34,7 @@ jobs:
     strategy:
       fail-fast: false
     runs-on: ubuntu-latest
+    environment: Testing
     timeout-minutes: 30
     env:
       DEPENDENCY_SOURCE_MODE: ${{ secrets.DEPENDENCY_SOURCE_MODE }}


### PR DESCRIPTION
Add environment for build job so that we can only use one federated credential for below scenarios:
1. Manually trigger use any branch, test link https://github.com/microsoft/promptflow/actions/runs/9029698172:
![image](https://github.com/microsoft/promptflow/assets/49388944/da06fc80-b92b-4ff5-bcc0-be25d1bf3dcf)
2. Trigger from a PR

For all these scenarios, the subject claim will be repo:microsoft/promptflow:environment:Testing. So only need to keep below federated credential:
![image](https://github.com/microsoft/promptflow/assets/49388944/3f16f338-1286-4d22-8431-35d411f94d39)
