### PR TITLE
[Internal] add public function get_trace_destination

### DIFF
--- a/src/promptflow-devkit/promptflow/_dependencies/_pf_evals.py
+++ b/src/promptflow-devkit/promptflow/_dependencies/_pf_evals.py
@@ -7,4 +7,4 @@
 
 # flake8: noqa
 from promptflow._sdk._constants import LINE_NUMBER, Local2Cloud
-from promptflow._sdk._configuration import Configuration
+from promptflow._sdk._utilities.general_utils import get_trace_destination

--- a/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
@@ -1130,17 +1130,14 @@ def resolve_flow_language(
     return yaml_dict.get(LANGUAGE_KEY, FlowLanguage.Python)
 
 
-def get_trace_destination(pf_client=None, path=None):
-    """
+def get_trace_destination(pf_client=None):
+    """get trace.destination
+
     :param pf_client: pf_client object
     :type pf_client: promptflow._sdk._pf_client.PFClient
-    :param path: The path to the config file of (subscription, resource_group, workspace)
-                or starting directory to search.
-                The parameter defaults to starting the search in the current directory.
-    :type path: str
     :return:
     """
     config = pf_client._config if pf_client else Configuration.get_instance()
-    trace_destination = config.get_trace_destination(path=path)
+    trace_destination = config.get_trace_destination()
 
     return trace_destination

--- a/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
@@ -40,6 +40,7 @@ from promptflow._constants import (
     PROMPTY_EXTENSION,
     FlowLanguage,
 )
+from promptflow._sdk._configuration import Configuration
 from promptflow._sdk._constants import (
     AZURE_WORKSPACE_REGEX_FORMAT,
     DEFAULT_ENCODING,
@@ -1127,3 +1128,19 @@ def resolve_flow_language(
                 f"Invalid flow path {file_path.as_posix()}, must exist and of suffix yaml, yml or prompty."
             )
     return yaml_dict.get(LANGUAGE_KEY, FlowLanguage.Python)
+
+
+def get_trace_destination(pf_client=None, path=None):
+    """
+    :param pf_client: pf_client object
+    :type pf_client: promptflow._sdk._pf_client.PFClient
+    :param path: The path to the config file of (subscription, resource_group, workspace)
+                or starting directory to search.
+                The parameter defaults to starting the search in the current directory.
+    :type path: str
+    :return:
+    """
+    config = pf_client._config if pf_client else Configuration.get_instance()
+    trace_destination = config.get_trace_destination(path=path)
+
+    return trace_destination

--- a/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
@@ -40,7 +40,6 @@ from promptflow._constants import (
     PROMPTY_EXTENSION,
     FlowLanguage,
 )
-from promptflow._sdk._configuration import Configuration
 from promptflow._sdk._constants import (
     AZURE_WORKSPACE_REGEX_FORMAT,
     DEFAULT_ENCODING,
@@ -1137,6 +1136,8 @@ def get_trace_destination(pf_client=None):
     :type pf_client: promptflow._sdk._pf_client.PFClient
     :return:
     """
+    from promptflow._sdk._configuration import Configuration
+
     config = pf_client._config if pf_client else Configuration.get_instance()
     trace_destination = config.get_trace_destination()
 

--- a/src/promptflow-devkit/tests/unittests/_sdk/_utilities/test_pf_eval_dependencies.py
+++ b/src/promptflow-devkit/tests/unittests/_sdk/_utilities/test_pf_eval_dependencies.py
@@ -1,10 +1,14 @@
 from unittest.mock import patch
 
 import pytest
-from promptflow._dependencies._pf_evals import LINE_NUMBER, Local2Cloud, Configuration
 
-DUMMY_TRACE_DESTINATION = ("azureml://subscriptions/sub_id/resourceGroups/resource_group_name"
-                           "/providers/Microsoft.MachineLearningServices/workspaces/workspace_name")
+from promptflow._dependencies._pf_evals import LINE_NUMBER, Local2Cloud, get_trace_destination
+from promptflow._sdk._pf_client import PFClient
+
+DUMMY_TRACE_DESTINATION = (
+    "azureml://subscriptions/sub_id/resourceGroups/resource_group_name"
+    "/providers/Microsoft.MachineLearningServices/workspaces/workspace_name"
+)
 
 
 @pytest.fixture
@@ -15,7 +19,6 @@ def patch_config_validation():
 
 @pytest.mark.unittest
 class TestPromptflowEvalsDependencies:
-
     def test_pf_eval_constants_dependencies(self):
         assert LINE_NUMBER == "line_number"
         assert Local2Cloud.FLOW_INSTANCE_RESULTS_FILE_NAME == "instance_results.jsonl"
@@ -23,5 +26,5 @@ class TestPromptflowEvalsDependencies:
         assert Local2Cloud.BLOB_ARTIFACTS == "PromptFlowArtifacts"
 
     def test_pf_eval_configuration_dependencies(self, patch_config_validation):
-        config = Configuration(overrides={"trace.destination": DUMMY_TRACE_DESTINATION})
-        assert config.get_trace_destination() == DUMMY_TRACE_DESTINATION
+        pf_client = PFClient(config={"trace.destination": DUMMY_TRACE_DESTINATION})
+        assert get_trace_destination(pf_client=pf_client) == DUMMY_TRACE_DESTINATION


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
```python
pf = PFCLient(config = {"trace.destination": 'azureml://subscriptions/......'}) # override 
pf = PFClient()        # global
pf.run(...) # will pick up config in PFClient

from promptflow._dependencies._pf_evals import get_trace_destination
# if azureml -> azureml://sub/rg/ws
url = get_trace_destination(pf) 
# if azureml -> azureml://sub/rg/ws (search from current working directory
```

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
