### PR TITLE
feat: pf flow serve support for directory with 1 and only 1 prompty

### DIFF
--- a/src/promptflow-core/promptflow/_utils/flow_utils.py
+++ b/src/promptflow-core/promptflow/_utils/flow_utils.py
@@ -68,6 +68,7 @@ def resolve_flow_path(
     base_path: Union[str, Path, PathLike, None] = None,
     check_flow_exist: bool = True,
     default_flow_file: str = FLOW_DAG_YAML,
+    allow_prompty_dir: bool = False,
 ) -> Tuple[Path, str]:
     """Resolve flow path and return the flow directory path and the file name of the target yaml.
 
@@ -82,6 +83,8 @@ def resolve_flow_path(
       If False, the function will return the flow directory path and the file name of the target yaml.
     :param default_flow_file: Default file name used when flow file is not found.
     :type default_flow_file: str
+    :param allow_prompty_dir: If True along with check_flow_exist, the function will allow the flow path to be a
+      directory with no yaml/yml but 1 and only 1 prompty in it.
     :return: The flow directory path and the file name of the target yaml.
     :rtype: Tuple[Path, str]
     """
@@ -107,6 +110,10 @@ def resolve_flow_path(
                 f"Please specify a file or remove the extra YAML file.",
                 privacy_info=[str(flow_path)],
             )
+        elif allow_prompty_dir and check_flow_exist:
+            candidates = list(flow_folder.glob(f"*{PROMPTY_EXTENSION}"))
+            if len(candidates) == 1:
+                flow_file = candidates[0].name
     elif flow_path.is_file() or flow_path.suffix.lower() in FLOW_FILE_SUFFIX:
         flow_folder = flow_path.parent
         flow_file = flow_path.name

