### PR TITLE
Update token_provider.py to Oauth2.0 scope instead of OAuth 1.0 audience

### DIFF
--- a/src/promptflow-core/promptflow/_core/token_provider.py
+++ b/src/promptflow-core/promptflow/_core/token_provider.py
@@ -4,8 +4,8 @@ from promptflow.exceptions import UserErrorException
 from promptflow._utils.credential_utils import get_default_azure_credential
 
 
-# to access azure ai services, we need to get the token with this audience
-COGNITIVE_AUDIENCE = "https://cognitiveservices.azure.com/"
+# to access azure ai services, we need to get the token with this scope
+COGNITIVE_SCOPE = "https://cognitiveservices.azure.com/.default"
 
 
 class TokenProviderABC(ABC):
@@ -48,5 +48,5 @@ class AzureTokenProvider(TokenProviderABC):
             )
 
     def get_token(self):
-        audience = COGNITIVE_AUDIENCE
-        return self.credential.get_token(audience).token
+        scope = COGNITIVE_SCOPE
+        return self.credential.get_token(scope).token


### PR DESCRIPTION
# Description

Fixes #3243

PromptFlow currently falls back to using DefaultAzureCredential and fetching a token for the Oauth 1.0 audience. That is not compatible with all credentials in the chain, specifically, the AzureDeveloperCliCredential which is Oauth 2.0 only. This PR changes the audience value to the correct scope value, and renames variables accordingly.

I tested with the AzureDeveloperCliCredential and AzureCliCredential flow.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**: I am not sure if this is OAuth 1 only for some reason now, so am not sure if it breaks something I'm unaware of.
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**: Should I update for this?
- [X] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes: This doesn't seem to be tested yet. It would have to be mocked out anyway, so am not sure what would be a good test. Unless your tests run with actual credentials?
