### PR TITLE
[SDK/CLI][Perf] Initialize run uploader simultaneously with run execution

### DIFF
--- a/src/promptflow-azure/promptflow/azure/operations/_async_run_uploader.py
+++ b/src/promptflow-azure/promptflow/azure/operations/_async_run_uploader.py
@@ -17,6 +17,7 @@ from promptflow._sdk._constants import (
     FlowRunProperties,
     Local2Cloud,
     LocalStorageFilenames,
+    RunStatus,
 )
 from promptflow._sdk._errors import RunNotFoundError, UploadInternalError, UploadUserError, UserAuthenticationError
 from promptflow._sdk.entities import Run
@@ -37,9 +38,7 @@ class AsyncRunUploader:
 
     IGNORED_PATTERN = ["__pycache__"]
 
-    def __init__(self, run: Run, run_ops: "RunOperations", overwrite=True):
-        self.run = run
-        self.run_output_path = Path(run.properties[FlowRunProperties.OUTPUT_PATH])
+    def __init__(self, run_ops: "RunOperations", overwrite=True):
         self.run_ops = run_ops
         self.overwrite = overwrite
         self.datastore = self._get_datastore_with_secrets()
@@ -74,24 +73,60 @@ class AsyncRunUploader:
             result[name] = BlobServiceClient(account_url=account_url, credential=credential)
         return result
 
-    def _check_run_exists(self):
-        """Check if run exists in cloud."""
+    def _prepare_run_to_upload(self, run: Run):
+        """Prepare the run to be uploaded."""
+        self.run = self._check_run_is_valid_to_upload(run=run)
+        self.run_output_path = Path(run.properties[FlowRunProperties.OUTPUT_PATH])
+        # check if the run already exists in cloud
+        self._check_run_exists(run=self.run)
+
+    def _check_run_exists(self, run):
+        """Check if the run already exists in cloud."""
         try:
-            self.run_ops.get(self.run.name)
+            self.run_ops.get(run)
         except RunNotFoundError:
             # go ahead to upload if run does not exist
             pass
         else:
-            msg_prefix = f"Run record {self.run.name!r} already exists in cloud"
+            msg_prefix = f"Run record {run.name!r} already exists in cloud"
             if self.overwrite is True:
                 logger.warning(f"{msg_prefix}. Overwrite is set to True, will overwrite existing run record.")
             else:
                 raise UploadUserError(f"{msg_prefix}. Overwrite is set to False, cannot upload the run record.")
 
-    async def upload(self) -> Dict:
+    def _check_run_is_valid_to_upload(self, run):
+        """Check if the run is valid to be uploaded."""
+        from promptflow._sdk._pf_client import PFClient as LocalPFClient
+
+        # always get run object from db, since the passed in run object may not have all latest info
+        pf = LocalPFClient()
+        run = pf.runs.get(run)
+
+        # check if the run is in terminated status
+        terminated_statuses = RunStatus.get_terminated_statuses()
+        if run.status not in terminated_statuses:
+            raise UserErrorException(
+                f"Can only upload the run with status {terminated_statuses!r} "
+                f"while {run.name!r}'s status is {run.status!r}."
+            )
+
+        # check if it's evaluation run and make sure the main run is already uploaded
+        if run.run:
+            main_run_name = run.run.name if isinstance(run.run, Run) else run.run
+            try:
+                self.run_ops.get(main_run_name)
+            except RunNotFoundError:
+                raise UserErrorException(
+                    f"Failed to upload evaluation run {run.name!r} to cloud. It ran against the run {main_run_name!r} "
+                    f"that was not uploaded to cloud. Make sure the previous run is already uploaded to cloud when "
+                    f"uploading an evaluation run."
+                )
+        return run
+
+    async def upload(self, run: Run) -> Dict:
         """Upload run record to cloud."""
