### PR TITLE
Revert "[Prompty] Check the required parameters in model configuration is configured"

### DIFF
--- a/src/promptflow-core/promptflow/core/_model_configuration.py
+++ b/src/promptflow-core/promptflow/core/_model_configuration.py
@@ -28,11 +28,6 @@ class AzureOpenAIModelConfiguration(ModelConfiguration):
         self._type = ConnectionType.AZURE_OPEN_AI
         if any([self.azure_endpoint, self.api_key, self.api_version]) and self.connection:
             raise InvalidConnectionError("Cannot configure model config and connection at the same time.")
-        if not self.connection and not all([self.azure_endpoint, self.api_key, self.api_version]):
-            raise InvalidConnectionError(
-                "AzureOpenAIModel parameters are incomplete. Please ensure azure_endpoint, "
-                "api_version, and api_key are provided."
-            )
 
     @classmethod
     def from_connection(cls, connection: AzureOpenAIConnection, azure_deployment: str):
@@ -64,8 +59,6 @@ class OpenAIModelConfiguration(ModelConfiguration):
         self._type = ConnectionType.OPEN_AI
         if any([self.base_url, self.api_key, self.organization]) and self.connection:
             raise InvalidConnectionError("Cannot configure model config and connection at the same time.")
-        if not self.connection and not self.base_url:
-            raise InvalidConnectionError("OpenAIModel parameters are incomplete. Please ensure api_key are provided.")
 
     @classmethod
     def from_connection(cls, connection: OpenAIConnection, model: str):

--- a/src/promptflow-core/tests/core/e2etests/test_eager_flow.py
+++ b/src/promptflow-core/tests/core/e2etests/test_eager_flow.py
@@ -101,14 +101,9 @@ class TestEagerFlow:
                 lambda x: x["azure_open_ai_model_config_azure_endpoint"] == "fake_endpoint",
                 {
                     "azure_open_ai_model_config": AzureOpenAIModelConfiguration(
-                        azure_deployment="my_deployment",
-                        azure_endpoint="fake_endpoint",
-                        api_key="fake_api_key",
-                        api_version="fake_api_version",
+                        azure_deployment="my_deployment", azure_endpoint="fake_endpoint"
                     ),
-                    "open_ai_model_config": OpenAIModelConfiguration(
-                        model="my_model", base_url="fake_base_url", api_key="fake_api_key"
-                    ),
+                    "open_ai_model_config": OpenAIModelConfiguration(model="my_model", base_url="fake_base_url"),
                 },
             ),
             (

--- a/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_test.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/e2etests/test_flow_test.py
@@ -499,12 +499,7 @@ class TestFlowTest:
 
     def test_flex_flow_with_model_config(self, pf):
         flow_path = Path(f"{EAGER_FLOWS_DIR}/basic_model_config")
-        config1 = AzureOpenAIModelConfiguration(
-            azure_deployment="my_deployment",
-            azure_endpoint="fake_endpoint",
-            api_version="fake_api_version",
-            api_key="fake_api_key",
-        )
+        config1 = AzureOpenAIModelConfiguration(azure_deployment="my_deployment", azure_endpoint="fake_endpoint")
         config2 = OpenAIModelConfiguration(model="my_model", base_url="fake_base_url")
         result1 = pf.test(
             flow=flow_path,
@@ -540,12 +535,7 @@ class TestFlowTest:
 
     def test_model_config_wrong_connection_type(self, pf):
         flow_path = Path(f"{EAGER_FLOWS_DIR}/basic_model_config")
-        config1 = AzureOpenAIModelConfiguration(
-            azure_deployment="my_deployment",
-            api_key="fake_api_key",
-            api_version="fake_api_verison",
-            azure_endpoint="fake_endpoint",
-        )
+        config1 = AzureOpenAIModelConfiguration(azure_deployment="my_deployment", azure_endpoint="fake_endpoint")
         # using azure open ai connection to initialize open ai model config
         config2 = OpenAIModelConfiguration(model="my_model", connection="azure_open_ai_connection")
         with pytest.raises(FlowEntryInitializationError) as e:

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_prompty.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_prompty.py
@@ -6,36 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
-from promptflow.core import AzureOpenAIModelConfiguration, OpenAIModelConfiguration
-from promptflow.core._errors import InvalidConnectionError
 from promptflow.core._prompty_utils import ChatInputList, Escaper, PromptResult
 
 
-@pytest.mark.sdk_test
-@pytest.mark.unittest
-class TestPrompty:
-    def test_connection_validate(self):
-        with pytest.raises(InvalidConnectionError) as ex:
-            AzureOpenAIModelConfiguration(
-                connection="mock_connection", azure_deployment="mock_deployment", api_key="mock_api_key"
-            )
-        assert "Cannot configure model config and connection at the same time." in ex.value.message
-
-        with pytest.raises(InvalidConnectionError) as ex:
-            AzureOpenAIModelConfiguration(azure_deployment="mock_deployment", api_key="mock_api_key")
-        assert "AzureOpenAIModel parameters are incomplete" in ex.value.message
-
-        with pytest.raises(InvalidConnectionError) as ex:
-            OpenAIModelConfiguration(connection="mock_connection", model="mock_deployment", api_key="mock_api_key")
-        assert "Cannot configure model config and connection at the same time." in ex.value.message
-
-        with pytest.raises(InvalidConnectionError) as ex:
-            OpenAIModelConfiguration(model="mock_deployment", api_key="mock_api_key")
-        assert "OpenAIModel parameters are incomplete" in ex.value.message
-
-
-@pytest.mark.sdk_test
-@pytest.mark.unittest
 class TestEscaper:
     @pytest.mark.parametrize(
         "value, escaped_dict, expected_val",

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_prompty.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_prompty.py
@@ -9,6 +9,8 @@ import pytest
 from promptflow.core._prompty_utils import ChatInputList, Escaper, PromptResult
 
 
+@pytest.mark.sdk_test
+@pytest.mark.unittest
 class TestEscaper:
     @pytest.mark.parametrize(
         "value, escaped_dict, expected_val",


### PR DESCRIPTION
Reverts microsoft/promptflow#3261
When create aoai or openai clinet, api_key, api_version and base_url will be get from env if not set.