### PR TITLE
[devkit][bugfix] Add check for `trace.NoOpTracerProvider` to avoid crash

### DIFF
--- a/src/promptflow-devkit/CHANGELOG.md
+++ b/src/promptflow-devkit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # promptflow-devkit package
 
+## v1.13.0 (Upcoming)
+
+### Bugs Fixed
+- Fix incompatibility with `trace.NoOpTracerProvider` when set exporter to prompt flow service.
+
 ## v1.12.0 (2024.06.11)
 
 ### Improvements

--- a/src/promptflow-devkit/promptflow/_sdk/_tracing.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_tracing.py
@@ -550,6 +550,10 @@ def setup_exporter_to_pfs() -> None:
         tracer_provider: TracerProvider = trace.get_tracer_provider()
         if is_exporter_setup_skipped():
             _logger.debug("exporter setup is skipped according to environment variable.")
+        elif isinstance(tracer_provider, trace.NoOpTracerProvider):
+            _logger.warning(
+                "tracer provider is set to NoOpTracerProvider, skip setting exporter to prompt flow service."
+            )
         else:
             if not getattr(tracer_provider, TRACER_PROVIDER_PFS_EXPORTER_SET_ATTR, False):
                 _logger.info("have not set exporter to prompt flow service, will set it...")

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Release History
+
+## v1.13.0 (Upcoming)
+
+### Bugs Fixed
+- Fix incompatibility with `trace.NoOpTracerProvider` when set exporter to prompt flow service.
+
 ## v1.12.0 (2024.06.11)
 
 ### Bugs fixed


### PR DESCRIPTION
# Description

In some cases (we have observed in runtime scenario, related to mlflow), tracer provider can be set as `trace.NoOpTracerProvider`, which does not have method `add_span_processor` and lead to error. This PR adds a check on that to avoid such crash.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