-        # check if run already exists in cloud
-        self._check_run_exists()
+        # check if run is ready to be uploaded
+        self._prepare_run_to_upload(run=run)
 
         # upload run details to cloud
         error_msg_prefix = f"Failed to upload run {self.run.name!r}"
@@ -415,16 +450,17 @@ class AsyncRunUploader:
                     raise
 
     @classmethod
-    def _from_run_operations(cls, run: Run, run_ops: "RunOperations"):
-        """Create an instance from run operations."""
+    def _from_run_operations(cls, run_ops: "RunOperations"):
+        """Create an instance from run and run operations."""
         from azure.ai.ml.entities._datastore.azure_storage import AzureBlobDatastore
 
+        # validate the datastore is supported
         datastore = run_ops._workspace_default_datastore
         if isinstance(datastore, AzureBlobDatastore):
-            return cls(run=run, run_ops=run_ops)
+            return cls(run_ops=run_ops)
         else:
             raise UserErrorException(
-                f"Cannot upload run {run.name!r} because the workspace default datastore is not supported. "
+                f"Cannot upload run because the workspace default datastore is not supported. "
                 f"Supported ones are ['AzureBlobDatastore'], got {type(datastore).__name__!r}."
             )
 

--- a/src/promptflow-azure/promptflow/azure/operations/_async_run_uploader.py
+++ b/src/promptflow-azure/promptflow/azure/operations/_async_run_uploader.py
@@ -73,10 +73,15 @@ class AsyncRunUploader:
             result[name] = BlobServiceClient(account_url=account_url, credential=credential)
         return result
 
+    def _set_run(self, run: Run):
+        """Set the run to be uploaded."""
+        self.run = run
+        self.run_output_path = Path(self.run.properties[FlowRunProperties.OUTPUT_PATH])
+
     def _prepare_run_to_upload(self, run: Run):
         """Prepare the run to be uploaded."""
-        self.run = self._check_run_is_valid_to_upload(run=run)
-        self.run_output_path = Path(run.properties[FlowRunProperties.OUTPUT_PATH])
+        run = self._check_run_is_valid_to_upload(run=run)
+        self._set_run(run=run)
         # check if the run already exists in cloud
         self._check_run_exists(run=self.run)
 

--- a/src/promptflow-azure/promptflow/azure/operations/_run_operations.py
+++ b/src/promptflow-azure/promptflow/azure/operations/_run_operations.py
@@ -950,38 +950,18 @@ class RunOperations(WorkspaceTelemetryMixin, _ScopeDependentOperations):
         logger.info(f"Successfully downloaded run {run!r} to {result_path!r}.")
         return result_path
 
-    def _upload(self, run: Union[str, Run]) -> str:
-        from promptflow._sdk._pf_client import PFClient
+    def _upload(self, run: Optional[Union[str, Run]], run_uploader=None) -> str:
         from promptflow.azure.operations._async_run_uploader import AsyncRunUploader
 
-        # always get run object from db, since the passed in run object may not have all latest info
-        pf = PFClient()
-        run = pf.runs.get(run)
-
-        # check if the run is in terminated status
-        terminated_statuses = RunStatus.get_terminated_statuses()
-        if run.status not in terminated_statuses:
-            raise UserErrorException(
-                f"Can only upload the run with status {terminated_statuses!r} "
-                f"while {run.name!r}'s status is {run.status!r}."
-            )
         set_event_loop_policy()
 
-        # check if it's evaluation run and make sure the main run is already uploaded
-        if run.run:
-            main_run_name = run.run.name if isinstance(run.run, Run) else run.run
-            try:
-                self.get(main_run_name)
-            except RunNotFoundError:
-                raise UserErrorException(
-                    f"Failed to upload evaluation run {run.name!r} to cloud. It ran against a run {main_run_name!r} "
-                    f"that was not uploaded to cloud. Make sure the previous run is already uploaded to cloud when "
-                    f"uploading an evaluation run."
-                )
+        # if the run_uploader is not provided, create a new one
+        if run_uploader is None:
+            run_uploader = AsyncRunUploader._from_run_operations(run_ops=self)
 
         # upload local run details to cloud
