### PR TITLE
Update msi release workflow because disable storage account key access

### DIFF
--- a/.github/workflows/build_msi_installer.yml
+++ b/.github/workflows/build_msi_installer.yml
@@ -28,6 +28,9 @@ permissions:
 env:
   packageSetupType: promptflow_with_extra
   testWorkingDirectory: src/promptflow
+  AZURE_ACCOUNT_NAME: promptflowartifact
+  AZURE_MSI_CONTAINER_NAME: msi-installer
+  AZURE_PORTABLE_CONTAINER_NAME: portable-installer
 
 jobs:
   build_msi_installer:
@@ -187,7 +190,7 @@ jobs:
       - name: Download JSON file from Azure Blob Storage
         id: download-json
         run: |
-          az storage blob download --account-name promptflowartifact --container-name msi-installer --name latest_version.json --file downloaded_version.json --auth-mode login
+          az storage blob download --account-name ${{ env.AZURE_ACCOUNT_NAME }} --container-name ${{ env.AZURE_MSI_CONTAINER_NAME }} --name latest_version.json --file downloaded_version.json --auth-mode login
           $downloaded_version = (Get-Content downloaded_version.json | ConvertFrom-Json).promptflow
           echo "::set-output name=downloaded_version::$downloaded_version"
 
@@ -203,28 +206,32 @@ jobs:
             $jsonContent | Out-File -FilePath latest_version.json -Encoding UTF8
 
             Write-Output "Created latest_version.json with version: $version"
-            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "latest_version.json" --name "latest_version.json" --overwrite --auth-mode login
+            az storage blob upload --account-name ${{ env.AZURE_ACCOUNT_NAME }} --container-name ${{ env.AZURE_MSI_CONTAINER_NAME }} --file "latest_version.json" --name "latest_version.json" --overwrite --auth-mode login
           } else {
             Write-Output "skip uploading since version input isn't greater than latest version or does not start with '1.'"
           }
 
       - name: Upload to Azure Storage
         run: |
+          function Upload-File($filePath, $blobName, $containerName) {
+            az storage blob upload --account-name ${{ env.AZURE_ACCOUNT_NAME }} --container-name $containerName --file $filePath --name $blobName --overwrite --auth-mode login
+          }
+    
           $msi_files = Get-ChildItem -Path 'scripts/installer/windows/out/' -Filter *.msi
           foreach ($msi_file in $msi_files) {
-          if ($env:INPUT_UPLOADASLATEST -ieq 'True') {
-            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "scripts/installer/windows/out/$($msi_file.Name)" --name "promptflow.msi" --overwrite --auth-mode login
-            az storage blob copy start --account-name promptflowartifact --destination-container msi-installer --destination-blob "$($msi_file.Name)" --source-container msi-installer --source-blob "promptflow.msi" --auth-mode login
-          } else {
-            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "scripts/installer/windows/out/$($msi_file.Name)" --name "$($msi_file.Name)" --overwrite --auth-mode login
-          }
+            if ($env:INPUT_UPLOADASLATEST -ieq 'True') {
+              Upload-File "scripts/installer/windows/out/$($msi_file.Name)" "promptflow.msi" ${{ env.AZURE_MSI_CONTAINER_NAME }}
+              az storage blob copy start --account-name ${{ env.AZURE_ACCOUNT_NAME }} --destination-container ${{ env.AZURE_MSI_CONTAINER_NAME }} --destination-blob "$($msi_file.Name)" --source-container ${{ env.AZURE_MSI_CONTAINER_NAME }} --source-blob "promptflow.msi" --auth-mode login
+            } else {
+              Upload-File "scripts/installer/windows/out/$($msi_file.Name)" "$($msi_file.Name)" ${{ env.AZURE_MSI_CONTAINER_NAME }}
+            }
           }
           # Upload zip file
           if ($env:INPUT_UPLOADASLATEST -ieq 'True') {
-            az storage blob upload --account-name promptflowartifact --container-name portable-installer --file "promptflow-${{ steps.get-version.outputs.version }}.zip" --name "promptflow.zip" --overwrite --auth-mode login
-            az storage blob copy start --account-name promptflowartifact --destination-container portable-installer --destination-blob "promptflow-${{ steps.get-version.outputs.version }}.zip" --source-container portable-installer --source-blob "promptflow.zip" --auth-mode login
+            Upload-File "promptflow-${{ steps.get-version.outputs.version }}.zip" "promptflow.zip" ${{ env.AZURE_PORTABLE_CONTAINER_NAME }}
+            az storage blob copy start --account-name ${{ env.AZURE_ACCOUNT_NAME }} --destination-container ${{ env.AZURE_PORTABLE_CONTAINER_NAME }} --destination-blob "promptflow-${{ steps.get-version.outputs.version }}.zip" --source-container ${{ env.AZURE_PORTABLE_CONTAINER_NAME }} --source-blob "promptflow.zip" --auth-mode login
           } else {
-            az storage blob upload --account-name promptflowartifact --container-name portable-installer --file "promptflow-${{ steps.get-version.outputs.version }}.zip" --name "promptflow-${{ steps.get-version.outputs.version }}.zip" --overwrite --auth-mode login
+            Upload-File "promptflow-${{ steps.get-version.outputs.version }}.zip" "promptflow-${{ steps.get-version.outputs.version }}.zip" ${{ env.AZURE_PORTABLE_CONTAINER_NAME }}
           }
         env:
           INPUT_UPLOADASLATEST: ${{ github.event.inputs.uploadAsLatest }}

