### PR TITLE
[Connection] Return secrets in connection obj for better flex flow experience

### DIFF
--- a/src/promptflow-azure/CHANGELOG.md
+++ b/src/promptflow-azure/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Improvements
 - Refine trace Cosmos DB setup process to print setup status during the process, and display error message from service when setup failed.
+- Return the secrets in the connection object by default to improve flex flow experience.
+  - Behaviors not changed: 'pfazure connection' command will scrub secrets.
+  - New behavior: connection object by `client.connection.get` will have real secrets. `print(connection_obj)` directly will scrub those secrets. `print(connection_obj.api_key)` or `print(connection_obj.secrets)` will print the REAL secrets.
+  - Workspace listsecrets permission is required to get the secrets. Call `client.connection.get(name, with_secrets=True)` if you want to get without the secrets and listsecrets permission.
 
 ## v1.10.0 (2024.04.26)
 

--- a/src/promptflow-azure/promptflow/azure/operations/_arm_connection_operations.py
+++ b/src/promptflow-azure/promptflow/azure/operations/_arm_connection_operations.py
@@ -45,6 +45,11 @@ class ArmConnectionOperations(_ScopeDependentOperations):
         )
 
     def get(self, name, **kwargs):
+        with_secrets = kwargs.get("with_secrets", True)
+        if with_secrets:
+            return self._direct_get(
+                name, self._subscription_id, self._resource_group_name, self._workspace_name, self._credential
+            )
         return _Connection._from_core_connection(self._provider.get(name))
 
     @classmethod

--- a/src/promptflow-core/promptflow/core/_connection.py
+++ b/src/promptflow-core/promptflow/core/_connection.py
@@ -10,7 +10,6 @@ from promptflow._constants import CONNECTION_SCRUBBED_VALUE as SCRUBBED_VALUE
 from promptflow._constants import CONNECTION_SCRUBBED_VALUE_NO_CHANGE, ConnectionType, CustomStrongTypeConnectionConfigs
 from promptflow._core.token_provider import AzureTokenProvider
 from promptflow._utils.logger_utils import LoggerFactory
-from promptflow._utils.utils import in_jupyter_notebook
 from promptflow.constants import ConnectionAuthMode, ConnectionDefaultApiVersion
 from promptflow.contracts.types import Secret
 from promptflow.core._errors import RequiredEnvironmentVariablesNotSetError
@@ -64,10 +63,6 @@ class _Connection:
         self.expiry_time = kwargs.get("expiry_time", None)
         self.created_date = kwargs.get("created_date", None)
         self.last_modified_date = kwargs.get("last_modified_date", None)
-        # Conditional assignment to prevent entity bloat when unused.
-        print_as_yaml = kwargs.pop("print_as_yaml", in_jupyter_notebook())
-        if print_as_yaml:
-            self.print_as_yaml = True
 
     def keys(self) -> List:
         """Return keys of the connection properties."""

--- a/src/promptflow-devkit/CHANGELOG.md
+++ b/src/promptflow-devkit/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Improvements
 - Interactive browser credential is excluded by default when using Azure AI connections, user could set `PF_NO_INTERACTIVE_LOGIN=False` to enable it.
 - Visualize flex flow run(s) switches to trace UI page.
+- Return the secrets in the connection object by default to improve flex flow experience.
+  - Behaviors not changed: 'pf connection' command will scrub secrets.
+  - New behavior: connection object by `client.connection.get` will have real secrets. `print(connection_obj)` directly will scrub those secrets. `print(connection_obj.api_key)` or `print(connection_obj.secrets)` will print the REAL secrets.
 
 ### Bugs Fixed
 - Fix the issue that import error will be raised after downgrading promptflow from >=1.10.0 to <1.8.0.

--- a/src/promptflow-devkit/promptflow/_cli/_pf/_connection.py
+++ b/src/promptflow-devkit/promptflow/_cli/_pf/_connection.py
@@ -202,12 +202,12 @@ def create_connection(file_path, params_override=None, name=None):
         logger.warning(f"Connection with name {connection.name} already exists. Updating it.")
         # Note: We don't set the existing secret back here, let user input the secrets.
     validate_and_interactive_get_secrets(connection)
-    connection = _get_pf_client().connections.create_or_update(connection)
+    connection = _get_pf_client().connections.create_or_update(connection, with_secrets=False)
     print(json.dumps(connection._to_dict(), indent=4))
 
 
 def show_connection(name):
