### PR TITLE
Ignore aggregation node for trace telemetry.

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_utilities/tracing_utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_utilities/tracing_utils.py
@@ -307,6 +307,9 @@ def aggregate_trace_count(all_spans: typing.List[Span]) -> typing.Dict[TraceCoun
 
     # Iterate over all spans
     for span in all_spans:
+        if span.attributes.get(SpanAttributeFieldName.IS_AGGREGATION, False):
+            # Ignore aggregation span, because it does not represent a line execution.
+            continue
         # Only count for root span, ignore span count telemetry for now.
         if span.parent_id is None:
             resource_attributes = span.resource.get(SpanResourceFieldName.ATTRIBUTES, {})


### PR DESCRIPTION
# Description

Ignore aggregate node for trace telemetry.
For aggregate node trace, it doesn't have parent span, line run id or batch run id.
So, will be wrongly marked as script execution.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
