### PR TITLE
Allow whitespace in accuracy grade evaluation

### DIFF
--- a/examples/flows/evaluation/eval-classification-accuracy/grade.py
+++ b/examples/flows/evaluation/eval-classification-accuracy/grade.py
@@ -3,4 +3,4 @@ from promptflow.core import tool
 
 @tool
 def grade(groundtruth: str, prediction: str):
-    return "Correct" if groundtruth.lower() == prediction.lower() else "Incorrect"
+    return "Correct" if groundtruth.replace(" ", "").lower() == prediction.replace(" ", "").lower() else "Incorrect"

--- a/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/expected_metrics.json
+++ b/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/expected_metrics.json
@@ -1,1 +1,1 @@
-{"accuracy": 0.67}
+{"accuracy": 0.75}

--- a/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/expected_status_summary.json
+++ b/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/expected_status_summary.json
@@ -1,5 +1,5 @@
 {
-    "grade.completed": 3,
+    "grade.completed": 4,
     "calculate_accuracy.completed": 1,
     "aggregation_assert.completed": 1
 }

--- a/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/grade.py
+++ b/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/grade.py
@@ -5,4 +5,4 @@ from promptflow.core import tool
 def grade(groundtruth: str, prediction: str):
     groundtruth = groundtruth.lower().strip('"')
     prediction = prediction.lower().strip('"')
-    return "Correct" if groundtruth == prediction else "Incorrect"
+    return "Correct" if groundtruth.replace(" ", "").lower() == prediction.replace(" ", "").lower() else "Incorrect"

--- a/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/samples.json
+++ b/src/promptflow/tests/test_configs/flows/classification_accuracy_evaluation/samples.json
@@ -16,5 +16,11 @@
     "variant_id": "variant_0",
     "groundtruth": "App",
     "prediction": "Pdf"
+  },
+  {
+    "line_number": 3,
+    "variant_id": "variant_0",
+    "groundtruth": "dogs, cats, birds",
+    "prediction": "dogs,cats,birds"
   }
 ]


### PR DESCRIPTION
# Description
In testing, I noticed accuracy was marked incorrectly when evaluating in the portal. An example of this is below
![image](https://github.com/microsoft/promptflow/assets/4297028/7c8b7449-b8b0-4576-8850-39ae43649826)

This change allows white spaces to not be considered when grading accuracy. If white space is needed, coherency evaluations will grade it correctly.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
