### PR TITLE
[docs]fix invalid option of `pf flow validate`

### DIFF
--- a/docs/cloud/azureai/use-flow-in-azure-ml-pipeline.md
+++ b/docs/cloud/azureai/use-flow-in-azure-ml-pipeline.md
@@ -13,7 +13,7 @@ To enable this feature, customer need to:
     2. `run.yaml`: `$schema`: `https://azuremlschemas.azureedge.net/promptflow/latest/Run.schema.json`
 3. ensure that metadata has been generated and is up-to-date:
     1. `<my-flow-directory>/.promptflow/flow.tools.json` should exist;
-    2. customer may update the file via `pf flow validate --file <my-flow-directory>`.
+    2. customer may update the file via `pf flow validate --source <my-flow-directory>`.
 
 :::
 

--- a/examples/tutorials/run-flow-with-pipeline/pipeline.ipynb
+++ b/examples/tutorials/run-flow-with-pipeline/pipeline.ipynb
@@ -120,7 +120,7 @@
     "\n",
     "> __REMARK:__ To use `load_component` function with flow.dag.yaml, please ensure the following:</br>\n",
     "> - The `$schema` should be defined in target DAG yaml file. For example: `$schema: https://azuremlschemas.azureedge.net/promptflow/latest/Flow.schema.json`.</br>\n",
-    "> - Flow metadata must be generated and kept up-to-date by verifying the file '<my-flow-directory>/.promptflow/flow.tools.json'. If it doesn't exist, run the following command to generate and update it: `pf flow validate --file <my-flow-directory>`."
+    "> - Flow metadata must be generated and kept up-to-date by verifying the file '<my-flow-directory>/.promptflow/flow.tools.json'. If it doesn't exist, run the following command to generate and update it: `pf flow validate --source <my-flow-directory>`."
    ]
   },
   {


### PR DESCRIPTION
# Description

`pf flow validate` don't have `file` option. The correct option is `source` , right?

```bash
% pf flow validate -h
usage: pf flow validate [-h] --source SOURCE [--verbose] [-d]

Validate a flow and generate flow.tools.json for the flow.

options:
  -h, --help       show this help message and exit
  --source SOURCE  The flow or run source to be used.
  --verbose        Increase logging verbosity. Use --debug for full debug logs.
  -d, --debug      The flag to turn on debug mode for cli.

Examples:

# Validate flow
pf flow validate --source <path_to_flow>
```

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