-    connection = _get_pf_client().connections.get(name)
+    connection = _get_pf_client().connections.get(name, with_secrets=False)
     print(json.dumps(connection._to_dict(), indent=4))
 
 
@@ -229,7 +229,7 @@ def _upsert_connection_from_file(file, params_override=None):
         connection._secrets = existing_connection._secrets
     else:
         validate_and_interactive_get_secrets(connection)
-    connection = _get_pf_client().connections.create_or_update(connection)
+    connection = _get_pf_client().connections.create_or_update(connection, with_secrets=False)
     return connection
 
 
@@ -240,7 +240,7 @@ def update_connection(name, params_override=None):
     validate_and_interactive_get_secrets(connection, is_update=True)
     # Set the secrets not scrubbed, as _to_dict() dump scrubbed connections.
     connection._secrets = existing_connection._secrets
-    connection = _get_pf_client().connections.create_or_update(connection)
+    connection = _get_pf_client().connections.create_or_update(connection, with_secrets=False)
     print(json.dumps(connection._to_dict(), indent=4))
 
 

--- a/src/promptflow-devkit/promptflow/_sdk/entities/_connection.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_connection.py
@@ -2,6 +2,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 import abc
+import copy
 import importlib
 import json
 from os import PathLike
@@ -68,6 +69,16 @@ PROMPTFLOW_CONNECTIONS = "promptflow.connections"
 
 class _Connection(_CoreConnection, YAMLTranslatableMixin):
     SUPPORTED_TYPES = {}
+
+    def __str__(self):
+        """Override this function to scrub secrets in connection when print."""
+        obj_for_dump = copy.deepcopy(self)
+        # Scrub secrets.
+        obj_for_dump.secrets = {k: SCRUBBED_VALUE for k in obj_for_dump.secrets}
+        try:
+            return obj_for_dump._to_yaml()
+        except BaseException:  # pylint: disable=broad-except
+            return super(YAMLTranslatableMixin, self).__str__()
 
     @classmethod
     def _casting_type(cls, typ):

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_connection_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_connection_operations.py
@@ -55,7 +55,7 @@ class ConnectionOperations(TelemetryMixin):
         return self._get(name, **kwargs)
 
     def _get(self, name: str, **kwargs) -> _Connection:
-        with_secrets = kwargs.get("with_secrets", False)
+        with_secrets = kwargs.get("with_secrets", True)
         raise_error = kwargs.get("raise_error", True)
         orm_connection = ORMConnection.get(name, raise_error)
         if orm_connection is None:
@@ -90,4 +90,4 @@ class ConnectionOperations(TelemetryMixin):
             orm_object.createdDate = now
         orm_object.lastModifiedDate = now
         ORMConnection.create_or_update(orm_object)
