### PR TITLE
[Internal] Fix tool ci by skipping acs test since the test resource is not valid

### DIFF
--- a/src/promptflow-tools/tests/test_acs.py
+++ b/src/promptflow-tools/tests/test_acs.py
@@ -3,6 +3,7 @@ import pytest
 from promptflow.tools.azure_content_safety import analyze_text
 
 
+@pytest.mark.skip("Skipping - Key based authentication is disabled for this resource")
 @pytest.mark.usefixtures("use_secrets_config_file")
 class TestAzureContentSafety:
     def test_azure_content_safety_analyze_happy_path(self, azure_content_safety_connection):


### PR DESCRIPTION
# Description

Failed tool ci: https://github.com/microsoft/promptflow/actions/runs/9542727564/job/26298045963
```
FAILED src/promptflow-tools/tests/test_acs.py::TestAzureContentSafety::test_azure_content_safety_analyze_happy_path - promptflow.tools.exception.AzureContentSafetySystemError: Error in detecting content: Key based authentication is disabled for this resource.
```

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
