### PR TITLE
only pass user parameter when it is not empty for chat api

### DIFF
--- a/src/promptflow-tools/promptflow/tools/aoai.py
+++ b/src/promptflow-tools/promptflow/tools/aoai.py
@@ -136,7 +136,6 @@ class AzureOpenAI(ToolProvider):
             "top_p": top_p,
             "n": n,
             "stream": stream,
-            "user": user,
             "extra_headers": {"ms-azure-ai-promptflow-called-from": "aoai-tool"}
         }
 
@@ -167,6 +166,8 @@ class AzureOpenAI(ToolProvider):
             params["presence_penalty"] = presence_penalty
         if frequency_penalty is not None:
             params["frequency_penalty"] = frequency_penalty
+        if user:
+            params["user"] = user
 
         completion = self._client.chat.completions.create(**params)
         return post_process_chat_api_response(completion, stream, functions, tools)

--- a/src/promptflow-tools/promptflow/tools/openai.py
+++ b/src/promptflow-tools/promptflow/tools/openai.py
@@ -121,7 +121,6 @@ class OpenAI(ToolProvider):
             "temperature": temperature,
             "top_p": top_p,
             "stream": stream,
-            "user": user,
         }
 
         # functions and function_call are deprecated and are replaced by tools and tool_choice.
@@ -152,6 +151,8 @@ class OpenAI(ToolProvider):
             params["presence_penalty"] = presence_penalty
         if frequency_penalty is not None:
             params["frequency_penalty"] = frequency_penalty
+        if user:
+            params["user"] = user
 
         completion = self._client.chat.completions.create(**params)
         return post_process_chat_api_response(completion, stream, functions, tools)


### PR DESCRIPTION
only pass user parameter when it is not empty for chat api

Test against below package:
--extra-index-url https://azuremlsdktestpypi.azureedge.net/test-promptflow/
promptflow_tools==0.0.430