-        return self.get(connection.name)
+        return self.get(connection.name, **kwargs)

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_local_azure_connection_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_local_azure_connection_operations.py
@@ -118,7 +118,7 @@ class LocalAzureConnectionOperations(WorkspaceTelemetryMixin):
         :return: connection object retrieved from Azure.
         :rtype: ~promptflow.sdk.entities._connection._Connection
         """
-        with_secrets = kwargs.get("with_secrets", False)
+        with_secrets = kwargs.get("with_secrets", True)
         if with_secrets:
             # Do not use pfazure_client here as it requires workspace read permission
             # Get secrets from arm only requires workspace listsecrets permission

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_custom_strong_type_connection.py
@@ -4,7 +4,7 @@ import pydash
 import pytest
 from _constants import PROMPTFLOW_ROOT
 
-from promptflow._sdk._constants import SCRUBBED_VALUE, CustomStrongTypeConnectionConfigs
+from promptflow._sdk._constants import CustomStrongTypeConnectionConfigs
 from promptflow._sdk._pf_client import PFClient
 from promptflow._sdk.entities import CustomStrongTypeConnection
 from promptflow.contracts.types import Secret
@@ -40,7 +40,7 @@ class TestCustomStrongTypeConnection:
                 "promptflow.connection.custom_type": "MyCustomConnection",
                 "promptflow.connection.module": "sdk_cli_test.e2etests.test_custom_strong_type_connection",
             },
-            "secrets": {"api_key": "******"},
+            "secrets": {"api_key": "test"},
         }
         # Update
         conn.configs["api_base"] = "test2"
@@ -53,7 +53,7 @@ class TestCustomStrongTypeConnection:
                 "promptflow.connection.custom_type": "MyCustomConnection",
                 "promptflow.connection.module": "sdk_cli_test.e2etests.test_custom_strong_type_connection",
             },
-            "secrets": {"api_key": "******"},
+            "secrets": {"api_key": "test"},
         }
         # List
         result = _client.connections.list()
@@ -79,7 +79,7 @@ class TestCustomStrongTypeConnection:
                 "promptflow.connection.custom_type": "MyCustomConnection",
                 "promptflow.connection.module": "sdk_cli_test.e2etests.test_custom_strong_type_connection",
             },
-            "secrets": {"api_key": "******"},
+            "secrets": {"api_key": "test"},
         }
         # Update
         custom_conn.configs["api_base"] = "test2"
@@ -92,7 +92,7 @@ class TestCustomStrongTypeConnection:
                 "promptflow.connection.custom_type": "MyCustomConnection",
                 "promptflow.connection.module": "sdk_cli_test.e2etests.test_custom_strong_type_connection",
             },
-            "secrets": {"api_key": "******"},
+            "secrets": {"api_key": "test"},
         }
         # List
         result = _client.connections.list()
@@ -106,19 +106,21 @@ class TestCustomStrongTypeConnection:
     def test_connection_get_and_update(self):
         # Test api key not updated
         name = f"Connection_{str(uuid.uuid4())[:4]}"
-        conn = MyCustomConnection(name=name, secrets={"api_key": "test"}, configs={"api_base": "test"})
+        conn = MyCustomConnection(name=name, secrets={"api_key": "test_key"}, configs={"api_base": "test"})
         result = _client.connections.create_or_update(conn)
-        assert result.secrets["api_key"] == SCRUBBED_VALUE
+        assert result.secrets["api_key"] == "test_key"
+        assert "test_key" not in str(result)  # Assert key scrubbed when print
         # Update api_base only Assert no exception
         result.configs["api_base"] = "test2"
         result = _client.connections.create_or_update(result)
         assert result._to_dict()["configs"]["api_base"] == "test2"
         # Assert value not scrubbed
-        assert result._secrets["api_key"] == "test"
+        assert result._secrets["api_key"] == "test_key"
         _client.connections.delete(name)
         # Invalid update
         with pytest.raises(Exception) as e:
             result._secrets = {}
+            result.secrets["api_key"] = "****"
             _client.connections.create_or_update(result)
         assert "secrets ['api_key'] value invalid, please fill them" in str(e.value)
 

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_connection.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_connection.py
@@ -288,8 +288,8 @@ module: promptflow.connections
 type: custom
 configs: {}
 secrets:
-  aaa: bbb
-  ccc: ddd
+  aaa: '******'
+  ccc: '******'
 """
         )
 

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Improvements
 - [promptflow-devkit]: Interactive browser credential is excluded by default when using Azure AI connections, user could set `PF_NO_INTERACTIVE_LOGIN=False` to enable it.
 - [promptflow-azure]: Refine trace Cosmos DB setup process to print setup status during the process, and display error message from service when setup failed.
+- [promptflow-devkit][promptflow-azure] - Return the secrets in the connection object by default to improve flex flow experience.
+  - Reach the sub package docs for more details about this. [promptflow-devkit](https://microsoft.github.io/promptflow/reference/changelog/promptflow-devkit.html) [promptflow-azure](https://microsoft.github.io/promptflow/reference/changelog/promptflow-azure.html)
 
 ### Bugs Fixed
 - Fix the issue that import error will be raised after downgrading promptflow from >=1.10.0 to <1.8.0.


### PR DESCRIPTION
# Description

Please add an informative description that covers that changes made by the pull request and link all relevant issues.
- Return the secrets in the connection object by default to improve flex flow experience.
  - Behaviors not changed: 'pfazure connection'/'pf connection' command will scrub secrets.
  - New behavior: connection object by `client.connection.get` will have real secrets. `print(connection_obj)` directly will scrub those secrets. `print(connection_obj.api_key)` or `print(connection_obj.secrets)` will print the REAL secrets.
  - Workspace listsecrets permission is required to get the Azure AI connection secrets. Call `client.connection.get(name, with_secrets=True)` if you want to get without the secrets and listsecrets permission.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