-        run_uploader = AsyncRunUploader._from_run_operations(run=run, run_ops=self)
-        result_dict = async_run_allowing_running_loop(run_uploader.upload)
+        result_dict = async_run_allowing_running_loop(run_uploader.upload, run=run)
+        run = run_uploader.run
         # patch details about the uploaded run
         run._local_to_cloud_info = result_dict
         logger.debug(f"Successfully uploaded run details of {run.name!r} to cloud.")

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
@@ -70,7 +70,7 @@ class Local2CloudTestHelper:
 
         # check run details are actually uploaded to cloud
         if check_run_details_in_cloud:
-            run_uploader = AsyncRunUploader._from_run_operations(run=run, run_ops=pf.runs)
+            run_uploader = AsyncRunUploader._from_run_operations(run_ops=pf.runs)
             result_dict = async_run_allowing_running_loop(run_uploader._check_run_details_exist_in_cloud)
             for key, value in result_dict.items():
                 assert value is True, f"Run details {key!r} not found in cloud, run name is {run.name!r}"
@@ -274,9 +274,9 @@ class TestFlowRunUpload:
 
     @pytest.mark.skipif(condition=not pytest.is_live, reason="Bug - 3089145 Replay failed for test 'test_upload_run'")
     def test_upload_run_pf_eval_dependencies(
-            self,
-            pf: PFClient,
-            randstr: Callable[[str], str],
+        self,
+        pf: PFClient,
+        randstr: Callable[[str], str],
     ):
         # This test captures promptflow-evals dependencies on private API of promptflow.
         # In case changes are made please reach out to promptflow-evals team to update the dependencies.
@@ -298,10 +298,10 @@ class TestFlowRunUpload:
         # check the run is uploaded to cloud
         Local2CloudTestHelper.check_local_to_cloud_run(pf, run, check_run_details_in_cloud=True)
 
-        from promptflow.azure._dependencies._pf_evals import AsyncRunUploader
         from promptflow._sdk._constants import Local2Cloud
+        from promptflow.azure._dependencies._pf_evals import AsyncRunUploader
 
-        async_uploader = AsyncRunUploader._from_run_operations(run, pf.runs)
+        async_uploader = AsyncRunUploader._from_run_operations(pf.runs)
         instance_results = local_pf.runs.get_details(run, all_results=True)
 
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -310,6 +310,8 @@ class TestFlowRunUpload:
             instance_results.to_json(local_file, orient="records", lines=True)
 
             # overriding instance_results.jsonl file
-            remote_file = (f"{Local2Cloud.BLOB_ROOT_PROMPTFLOW}"
-                           f"/{Local2Cloud.BLOB_ARTIFACTS}/{run.name}/{Local2Cloud.FLOW_INSTANCE_RESULTS_FILE_NAME}")
+            remote_file = (
+                f"{Local2Cloud.BLOB_ROOT_PROMPTFLOW}"
+                f"/{Local2Cloud.BLOB_ARTIFACTS}/{run.name}/{Local2Cloud.FLOW_INSTANCE_RESULTS_FILE_NAME}"
+            )
             async_run_allowing_running_loop(async_uploader._upload_local_file_to_blob, local_file, remote_file)

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
@@ -49,7 +49,7 @@ class Local2CloudTestHelper:
         return local_pf
 
     @staticmethod
-    def check_local_to_cloud_run(pf: PFClient, run: Run, check_run_details_in_cloud: bool = True) -> Run:
+    def check_local_to_cloud_run(pf: PFClient, run: Run, check_run_details_in_cloud: bool = False) -> Run:
         # check if local run is uploaded
         cloud_run = pf.runs.get(run.name)
         assert cloud_run.display_name == run.display_name

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
@@ -49,7 +49,7 @@ class Local2CloudTestHelper:
         return local_pf
 
     @staticmethod