--- a/src/promptflow-core/promptflow/_utils/flow_utils.py
+++ b/src/promptflow-core/promptflow/_utils/flow_utils.py
@@ -117,7 +117,8 @@ def resolve_flow_path(
     file_path = flow_folder / flow_file
     if file_path.suffix.lower() not in FLOW_FILE_SUFFIX:
         raise UserErrorException(
-            error_format=f"The flow file suffix must be yaml or yml, and cannot be {file_path.suffix}"
+            message_format="The flow file suffix must be yaml, yml or prompty; cannot be {suffix}",
+            suffix=file_path.suffix,
         )
 
     if not check_flow_exist:

--- a/src/promptflow-core/promptflow/core/_serving/app_base.py
+++ b/src/promptflow-core/promptflow/core/_serving/app_base.py
@@ -5,9 +5,9 @@ import json
 import mimetypes
 import os
 from abc import ABC, abstractmethod
-from pathlib import Path
 from typing import Dict
 
+from promptflow._utils.flow_utils import resolve_flow_path
 from promptflow._utils.logger_utils import LoggerFactory
 from promptflow._utils.user_agent_utils import setup_user_agent_to_operation_context
 from promptflow.core import Flow
@@ -36,7 +36,8 @@ class PromptflowServingAppBasic(ABC):
         # parse promptflow project path
         self.project_path = self.extension.get_flow_project_path()
         logger.info(f"Project path: {self.project_path}")
-        self.flow = init_executable(flow_path=Path(self.project_path))
+        flow_dir, flow_file_name = resolve_flow_path(self.project_path, allow_prompty_dir=True)
+        self.flow = init_executable(flow_path=flow_dir / flow_file_name)
 
         # enable environment_variables
         environment_variables = kwargs.get("environment_variables", {})
@@ -87,8 +88,9 @@ class PromptflowServingAppBasic(ABC):
         if self.flow_invoker:
             return
         self.logger.info("Promptflow executor starts initializing...")
+        flow_dir, flow_file_name = resolve_flow_path(self.project_path, allow_prompty_dir=True)
         self.flow_invoker = AsyncFlowInvoker(
-            flow=Flow.load(source=self.project_path),
+            flow=Flow.load(source=flow_dir / flow_file_name),
             connection_provider=self.connection_provider,
             streaming=self.streaming_response_required,
             raise_ex=False,

--- a/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_utilities/general_utils.py
@@ -1141,16 +1141,16 @@ def resolve_flow_language(
     if flow_path is not None and yaml_dict is not None:
         raise UserErrorException("Only one of flow_path and yaml_dict should be provided.")
     if flow_path is not None:
-        flow_path, flow_file = resolve_flow_path(flow_path, base_path=working_dir, check_flow_exist=False)
+        # flow path must exist
+        flow_path, flow_file = resolve_flow_path(flow_path, base_path=working_dir, check_flow_exist=True)
         file_path = flow_path / flow_file
-        if file_path.is_file() and file_path.suffix.lower() in (".yaml", ".yml"):
+        if file_path.suffix.lower() in (".yaml", ".yml"):
             yaml_dict = load_yaml(file_path)
-        elif file_path.is_file() and file_path.suffix.lower() == PROMPTY_EXTENSION:
+        elif file_path.suffix.lower() == PROMPTY_EXTENSION:
             return FlowLanguage.Python
         else:
-            raise UserErrorException(
-                f"Invalid flow path {file_path.as_posix()}, must exist and of suffix yaml, yml or prompty."
-            )
+            # actually suffix is already checked in resolve_flow_path
+            raise UserErrorException(f"Invalid flow path {file_path.as_posix()}, must of suffix yaml, yml or prompty.")
     return yaml_dict.get(LANGUAGE_KEY, FlowLanguage.Python)
 
 

--- a/src/promptflow-devkit/promptflow/_sdk/_utilities/serve_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_utilities/serve_utils.py
@@ -64,9 +64,12 @@ def start_flow_service(
         "Start promptflow server with port %s",
         port,
     )
-    language = resolve_flow_language(flow_path=source)
 
-    flow_dir, flow_file_name = resolve_flow_path(source)
+    flow_dir, flow_file_name = resolve_flow_path(source, allow_prompty_dir=True)
+    # prompty dir works for resolve_flow_path, but not for resolve_flow_language,
+    # so infer language after resolve_flow_path
+    language = resolve_flow_language(flow_path=flow_dir / flow_file_name)
+
     if language == FlowLanguage.Python:
         if not os.path.isdir(source):
             raise UserErrorException(

--- a/src/promptflow-devkit/tests/sdk_cli_test/conftest.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/conftest.py
@@ -45,6 +45,7 @@ except ImportError:
 
 EAGER_FLOW_ROOT = Path(PROMPTFLOW_ROOT / "tests/test_configs/eager_flows")
 MODEL_ROOT = Path(PROMPTFLOW_ROOT / "tests/test_configs/flows")
+PROMPTY_ROOT = Path(PROMPTFLOW_ROOT / "tests/test_configs/prompty")
 
 RECORDINGS_TEST_CONFIGS_ROOT = Path(PROMPTFLOW_ROOT / "../promptflow-recording/recordings/local").resolve()
 COUNTER_FILE = (Path(__file__) / "../count.json").resolve()
@@ -133,6 +134,20 @@ def setup_experiment_table():
 @pytest.fixture
 def flow_serving_client(mocker: MockerFixture):
     model_path = (Path(MODEL_ROOT) / "basic-with-connection").resolve().absolute().as_posix()
+    mocker.patch.dict(os.environ, {"PROMPTFLOW_PROJECT_PATH": model_path})
+    mocker.patch.dict(os.environ, {"USER_AGENT": "test-user-agent"})
+    app = create_serving_app(environment_variables={"API_TYPE": "${azure_open_ai_connection.api_type}"})
+    app.config.update(
+        {
+            "TESTING": True,
+        }
+    )
+    return app.test_client()
+
+
+@pytest.fixture
+def prompty_serving_client(mocker: MockerFixture):
+    model_path = (Path(PROMPTY_ROOT) / "single_prompty").resolve().absolute().as_posix()
     mocker.patch.dict(os.environ, {"PROMPTFLOW_PROJECT_PATH": model_path})
     mocker.patch.dict(os.environ, {"USER_AGENT": "test-user-agent"})
     app = create_serving_app(environment_variables={"API_TYPE": "${azure_open_ai_connection.api_type}"})

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_serve.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_serve.py
@@ -12,6 +12,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from promptflow._utils.multimedia_utils import OpenaiVisionMultimediaProcessor
 from promptflow.core._serving.constants import FEEDBACK_TRACE_FIELD_NAME
 from promptflow.core._serving.utils import load_feedback_swagger
+from promptflow.recording.record_mode import is_live
 from promptflow.tracing._operation_context import OperationContext
 
 
@@ -452,3 +453,66 @@ def test_async_generator_serving_client(async_generator_serving_client):
     response = async_generator_serving_client.post("/score", data=json.dumps({"count": 10}), headers=headers)
     assert response.status_code == 400
     assert "Flask engine does not support async generator output" in response.data.decode()
+
+
+@pytest.mark.usefixtures("recording_injection", "setup_local_connection")
+@pytest.mark.e2etest
+def test_prompty_serving_api(prompty_serving_client):
+    response = prompty_serving_client.get("/health")
+    assert b"Healthy" in response.data
+    response = prompty_serving_client.get("/")
+    print(response.data)
+    assert response.status_code == 200
+    response = prompty_serving_client.get("/swagger.json")
+    assert (
+        response.status_code == 200
+    ), f"Response code indicates error {response.status_code} - {response.data.decode()}"
+    response = json.loads(response.data.decode())
+    assert response["paths"]["/score"] == {
+        "post": {
+            "requestBody": {
+                "content": {
+                    "application/json": {
+                        "example": {},
+                        "schema": {
+                            "properties": {
+                                "firstName": {"default": "John", "type": "string"},
+                                "lastName": {"default": "Doh", "type": "string"},
+                                "question": {"type": "string"},
+                            },
+                            "required": ["firstName", "lastName", "question"],
+                            # TODO: expected to be "string" but got "object"
+                            #  now it is fully depends on signature of the prompty
+                            #  but will be object when no signature is provided
+                            "type": "object",
+                        },
+                    }
+                },
+                "description": "promptflow input data",
+                "required": True,
+            },
+            "responses": {
+                "200": {
+                    "content": {"application/json": {"schema": {"type": "object"}}},
+                    "description": "successful operation",
+                },
+                "400": {"description": "Invalid input"},
+                "default": {"description": "unexpected error"},
+            },
+            "summary": "run promptflow: single_prompty with an given input",
+        }
+    }
+
+
+@pytest.mark.usefixtures("recording_injection", "setup_local_connection")
+@pytest.mark.e2etest
+@pytest.mark.skipif(not is_live(), reason="llm request involved but no recording found")
+def test_prompty_serving_api_live(prompty_serving_client):
+    response = prompty_serving_client.post(
+        "/score", data=json.dumps({"firstName": "first", "lastName": "last", "question": "hello"})
+    )
+    assert (
+        response.status_code == 200
+    ), f"Response code indicates error {response.status_code} - {response.data.decode()}"
+    response = json.loads(response.data.decode())
+    assert isinstance(response, str)

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_flow_serve_cli.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_flow_serve_cli.py
@@ -9,6 +9,7 @@ from promptflow._cli._pf.entry import main
 
 FLOWS_DIR = Path("./tests/test_configs/flows")
 EAGER_FLOWS_DIR = Path("./tests/test_configs/eager_flows")
+PROMPTY_DIR = Path("./tests/test_configs/prompty")
 
 
 # TODO: move this to a shared utility module
@@ -35,8 +36,9 @@ class TestRun:
     @pytest.mark.parametrize(
         "source",
         [
-            pytest.param(EAGER_FLOWS_DIR / "simple_with_yaml", id="simple_with_yaml_dir"),
-            pytest.param(FLOWS_DIR / "simple_hello_world", id="simple_hello_world_dir"),
+            pytest.param(EAGER_FLOWS_DIR / "simple_with_yaml", id="simple_flex_dir"),
+            pytest.param(FLOWS_DIR / "simple_hello_world", id="simple_dag_dir"),
+            pytest.param(PROMPTY_DIR / "single_prompty", id="simple_prompty_dir"),
         ],
     )
     def test_flow_serve(self, source: Path):

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_utils.py
@@ -43,6 +43,7 @@ from promptflow._sdk._utilities.general_utils import (
     get_system_info,
     refresh_connections_dir,
     resolve_flow_language,
+    resolve_flow_path,
 )
 from promptflow._sdk._version_hint_utils import check_latest_version
 from promptflow._utils.load_data import load_data
@@ -337,6 +338,25 @@ class TestUtils:
             importlib.reload(_constants)
             assert _constants.HOME_PROMPT_FLOW_DIR.as_posix() == (Path.home() / ".promptflow").resolve().as_posix()
         importlib.reload(_constants)
+
+    def test_resolve_flow_path_allow_prompty_dir(self):
+        flow_dir, flow_file_name = resolve_flow_path(
+            "./tests/test_configs/prompty/single_prompty", allow_prompty_dir=True
+        )
+        assert flow_file_name == "prompty_example.prompty"
+
+        flow_dir, flow_file_name = resolve_flow_path(
+            "./tests/test_configs/prompty", allow_prompty_dir=True, check_flow_exist=False
+        )
+        assert flow_file_name == "flow.dag.yaml"
+
+        with pytest.raises(UserErrorException) as ex:
+            resolve_flow_path("./tests/test_configs/prompty", allow_prompty_dir=True)
+        assert "either flow.dag.yaml or flow.flex.yaml" in ex.value.message
+
+        with pytest.raises(UserErrorException) as ex:
+            resolve_flow_path("./tests/test_configs/prompty/single_prompty")
+        assert "either flow.dag.yaml or flow.flex.yaml" in ex.value.message
 
     def test_resolve_flow_language(self):
         # dag flow

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_utils.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_utils.py
@@ -372,8 +372,18 @@ class TestUtils:
         assert "Only one of flow_path and yaml_dict should be provided." in ex.value.message
 
         with pytest.raises(UserErrorException) as ex:
+            resolve_flow_language(
+                flow_path=TEST_ROOT
+                / "test_configs"
+                / "eager_flows"
+                / "basic_callable_class"
+                / "simple_callable_class.py"
+            )
+        assert "suffix must be yaml, yml or prompty" in ex.value.message
+
+        with pytest.raises(UserErrorException) as ex:
             resolve_flow_language(flow_path="mock_path")
-        assert "must exist and of suffix yaml, yml or prompty." in ex.value.message
+        assert "mock_path does not exist." in ex.value.message
 
 
 @pytest.mark.unittest

--- a/src/promptflow/tests/test_configs/prompty/single_prompty/prompty_example.prompty
+++ b/src/promptflow/tests/test_configs/prompty/single_prompty/prompty_example.prompty
@@ -1,0 +1,36 @@
+---
+name: Basic Prompt
+description: A basic prompt that uses the GPT-3 chat API to answer questions
+model:
+    api: chat
+    configuration:
+      type: azure_openai
+      azure_deployment: gpt-35-turbo
+      connection: azure_open_ai_connection
+    parameters:
+      max_tokens: 128
+      temperature: 0.2
+inputs:
+  firstName:
+    type: string
+    default: John
+  lastName:
+    type: string
+    default: Doh
+  question:
+    type: string
+---
+system:
+You are an AI assistant who helps people find information.
+As the assistant, you answer questions briefly, succinctly,
+and in a personable manner using markdown and even add some personal flair with appropriate emojis.
+
+# Safety
+- You **should always** reference factual statements to search results based on [relevant documents]
+- Search results based on [relevant documents] may be incomplete or irrelevant. You do not make assumptions
+# Customer
+You are helping {{firstName}} {{lastName}} to find answers to their questions.
+Use their name to address them in your responses.
+
+user:
+{{question}}


### PR DESCRIPTION
# Description

Support passing a directory without `flow.dag.yaml` nor `flow.flex.yaml` but with 1 and only 1 prompty in it as `source` in `pf flow serve`.

![image](https://github.com/microsoft/promptflow/assets/37076709/b9e67e44-1955-40dc-a417-a5402a1c5aa7)

App support is already done by support prompty in `init_executable`, so this PR is mainly focus on changes in cli.

Note that this is not a full support for prompty in `pf flow serve` as there can usually be multiple prompty in 1 directory. We will need to figure out this in next release.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
