### PR TITLE
Add deployment name to notebooks

### DIFF
--- a/examples/flex-flows/basic/flex-flow-quickstart.ipynb
+++ b/examples/flex-flows/basic/flex-flow-quickstart.ipynb
@@ -141,7 +141,7 @@
     "# call the flow entry function\n",
     "from programmer import write_simple_program\n",
     "\n",
-    "result = write_simple_program(\"Java Hello, world!\")\n",
+    "result = write_simple_program(\"Java Hello, world!\", deployment_name=deployment_name)\n",
     "result"
    ]
   },

--- a/examples/flex-flows/eval-criteria-with-langchain/eval_conciseness.py
+++ b/examples/flex-flows/eval-criteria-with-langchain/eval_conciseness.py
@@ -16,7 +16,7 @@ class Result:
 
 
 class LangChainEvaluator:
-    def __init__(self, custom_connection: CustomConnection):
+    def __init__(self, custom_connection: CustomConnection, deployment_name: str):
         self.custom_connection = custom_connection
 
         # create llm according to the secrets in custom connection
@@ -27,7 +27,7 @@ class LangChainEvaluator:
             )
         elif "openai_api_key" in self.custom_connection.secrets:
             self.llm = AzureChatOpenAI(
-                deployment_name="gpt-35-turbo",
+                deployment_name=deployment_name,
                 openai_api_key=self.custom_connection.secrets["openai_api_key"],
                 azure_endpoint=self.custom_connection.configs["azure_endpoint"],
                 openai_api_type="azure",

--- a/examples/flex-flows/eval-criteria-with-langchain/langchain-eval.ipynb
+++ b/examples/flex-flows/eval-criteria-with-langchain/langchain-eval.ipynb
@@ -100,6 +100,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Deployment name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "deployment_name = \"gpt-35-turbo\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Test the evaluator with trace"
    ]
   },
@@ -141,6 +157,7 @@
     "    # reference custom connection by name\n",
     "    init={\n",
     "        \"custom_connection\": \"my_llm_connection\",\n",
+    "        \"deployment_name\": deployment_name,\n",
     "    },\n",
     "    data=data,\n",
     "    column_mapping={\n",

--- a/examples/flex-flows/eval-criteria-with-langchain/langchain-eval.ipynb
+++ b/examples/flex-flows/eval-criteria-with-langchain/langchain-eval.ipynb
@@ -128,7 +128,7 @@
     "from eval_conciseness import LangChainEvaluator\n",
     "\n",
     "\n",
-    "evaluator = LangChainEvaluator(custom_connection=conn)\n",
+    "evaluator = LangChainEvaluator(custom_connection=conn, deployment_name=deployment_name)\n",
     "result = evaluator(\n",
     "    prediction=\"What's 2+2? That's an elementary question. The answer you're looking for is that two and two is four.\",\n",
     "    input=\"What's 2+2?\",\n",

--- a/examples/flex-flows/eval-criteria-with-langchain/requirements.txt
+++ b/examples/flex-flows/eval-criteria-with-langchain/requirements.txt
@@ -1,3 +1,4 @@
 promptflow
 langchain>=0.1.5
+langchain_community>=0.1.5
 python-dotenv


### PR DESCRIPTION
# Description

Several notebooks do not pass `deployment_name` explicitly and therefore breaks if the user chooses a `deployment_name` other than what is used in the code being called. (eg. call to `my_llm_tool` passes the `deployment_name` but call to `write_simple_program` does not)

This PR, passes the `deployment_name` explicitly for two notebooks and has minor code changes for that.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