-    def check_local_to_cloud_run(pf: PFClient, run: Run, check_run_details_in_cloud: bool = False) -> Run:
+    def check_local_to_cloud_run(pf: PFClient, run: Run, check_run_details_in_cloud: bool = True) -> Run:
         # check if local run is uploaded
         cloud_run = pf.runs.get(run.name)
         assert cloud_run.display_name == run.display_name
@@ -71,6 +71,7 @@ class Local2CloudTestHelper:
         # check run details are actually uploaded to cloud
         if check_run_details_in_cloud:
             run_uploader = AsyncRunUploader._from_run_operations(run_ops=pf.runs)
+            run_uploader._set_run(run)
             result_dict = async_run_allowing_running_loop(run_uploader._check_run_details_exist_in_cloud)
             for key, value in result_dict.items():
                 assert value is True, f"Run details {key!r} not found in cloud, run name is {run.name!r}"

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
@@ -74,7 +74,7 @@ class Local2CloudTestHelper:
             run_uploader._set_run(run)
             result_dict = async_run_allowing_running_loop(run_uploader._check_run_details_exist_in_cloud)
             for key, value in result_dict.items():
-                assert value is True, f"Run details {key!r} not found in cloud, run name is {run.name!r}"
+                assert value, f"Run details {key!r} not found in cloud, run name is {run.name!r}"
 
         # check run output assets are uploaded to cloud
         original_run_record = pf.runs._get_run_from_run_history(run.name, original_form=True)

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_telemetry.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_telemetry.py
@@ -334,14 +334,14 @@ class TestTelemetry:
                 source=f"{RUNS_DIR}/run_with_env.yaml",
                 params_override=[{"environment_variables": {}}],
             )
-            # create 2 times will get 2 request ids
+            # create 2 times will get 4 request ids, every time contains 2 request ids: create and update
             run.name = str(uuid.uuid4())
             pf.runs.create_or_update(run=run)
             run.name = str(uuid.uuid4())
             pf.runs.create_or_update(run=run)
 
-        # only 1 request id
-        assert len(request_ids) == 2
+        # 4 request id
+        assert len(request_ids) == 4
         # 1 and last call is public call
         assert first_sdk_calls[0] is True
         assert first_sdk_calls[-1] is True

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/unittests/test_run_operations.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/unittests/test_run_operations.py
@@ -151,7 +151,7 @@ class TestRunOperations:
         blob_client.upload_blob.side_effect = HttpResponseError(response=response)
 
         mocker.patch.object(AsyncRunUploader, "_get_datastore_with_secrets")
-        run_uploader = AsyncRunUploader._from_run_operations(run=MagicMock(), run_ops=pf.runs)
+        run_uploader = AsyncRunUploader._from_run_operations(run_ops=pf.runs)
         with pytest.raises(UserAuthenticationError, match="User does not have permission"):
             async_run_allowing_running_loop(run_uploader._upload_single_blob, blob_client, random_data)
 
@@ -164,8 +164,8 @@ class TestRunOperations:
         # test upload run with run exist
         mocker.patch.object(AsyncRunUploader, "_get_datastore_with_secrets")
         mocker.patch.object(pf.runs, "get")
-        run_uploader = AsyncRunUploader._from_run_operations(run=MagicMock(), run_ops=pf.runs)
+        run_uploader = AsyncRunUploader._from_run_operations(run_ops=pf.runs)
         mocker.patch.object(run_uploader, "overwrite", False)
 
         with pytest.raises(UploadUserError, match="cannot upload the run record"):
-            run_uploader._check_run_exists()
+            run_uploader._check_run_exists(run=MagicMock())

