### PR TITLE
[SDK/CLI] Fix log level setting for promptflow logger

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py
@@ -105,7 +105,9 @@ class LoggerOperations(LogContext):
             else:
                 log_path.touch()
 
-        for _logger in self._get_execute_loggers_list():
+        # set the log level for all loggers except the logger "promptflow"
+        _loggers = [_logger for _logger in self._get_execute_loggers_list() if _logger.name != logger.name]
+        for _logger in _loggers:
             for handler in _logger.handlers:
                 if self.stream is False and isinstance(handler, logging.StreamHandler):
                     handler.setLevel(logging.CRITICAL)
@@ -113,11 +115,12 @@ class LoggerOperations(LogContext):
 
     def __exit__(self, *args):
         super().__exit__(*args)
-
-        for _logger in self._get_execute_loggers_list():
+        # set the log level for all loggers except the logger "promptflow"
+        _loggers = [_logger for _logger in self._get_execute_loggers_list() if _logger.name != logger.name]
+        for _logger in _loggers:
             for handler in _logger.handlers:
                 if self.stream is False and isinstance(handler, logging.StreamHandler):
-                    handler.setLevel(logging.CRITICAL)
+                    handler.setLevel(logging.INFO)
 
 
 @dataclass


### PR DESCRIPTION
# Description

promptflow logs are lost after the log line `[promptflow._sdk._orchestrator.run_submitter][INFO] - Submitting run xxx`, this change gets back those logs, and make sure content in `logs.txt` remain unchanged.

![image](https://github.com/microsoft/promptflow/assets/2572521/4c3cd0e3-eb3d-40b6-a188-79c2b6f5efe9)



# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
