### PR TITLE
Fixing timezone issue with local to cloud run

### DIFF
--- a/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
+++ b/src/promptflow-azure/tests/sdk_cli_azure_test/e2etests/test_run_upload.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 from typing import Callable
 from unittest.mock import patch
+from datetime import datetime
 
 import pytest
 from _constants import PROMPTFLOW_ROOT
@@ -56,6 +57,7 @@ class Local2CloudTestHelper:
         assert cloud_run.display_name == run.display_name
         assert cloud_run.status == run.status
         assert cloud_run._start_time and cloud_run._end_time
+        assert datetime.fromisoformat(cloud_run.created_on) == datetime.fromisoformat(run.created_on)
         assert cloud_run.properties["azureml.promptflow.local_to_cloud"] == "true"
         assert cloud_run.properties["azureml.promptflow.snapshot_id"]
         assert cloud_run.properties[Local2CloudProperties.EVAL_ARTIFACTS]

--- a/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_orchestrator/run_submitter.py
@@ -168,7 +168,7 @@ class RunSubmitter:
         exception = None
         # create run to db when fully prepared to run in executor, otherwise won't create it
         run._status = Status.Running.value
-        run._start_time = datetime.datetime.now()
+        run._start_time = datetime.datetime.now().astimezone()
         run._dump()  # pylint: disable=protected-access
 
         resume_from_run_storage = (
@@ -245,7 +245,7 @@ class RunSubmitter:
             run = self.run_operations.update(
                 name=run.name,
                 status=status,
-                end_time=datetime.datetime.now(),
+                end_time=datetime.datetime.now().astimezone(),
                 system_metrics=system_metrics,
             )
 

--- a/src/promptflow-devkit/promptflow/_sdk/entities/_run.py
+++ b/src/promptflow-devkit/promptflow/_sdk/entities/_run.py
@@ -155,7 +155,7 @@ class Run(YAMLTranslatableMixin):
         self.variant = variant
         self.run = run
         self._resume_from = kwargs.get("resume_from", None)
-        self._created_on = created_on or datetime.datetime.now()
+        self._created_on = created_on or datetime.datetime.now().astimezone()
         self._status = status or RunStatus.NOT_STARTED
         self.environment_variables = environment_variables or {}
         self.connections = connections or {}
@@ -756,8 +756,8 @@ class Run(YAMLTranslatableMixin):
         # when sending the request to the server.
         # e.g. WARNING:msrest.serialization:Datetime with no tzinfo will be considered UTC.
         # for start_time, switch to "_start_time" once the bug item is fixed: BUG - 3085432.
-        start_time = self._created_on.isoformat() + "Z" if self._created_on else None
-        end_time = self._end_time.isoformat() + "Z" if self._end_time else None
+        start_time = self._created_on.isoformat() if self._created_on else None
+        end_time = self._end_time.isoformat() if self._end_time else None
 
         # extract properties that needs to be passed to the request
         properties = {


### PR DESCRIPTION
# Description

Local to cloud tracking has incorrect creation time as shown in screenshot below. This PR fixes this issue.
![image](https://github.com/microsoft/promptflow/assets/30610298/753f6240-5f0d-43e0-af86-8dfc7c2343c3)

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