--- a/src/promptflow-azure/tests/sdk_cli_azure_test/unittests/test_run_operations.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/unittests/test_run_operations.py
@@ -132,6 +132,8 @@ class TestRunOperations:
         with pytest.raises(UserErrorException, match="workspace default datastore is not supported"):
             pf.runs._upload(run="fake_run_name")
 
+    @pytest.mark.skipif(condition=not pytest.is_live, reason="Subscription not found.")
+    @pytest.mark.usefixtures("mock_isinstance_for_mock_datastore")
     def test_upload_run_with_running_status(self, pf: PFClient):
         # test upload run with running status
         with patch.object(RunOperations, "get") as mock_get:
@@ -152,6 +154,7 @@ class TestRunOperations:
 
         mocker.patch.object(AsyncRunUploader, "_get_datastore_with_secrets")
         run_uploader = AsyncRunUploader._from_run_operations(run_ops=pf.runs)
+        run_uploader._set_run(MagicMock())
         with pytest.raises(UserAuthenticationError, match="User does not have permission"):
             async_run_allowing_running_loop(run_uploader._upload_single_blob, blob_client, random_data)
 

--- a/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
@@ -43,6 +43,7 @@ class RunSubmitter:
         if upload_to_cloud:
             logger.info(f"Upload run to cloud: {upload_to_cloud}")
         with ThreadPoolExecutor() as executor:
+            # if upload to cloud, initialize async run uploader simultaneously with run execution to improve performance
             tasks = [
                 executor.submit(self._run_bulk, run=run, stream=stream, **kwargs),
                 executor.submit(self._initialize_async_run_uploader, run=run, upload_to_cloud=upload_to_cloud),

--- a/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
@@ -4,6 +4,7 @@
 # this file is a middle layer between the local SDK and executor, it'll have some similar logic with cloud PFS.
 
 import datetime
+from concurrent.futures import ALL_COMPLETED, ThreadPoolExecutor, wait
 from pathlib import Path
 from typing import Union
 
@@ -38,7 +39,26 @@ class RunSubmitter:
         self.run_operations = self._client.runs
 
     def submit(self, run: Run, stream=False, **kwargs):
-        self._run_bulk(run=run, stream=stream, **kwargs)
+        upload_to_cloud = self._config._is_cloud_trace_destination(path=run._get_flow_dir().resolve())
+        if upload_to_cloud:
+            logger.info(f"Upload run to cloud: {upload_to_cloud}")
+        with ThreadPoolExecutor() as executor:
+            tasks = [
+                executor.submit(self._run_bulk, run=run, stream=stream, **kwargs),
+                executor.submit(self._initialize_async_run_uploader, run=run, upload_to_cloud=upload_to_cloud),
+            ]
+            wait(tasks, return_when=ALL_COMPLETED)
+            task_results = [task.result() for task in tasks]
+
+        # upload run to cloud if the trace destination is set to cloud
+        if upload_to_cloud:
+            logger.info(f"Uploading run {run.name!r} to cloud...")
+            uploader, pfazure_client = task_results[1]
+            portal_url = pfazure_client.runs._upload(run=run, run_uploader=uploader)
+            logger.info(f"Updating run {run.name!r} portal url to {portal_url!r}.")
+            if portal_url is not None:
+                self.run_operations.update(name=run.name, portal_url=portal_url)
+
         return self.run_operations.get(name=run.name)
 
     def resume(self, resume_from: str, **kwargs):
@@ -228,12 +248,6 @@ class RunSubmitter:
                 system_metrics=system_metrics,
             )
 
-            # upload run to cloud if the trace destination is set to cloud
-            if self._config._is_cloud_trace_destination(path=run._get_flow_dir().resolve()):
-                portal_url = self._upload_run_to_cloud(run=run, config=self._config)
-                if portal_url is not None:
-                    self.run_operations.update(name=run.name, portal_url=portal_url)
-
     def _resolve_input_dirs(self, run: Run):
         result = {"data": run.data if run.data else None}
         if run.run is not None:
