### PR TITLE
[azure][bugfix] Fix Azure replay test wrong sanitizations

### DIFF
--- a/.github/workflows/sdk-cli-azure-test-production.yml
+++ b/.github/workflows/sdk-cli-azure-test-production.yml
@@ -27,6 +27,7 @@ env:
   IS_IN_CI_PIPELINE: "true"
   PROMPT_FLOW_TEST_MODE: "live"
   PROMPT_FLOW_WORKSPACE_NAME: "promptflow-eastus"
+  PROMPT_FLOW_TEST_PACKAGE: "promptflow-azure"
   TRACING_DIRECTORY: ${{ github.workspace }}/src/promptflow-tracing
   CORE_DIRECTORY: ${{ github.workspace }}/src/promptflow-core
   DEVKIT_DIRECTORY: ${{ github.workspace }}/src/promptflow-devkit

--- a/.github/workflows/sdk-cli-azure-test-production.yml
+++ b/.github/workflows/sdk-cli-azure-test-production.yml
@@ -27,7 +27,6 @@ env:
   IS_IN_CI_PIPELINE: "true"
   PROMPT_FLOW_TEST_MODE: "live"
   PROMPT_FLOW_WORKSPACE_NAME: "promptflow-eastus"
-  PROMPT_FLOW_TEST_PACKAGE: "promptflow-azure"
   TRACING_DIRECTORY: ${{ github.workspace }}/src/promptflow-tracing
   CORE_DIRECTORY: ${{ github.workspace }}/src/promptflow-core
   DEVKIT_DIRECTORY: ${{ github.workspace }}/src/promptflow-devkit

--- a/.github/workflows/sdk-cli-azure-test-pull-request.yml
+++ b/.github/workflows/sdk-cli-azure-test-pull-request.yml
@@ -18,6 +18,7 @@ on:
 env:
   IS_IN_CI_PIPELINE: "true"
   PROMPT_FLOW_TEST_MODE: "replay"
+  PROMPT_FLOW_TEST_PACKAGE: "promptflow-azure"
   TRACING_DIRECTORY: ${{ github.workspace }}/src/promptflow-tracing
   WORKING_DIRECTORY: ${{ github.workspace }}/src/promptflow-azure
   CORE_DIRECTORY: ${{ github.workspace }}/src/promptflow-core

--- a/.github/workflows/sdk-cli-azure-test-pull-request.yml
+++ b/.github/workflows/sdk-cli-azure-test-pull-request.yml
@@ -13,6 +13,7 @@ on:
       - src/promptflow-core/**
       - src/promptflow-devkit/**
       - src/promptflow-azure/**
+      - src/promptflow-recording/**
 
 
 env:

--- a/src/promptflow-azure/tests/conftest.py
+++ b/src/promptflow-azure/tests/conftest.py
@@ -19,6 +19,11 @@ load_dotenv()
 _connection_setup = False
 
 
+@pytest.fixture(autouse=True)
+def declare_test_package(monkeypatch: MonkeyPatch):
+    monkeypatch.setenv("PROMPT_FLOW_TEST_PACKAGE", "promptflow-azure")
+
+
 @pytest.fixture
 def local_client() -> LocalClient:
     yield LocalClient()

--- a/src/promptflow-recording/promptflow/recording/azure/constants.py
+++ b/src/promptflow-recording/promptflow/recording/azure/constants.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------
 
 ENVIRON_TEST_MODE = "PROMPT_FLOW_TEST_MODE"
+ENVIRON_TEST_PACKAGE = "PROMPT_FLOW_TEST_PACKAGE"
 
 
 FILTER_HEADERS = [
@@ -72,9 +73,15 @@ class SanitizedValues:
     RUN_ID = "evals_e2etests_target_fn_wqo0_peh_20240606_102622_386974"
     # Fake Application insights event
     FAKE_APP_INSIGHTS = [
-        {"ver": 1, "name": "Microsoft.ApplicationInsights.Event",
-         "time": "2024-06-06T23:20:59.838896Z", "sampleRate": 100.0,
-         "iKey": UUID, "tags": {"foo": "bar"}}]
+        {
+            "ver": 1,
+            "name": "Microsoft.ApplicationInsights.Event",
+            "time": "2024-06-06T23:20:59.838896Z",
+            "sampleRate": 100.0,
+            "iKey": UUID,
+            "tags": {"foo": "bar"},
+        }
+    ]
 
 
 class AzureMLResourceTypes:

--- a/src/promptflow-recording/promptflow/recording/azure/utils.py
+++ b/src/promptflow-recording/promptflow/recording/azure/utils.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------
 
 import json
+import os
 import re
 from dataclasses import dataclass
 from typing import Dict
@@ -11,7 +12,7 @@ import jwt
 from azure.core.credentials import AccessToken
 from vcr.request import Request
 
-from .constants import SanitizedValues
+from .constants import ENVIRON_TEST_PACKAGE, SanitizedValues
 
 
 class FakeTokenCredential:
@@ -200,6 +201,11 @@ def sanitize_pfs_request_body(body: str) -> str:
     # PFS will help handle this field, so client does not need to pass this value
     if "runExperimentName" in body:
         body_dict["runExperimentName"] = ""
+
+    # promptflow-azure replay test does not require below sanitizations
+    if os.getenv(ENVIRON_TEST_PACKAGE) == "promptflow-azure":
+        return json.dumps(body_dict)
+
     # Start and end time
     if "start_time" in body_dict:
         body_dict["start_time"] = SanitizedValues.START_TIME


### PR DESCRIPTION
# Description

#3390 introduces some sanitizations, which breaks `promptflow-azure` replay test. This PR targets to add an environment variable to distinguish `promptflow-azure` and `promptflow-evals`.

Besides, make `promptflow-azure` replay test listen on pf-recording code path to avoid such breaking.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
