### PR TITLE
[tracing][devkit] Use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` for OTLP endpoint environ

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_tracing.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing.py
@@ -20,7 +20,7 @@ from google.protobuf.json_format import MessageToJson
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
@@ -338,10 +338,10 @@ def _inject_res_attrs_to_environ(
         os.environ[TraceEnvironmentVariableName.RESOURCE_GROUP_NAME] = ws_triad.resource_group_name
         os.environ[TraceEnvironmentVariableName.WORKSPACE_NAME] = ws_triad.workspace_name
     # we will not overwrite the value if it is already set
-    if OTEL_EXPORTER_OTLP_ENDPOINT not in os.environ:
-        otlp_endpoint = f"http://{PF_SERVICE_HOST}:{pfs_port}/v1/traces"
-        _logger.debug("set OTLP endpoint to environ: %s", otlp_endpoint)
-        os.environ[OTEL_EXPORTER_OTLP_ENDPOINT] = otlp_endpoint
+    if OTEL_EXPORTER_OTLP_TRACES_ENDPOINT not in os.environ:
+        otlp_traces_endpoint = f"http://{PF_SERVICE_HOST}:{pfs_port}/v1/traces"
+        _logger.debug("set OTLP traces endpoint to environ: %s", otlp_traces_endpoint)
+        os.environ[OTEL_EXPORTER_OTLP_TRACES_ENDPOINT] = otlp_traces_endpoint
 
 
 def _create_res(
@@ -522,8 +522,8 @@ def setup_exporter_to_pfs() -> None:
         _logger.info("tracer provider is set with resource attributes: %s", res.attributes)
     # set exporter to PFS
     # get OTLP endpoint from environment
-    endpoint = os.getenv(OTEL_EXPORTER_OTLP_ENDPOINT)
-    _logger.debug("environ OTEL_EXPORTER_OTLP_ENDPOINT: %s", endpoint)
+    endpoint = os.getenv(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+    _logger.debug("environ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: %s", endpoint)
     if endpoint is not None:
         # create OTLP span exporter if endpoint is set
         otlp_span_exporter = OTLPSpanExporterWithTraceURL(endpoint=endpoint)

--- a/src/promptflow-tracing/promptflow/tracing/_start_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_start_trace.py
@@ -9,7 +9,7 @@ import os
 import typing
 
 from opentelemetry import trace
-from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT
+from opentelemetry.sdk.environment_variables import OTEL_EXPORTER_OTLP_ENDPOINT, OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 
@@ -115,10 +115,13 @@ def setup_exporter_from_environ() -> None:
     logging.debug("OpenAI API injected.")
 
     # Ignore all the setup if the endpoint is not set
-    endpoint = os.getenv(OTEL_EXPORTER_OTLP_ENDPOINT)
+    otlp_endpoint = os.getenv(OTEL_EXPORTER_OTLP_ENDPOINT)
     logging.debug("environ OTEL_EXPORTER_OTLP_ENDPOINT: %s", endpoint)
+    otlp_traces_endpoint = os.getenv(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+    logging.debug("environ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: %s", otlp_traces_endpoint)
+    endpoint = otlp_traces_endpoint or otlp_endpoint
     if not endpoint:
-        logging.info("environ OTEL_EXPORTER_OTLP_ENDPOINT is not set, will skip the following setup.")
+        logging.info("environ OTLP endpoint is not set, will skip the following setup.")
         return
 
     if _is_devkit_installed():

--- a/src/promptflow-tracing/promptflow/tracing/_start_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_start_trace.py
@@ -116,7 +116,7 @@ def setup_exporter_from_environ() -> None:
 
     # Ignore all the setup if the endpoint is not set
     otlp_endpoint = os.getenv(OTEL_EXPORTER_OTLP_ENDPOINT)
-    logging.debug("environ OTEL_EXPORTER_OTLP_ENDPOINT: %s", endpoint)
+    logging.debug("environ OTEL_EXPORTER_OTLP_ENDPOINT: %s", otlp_endpoint)
     otlp_traces_endpoint = os.getenv(OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
     logging.debug("environ OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: %s", otlp_traces_endpoint)
     endpoint = otlp_traces_endpoint or otlp_endpoint


### PR DESCRIPTION
# Description

`OTEL_EXPORTER_OTLP_ENDPOINT` stands for the collector supports both traces and metrics; prompt flow currently only supports traces collection, so it's more properly to use `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.

However, to prevent breaking change in runtime, for consumer, still check two environs.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