@@ -263,24 +277,26 @@ class RunSubmitter:
                 f"current column mapping contains all static values: {column_mapping}"
             )
 
-    @classmethod
-    def _upload_run_to_cloud(cls, run: Run, config=None) -> str:
-        logger.info(f"Uploading run {run.name!r} to cloud...")
-        error_msg_prefix = f"Failed to upload run {run.name!r} to cloud."
-        try:
-            from promptflow._sdk._tracing import _get_ws_triad_from_pf_config
-            from promptflow.azure._cli._utils import _get_azure_pf_client
+    def _initialize_pfazure_client(self, run: Run, config=None):
+        """Initialize pfazure client."""
+        logger.debug("Initialize pfazure client to upload run to cloud...")
+        from promptflow._sdk._tracing import _get_ws_triad_from_pf_config
+        from promptflow.azure._cli._utils import _get_azure_pf_client
 
-            ws_triad = _get_ws_triad_from_pf_config(path=run._get_flow_dir().resolve(), config=config or run._config)
-            pf = _get_azure_pf_client(
-                subscription_id=ws_triad.subscription_id,
-                resource_group=ws_triad.resource_group_name,
-                workspace_name=ws_triad.workspace_name,
-            )
-            return pf.runs._upload(run=run)
-        except ImportError as e:
-            error_message = (
-                f'{error_msg_prefix}. "promptflow[azure]" is required for local to cloud tracing experience, '
-                f'please install it by running "pip install promptflow[azure]". Original error: {str(e)}'
-            )
-            raise UserErrorException(message=error_message) from e
+        ws_triad = _get_ws_triad_from_pf_config(path=run._get_flow_dir().resolve(), config=config or run._config)
+        return _get_azure_pf_client(
+            subscription_id=ws_triad.subscription_id,
+            resource_group=ws_triad.resource_group_name,
+            workspace_name=ws_triad.workspace_name,
+        )
+
+    def _initialize_async_run_uploader(self, run: Run, upload_to_cloud: bool):
+        """Initialize async run uploader if upload_to_cloud is True."""
+        uploader, pfazure_client = None, None
+        if upload_to_cloud:
+            logger.debug(f"Initialize async run uploader for run {run.name!r}...")
+            from promptflow.azure.operations._async_run_uploader import AsyncRunUploader
+
+            pfazure_client = self._initialize_pfazure_client(run=run, config=self._config)
+            uploader = AsyncRunUploader._from_run_operations(run_ops=pfazure_client.runs)
+        return uploader, pfazure_client

--- a/src/promptflow-evals/promptflow/evals/evaluate/_utils.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_utils.py
@@ -1,8 +1,8 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-import logging
 import json
+import logging
 import os
 import re
 import tempfile
@@ -95,18 +95,17 @@ def _get_mlflow_tracking_uri(trace_destination):
 
 def _get_trace_destination_config(tracking_uri):
     from promptflow._sdk._configuration import Configuration
-    pf_config = Configuration(overrides={
-        "trace.destination": tracking_uri
-    } if tracking_uri is not None else {}
-                              )
+
+    pf_config = Configuration(overrides={"trace.destination": tracking_uri} if tracking_uri is not None else {})
 
     trace_destination = pf_config.get_trace_destination()
 
     return trace_destination
 
 
-def _log_metrics_and_instance_results(metrics, instance_results, tracking_uri, run, pf_client, data,
-                                      evaluation_name=None) -> str:
+def _log_metrics_and_instance_results(
+    metrics, instance_results, tracking_uri, run, pf_client, data, evaluation_name=None
+) -> str:
     run_id = None
     trace_destination = _get_trace_destination_config(tracking_uri=tracking_uri)
 
