### PR TITLE
[fundamental] Touch result file for fork repository

### DIFF
--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -44,7 +44,7 @@ steps:
         Get-Location
         Get-ChildItem -Name
         Get-Content "result.tsv"
-    }
+      }
   displayName: 'Workaround for fork repository'
 
 - task: PowerShell@2

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -37,7 +37,8 @@ steps:
     targetType: inline
     script: |
       if (-Not (Test-Path "$(sourceLocation)/scripts/compliance-check/result.tsv")) {
-        Write-Host "Creating empty result file, as this might be a fork repository."
+        Write-Host "PoliCheck@2 (previous step) is not supported for forked GitHub repository, which will break the following step."
+        Write-Host "So as a workaround, this step will create an empty result.tsv file."
         New-Item -ItemType Directory -Force -Path "$(sourceLocation)/scripts/compliance-check"
         Set-Location "$(sourceLocation)/scripts/compliance-check"
         New-Item -ItemType File -Name "result.tsv"

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -32,7 +32,7 @@ steps:
     result: '$(sourceLocation)\scripts\compliance-check\result.tsv'
     optionsXCLASS: 'Geopolitical'
 
-- task: PowerShell@2
+- task: Bash@3
   inputs:
     targetType: inline
     script: |

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -41,9 +41,6 @@ steps:
         New-Item -ItemType Directory -Force -Path "$(sourceLocation)/scripts/compliance-check"
         Set-Location "$(sourceLocation)/scripts/compliance-check"
         New-Item -ItemType File -Name "result.tsv" -Value "<PoliCheckExclusions>`r`n</PoliCheckExclusions>"
-        Get-Location
-        Get-ChildItem -Name
-        Get-Content "result.tsv"
       }
   displayName: 'Workaround for fork repository'
 

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -32,6 +32,16 @@ steps:
     result: '$(sourceLocation)\scripts\compliance-check\result.tsv'
     optionsXCLASS: 'Geopolitical'
 
+- task: Bash@3
+  inputs:
+    targetType: inline
+    script: |
+      if [ ! -f $(sourceLocation)/scripts/compliance-check/result.tsv ]; then
+        echo "Creating empty result file, as this might be a fork repository."
+        touch $(sourceLocation)/scripts/compliance-check/result.tsv
+      fi
+  displayName: 'Workaround for fork repository'
+
 - task: PowerShell@2
   inputs:
     targetType: 'filePath'

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -32,21 +32,19 @@ steps:
     result: '$(sourceLocation)\scripts\compliance-check\result.tsv'
     optionsXCLASS: 'Geopolitical'
 
-- task: Bash@3
+- task: PowerShell@2
   inputs:
     targetType: inline
     script: |
-      if [ ! -f $(sourceLocation)/scripts/compliance-check/result.tsv ]; then
-        echo "Creating empty result file, as this might be a fork repository."
-        mkdir -p $(sourceLocation)/scripts/compliance-check
-        cd $(sourceLocation)/scripts/compliance-check
-        touch result.tsv
-        echo "<PoliCheckExclusions>" > result.tsv
-        echo "</PoliCheckExclusions>" >> result.tsv
-        pwd
-        ls -l
-        cat result.tsv
-      fi
+      if (-Not (Test-Path "$(sourceLocation)/scripts/compliance-check/result.tsv")) {
+        Write-Host "Creating empty result file, as this might be a fork repository."
+        New-Item -ItemType Directory -Force -Path "$(sourceLocation)/scripts/compliance-check"
+        Set-Location "$(sourceLocation)/scripts/compliance-check"
+        New-Item -ItemType File -Name "result.tsv" -Value "<PoliCheckExclusions>`r`n</PoliCheckExclusions>"
+        Get-Location
+        Get-ChildItem -Name
+        Get-Content "result.tsv"
+    }
   displayName: 'Workaround for fork repository'
 
 - task: PowerShell@2

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -32,7 +32,7 @@ steps:
     result: '$(sourceLocation)\scripts\compliance-check\result.tsv'
     optionsXCLASS: 'Geopolitical'
 
-- task: Bash@3
+- task: PowerShell@2
   inputs:
     targetType: inline
     script: |
@@ -41,8 +41,11 @@ steps:
         mkdir -p $(sourceLocation)/scripts/compliance-check
         cd $(sourceLocation)/scripts/compliance-check
         touch result.tsv
+        echo "<PoliCheckExclusions>" > result.tsv
+        echo "</PoliCheckExclusions>" >> result.tsv
         pwd
         ls -l
+        cat result.tsv
       fi
   displayName: 'Workaround for fork repository'
 

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -40,7 +40,7 @@ steps:
         Write-Host "Creating empty result file, as this might be a fork repository."
         New-Item -ItemType Directory -Force -Path "$(sourceLocation)/scripts/compliance-check"
         Set-Location "$(sourceLocation)/scripts/compliance-check"
-        New-Item -ItemType File -Name "result.tsv" -Value "<PoliCheckExclusions>`r`n</PoliCheckExclusions>"
+        New-Item -ItemType File -Name "result.tsv"
       }
   displayName: 'Workaround for fork repository'
 

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -38,6 +38,7 @@ steps:
     script: |
       if [ ! -f $(sourceLocation)/scripts/compliance-check/result.tsv ]; then
         echo "Creating empty result file, as this might be a fork repository."
+        mkdir -p $(sourceLocation)/scripts/compliance-check
         touch $(sourceLocation)/scripts/compliance-check/result.tsv
       fi
   displayName: 'Workaround for fork repository'

--- a/.github/pipelines/compliance_check.yml
+++ b/.github/pipelines/compliance_check.yml
@@ -39,7 +39,10 @@ steps:
       if [ ! -f $(sourceLocation)/scripts/compliance-check/result.tsv ]; then
         echo "Creating empty result file, as this might be a fork repository."
         mkdir -p $(sourceLocation)/scripts/compliance-check
-        touch $(sourceLocation)/scripts/compliance-check/result.tsv
+        cd $(sourceLocation)/scripts/compliance-check
+        touch result.tsv
+        pwd
+        ls -l
       fi
   displayName: 'Workaround for fork repository'
 


### PR DESCRIPTION
# Description

CI "Compliance Check" starts to fail recently (one example: #3478 ); the root cause is that the PoliCheck does not support fork repository, so the step that generates result tsv will be skipped, resulting in the following step that will consume the tsv file break.

This PR targets to fix this issue by checking the tsv file first, and create an empty one if the file does not exist; then the following step will regard everything is fine and goes on as before.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