--- a/.github/workflows/build_msi_installer.yml
+++ b/.github/workflows/build_msi_installer.yml
@@ -187,7 +187,7 @@ jobs:
       - name: Download JSON file from Azure Blob Storage
         id: download-json
         run: |
-          az storage blob download --account-name promptflowartifact --container-name msi-installer --name latest_version.json --file downloaded_version.json
+          az storage blob download --account-name promptflowartifact --container-name msi-installer --name latest_version.json --file downloaded_version.json --auth-mode login
           $downloaded_version = (Get-Content downloaded_version.json | ConvertFrom-Json).promptflow
           echo "::set-output name=downloaded_version::$downloaded_version"
 
@@ -203,7 +203,7 @@ jobs:
             $jsonContent | Out-File -FilePath latest_version.json -Encoding UTF8
 
             Write-Output "Created latest_version.json with version: $version"
-            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "latest_version.json" --name "latest_version.json" --overwrite
+            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "latest_version.json" --name "latest_version.json" --overwrite --auth-mode login
           } else {
             Write-Output "skip uploading since version input isn't greater than latest version or does not start with '1.'"
           }
@@ -213,18 +213,18 @@ jobs:
           $msi_files = Get-ChildItem -Path 'scripts/installer/windows/out/' -Filter *.msi
           foreach ($msi_file in $msi_files) {
           if ($env:INPUT_UPLOADASLATEST -ieq 'True') {
-            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "scripts/installer/windows/out/$($msi_file.Name)" --name "promptflow.msi" --overwrite
-            az storage blob copy start --account-name promptflowartifact --destination-container msi-installer --destination-blob "$($msi_file.Name)" --source-container msi-installer --source-blob "promptflow.msi"
+            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "scripts/installer/windows/out/$($msi_file.Name)" --name "promptflow.msi" --overwrite --auth-mode login
+            az storage blob copy start --account-name promptflowartifact --destination-container msi-installer --destination-blob "$($msi_file.Name)" --source-container msi-installer --source-blob "promptflow.msi" --auth-mode login
           } else {
-            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "scripts/installer/windows/out/$($msi_file.Name)" --name "$($msi_file.Name)" --overwrite
+            az storage blob upload --account-name promptflowartifact --container-name msi-installer --file "scripts/installer/windows/out/$($msi_file.Name)" --name "$($msi_file.Name)" --overwrite --auth-mode login
           }
           }
           # Upload zip file
           if ($env:INPUT_UPLOADASLATEST -ieq 'True') {
-            az storage blob upload --account-name promptflowartifact --container-name portable-installer --file "promptflow-${{ steps.get-version.outputs.version }}.zip" --name "promptflow.zip" --overwrite
-            az storage blob copy start --account-name promptflowartifact --destination-container portable-installer --destination-blob "promptflow-${{ steps.get-version.outputs.version }}.zip" --source-container portable-installer --source-blob "promptflow.zip"
+            az storage blob upload --account-name promptflowartifact --container-name portable-installer --file "promptflow-${{ steps.get-version.outputs.version }}.zip" --name "promptflow.zip" --overwrite --auth-mode login
+            az storage blob copy start --account-name promptflowartifact --destination-container portable-installer --destination-blob "promptflow-${{ steps.get-version.outputs.version }}.zip" --source-container portable-installer --source-blob "promptflow.zip" --auth-mode login
           } else {
-            az storage blob upload --account-name promptflowartifact --container-name portable-installer --file "promptflow-${{ steps.get-version.outputs.version }}.zip" --name "promptflow-${{ steps.get-version.outputs.version }}.zip" --overwrite
+            az storage blob upload --account-name promptflowartifact --container-name portable-installer --file "promptflow-${{ steps.get-version.outputs.version }}.zip" --name "promptflow-${{ steps.get-version.outputs.version }}.zip" --overwrite --auth-mode login
           }
         env:
           INPUT_UPLOADASLATEST: ${{ github.event.inputs.uploadAsLatest }}


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
https://github.com/microsoft/promptflow/actions/runs/9028720944/job/24811913622

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