@@ -137,8 +136,9 @@ def _log_metrics_and_instance_results(metrics, instance_results, tracking_uri, r
                     properties={
                         "_azureml.evaluation_run": "azure-ai-generative-parent",
                         "_azureml.evaluate_artifacts": json.dumps([{"path": "eval_results.jsonl", "type": "table"}]),
-                        "isEvaluatorRun": "true"
-                    })
+                        "isEvaluatorRun": "true",
+                    }
+                )
                 run_id = run.info.run_id
     else:
         azure_pf_client = _azure_pf_client(trace_destination=trace_destination)
@@ -148,9 +148,11 @@ def _log_metrics_and_instance_results(metrics, instance_results, tracking_uri, r
             instance_results.to_json(local_file, orient="records", lines=True)
 
             # overriding instance_results.jsonl file
-            async_uploader = AsyncRunUploader._from_run_operations(run, azure_pf_client.runs)
-            remote_file = (f"{Local2Cloud.BLOB_ROOT_PROMPTFLOW}"
-                           f"/{Local2Cloud.BLOB_ARTIFACTS}/{run.name}/{Local2Cloud.FLOW_INSTANCE_RESULTS_FILE_NAME}")
+            async_uploader = AsyncRunUploader._from_run_operations(azure_pf_client.runs)
+            remote_file = (
+                f"{Local2Cloud.BLOB_ROOT_PROMPTFLOW}"
+                f"/{Local2Cloud.BLOB_ARTIFACTS}/{run.name}/{Local2Cloud.FLOW_INSTANCE_RESULTS_FILE_NAME}"
+            )
             async_run_allowing_running_loop(async_uploader._upload_local_file_to_blob, local_file, remote_file)
             run_id = run.name
 
@@ -165,9 +167,11 @@ def _get_ai_studio_url(trace_destination: str, evaluation_id: str) -> str:
     ws_triad = extract_workspace_triad_from_trace_provider(trace_destination)
     studio_base_url = os.getenv("AI_STUDIO_BASE_URL", "https://ai.azure.com")
 
-    studio_url = f"{studio_base_url}/build/evaluation/{evaluation_id}?wsid=/subscriptions/{ws_triad.subscription_id}" \
-                 f"/resourceGroups/{ws_triad.resource_group_name}/providers/Microsoft.MachineLearningServices/" \
-                 f"workspaces/{ws_triad.workspace_name}"
+    studio_url = (
+        f"{studio_base_url}/build/evaluation/{evaluation_id}?wsid=/subscriptions/{ws_triad.subscription_id}"
+        f"/resourceGroups/{ws_triad.resource_group_name}/providers/Microsoft.MachineLearningServices/"
+        f"workspaces/{ws_triad.workspace_name}"
+    )
 
     return studio_url
 
@@ -188,7 +192,7 @@ def _trace_destination_from_project_scope(project_scope: dict) -> str:
 def _write_output(path, data_dict):
     p = Path(path)
     if os.path.isdir(path):
-        p = p/DEFAULT_EVALUATION_RESULTS_FILE_NAME
+        p = p / DEFAULT_EVALUATION_RESULTS_FILE_NAME
 
     with open(p, "w") as f:
         json.dump(data_dict, f)

--- a/src/promptflow-evals/promptflow/evals/evaluate/_utils.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_utils.py
@@ -13,7 +13,7 @@ import mlflow
 
 from promptflow._sdk._constants import Local2Cloud
 from promptflow._utils.async_utils import async_run_allowing_running_loop
-from promptflow.azure.operations._async_run_uploader import AsyncRunUploader
+from promptflow.azure._dependencies._pf_evals import AsyncRunUploader
 from promptflow.evals._constants import DEFAULT_EVALUATION_RESULTS_FILE_NAME
 
 LOGGER = logging.getLogger(__name__)


### PR DESCRIPTION
# Description

![image](https://github.com/microsoft/promptflow/assets/2572521/67a1a210-b2ec-4b9e-a356-8960e99051ff)

Put this uploader initialization part to be executed simutaneously with run execution, therefore reduce 10-17 seconds.


# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
