### PR TITLE
Make evaluation run a context manager instead of a singleton.

### DIFF
--- a/src/promptflow-evals/promptflow/evals/evaluate/_eval_run.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_eval_run.py
@@ -313,7 +313,7 @@ class EvalRun(contextlib.AbstractContextManager):
         """
         Check that the run is in the correct state and log worning if it is not.
 
-        :param action: Action, whcih caused this check. For example if it is "log artifact",
+        :param action: Action, which caused this check. For example if it is "log artifact",
                        the log message will start "Unable to log artifact."
         :type action: str
         :return: boolean saying if run is in the correct state.

--- a/src/promptflow-evals/tests/evals/e2etests/test_metrics_upload.py
+++ b/src/promptflow-evals/tests/evals/e2etests/test_metrics_upload.py
@@ -66,7 +66,7 @@ class TestMetricsUpload(object):
     @pytest.mark.usefixtures("vcr_recording")
     def test_writing_to_run_history(self, setup_data, caplog):
         """Test logging data to RunHistory service."""
-        logger = logging.getLogger(ev_utils.__name__)
+        logger = logging.getLogger(EvalRun.__module__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
         # as a parent. This logger does not propagate the logs and cannot be
         # captured by caplog. Here we will skip this logger to capture logs.
@@ -74,12 +74,13 @@ class TestMetricsUpload(object):
         # Just for sanity check let us make sure that the logging actually works
         mock_response = MagicMock()
         mock_response.status_code = 418
+        ev_run = EvalRun.get_instance()
         with patch("promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry", return_value=mock_response):
-            ev_utils._write_properties_to_run_history({"test": 42})
+            ev_run.write_properties_to_run_history({"test": 42})
             assert any(lg_rec.levelno == logging.ERROR for lg_rec in caplog.records), "The error log was not captured!"
         caplog.clear()
-        ev_utils._write_properties_to_run_history({"test": 42})
-        self._assert_no_errors_for_module(caplog.records, [ev_utils.__name__])
+        ev_run.write_properties_to_run_history({"test": 42})
+        self._assert_no_errors_for_module(caplog.records, [EvalRun.__module__])
 
     @pytest.mark.usefixtures("vcr_recording")
     def test_logging_metrics(self, setup_data, caplog):
@@ -159,7 +160,7 @@ class TestMetricsUpload(object):
             evaluators={"f1": f1_score_eval},
             azure_ai_project=project_scope,
         )
-        self._assert_no_errors_for_module(caplog.records, (ev_utils.__name__, EvalRun.__module__))
+        self._assert_no_errors_for_module(caplog.records, (EvalRun.__name__, EvalRun.__module__))
 
     @pytest.mark.skip(reason="Test runs individually but not when run with entire suite.")
     @pytest.mark.usefixtures("vcr_recording")

--- a/src/promptflow-evals/tests/evals/e2etests/test_metrics_upload.py
+++ b/src/promptflow-evals/tests/evals/e2etests/test_metrics_upload.py
@@ -33,18 +33,8 @@ def questions_file():
 
 
 @pytest.fixture
-def setup_data(azure_ml_client, project_scope):
-    tracking_uri = azure_ml_client.workspaces.get(project_scope["project_name"]).mlflow_tracking_uri
-    run = EvalRun(
-        run_name='test',
-        tracking_uri=tracking_uri,
-        subscription_id=project_scope["subscription_id"],
-        group_name=project_scope["resource_group_name"],
-        workspace_name=project_scope["project_name"],
-        ml_client=azure_ml_client
-    )
-    yield
-    run.end_run("FINISHED")
+def tracking_uri(azure_ml_client, project_scope):
+    return azure_ml_client.workspaces.get(project_scope["project_name"]).mlflow_tracking_uri
 
 
 @pytest.mark.usefixtures("model_config", "recording_injection", "project_scope")
@@ -64,7 +54,7 @@ class TestMetricsUpload(object):
             assert not error_messages, "\n".join(error_messages)
 
     @pytest.mark.usefixtures("vcr_recording")
-    def test_writing_to_run_history(self, setup_data, caplog):
+    def test_writing_to_run_history(self, caplog, project_scope, azure_ml_client, tracking_uri):
         """Test logging data to RunHistory service."""
         logger = logging.getLogger(EvalRun.__module__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
@@ -74,55 +64,77 @@ class TestMetricsUpload(object):
         # Just for sanity check let us make sure that the logging actually works
         mock_response = MagicMock()
         mock_response.status_code = 418
-        ev_run = EvalRun.get_instance()
-        with patch("promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry", return_value=mock_response):
+        with EvalRun(
+            run_name='test',
+            tracking_uri=tracking_uri,
+            subscription_id=project_scope["subscription_id"],
+            group_name=project_scope["resource_group_name"],
+            workspace_name=project_scope["project_name"],
+            ml_client=azure_ml_client
+        ) as ev_run:
+            with patch("promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry", return_value=mock_response):
+                ev_run.write_properties_to_run_history({"test": 42})
+                assert any(
+                    lg_rec.levelno == logging.ERROR for lg_rec in caplog.records), "The error log was not captured!"
+            caplog.clear()
             ev_run.write_properties_to_run_history({"test": 42})
-            assert any(lg_rec.levelno == logging.ERROR for lg_rec in caplog.records), "The error log was not captured!"
-        caplog.clear()
-        ev_run.write_properties_to_run_history({"test": 42})
         self._assert_no_errors_for_module(caplog.records, [EvalRun.__module__])
 
     @pytest.mark.usefixtures("vcr_recording")
-    def test_logging_metrics(self, setup_data, caplog):
+    def test_logging_metrics(self, caplog, project_scope, azure_ml_client, tracking_uri):
         """Test logging metrics."""
         logger = logging.getLogger(EvalRun.__module__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
         # as a parent. This logger does not propagate the logs and cannot be
         # captured by caplog. Here we will skip this logger to capture logs.
         logger.parent = logging.root
-        ev_run = EvalRun.get_instance()
-        mock_response = MagicMock()
-        mock_response.status_code = 418
-        with patch("promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry", return_value=mock_response):
+        with EvalRun(
+            run_name='test',
+            tracking_uri=tracking_uri,
+            subscription_id=project_scope["subscription_id"],
+            group_name=project_scope["resource_group_name"],
+            workspace_name=project_scope["project_name"],
+            ml_client=azure_ml_client
+        ) as ev_run:
+            mock_response = MagicMock()
+            mock_response.status_code = 418
+            with patch("promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry", return_value=mock_response):
+                ev_run.log_metric("f1", 0.54)
+                assert any(
+                    lg_rec.levelno == logging.WARNING for lg_rec in caplog.records), "The error log was not captured!"
+            caplog.clear()
             ev_run.log_metric("f1", 0.54)
-            assert any(
-                lg_rec.levelno == logging.WARNING for lg_rec in caplog.records), "The error log was not captured!"
-        caplog.clear()
-        ev_run.log_metric("f1", 0.54)
         self._assert_no_errors_for_module(caplog.records, EvalRun.__module__)
 
     @pytest.mark.usefixtures("vcr_recording")
-    def test_log_artifact(self, setup_data, caplog, tmp_path):
+    def test_log_artifact(self, project_scope, azure_ml_client, tracking_uri, caplog, tmp_path):
         """Test uploading artifact to the service."""
         logger = logging.getLogger(EvalRun.__module__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
         # as a parent. This logger does not propagate the logs and cannot be
         # captured by caplog. Here we will skip this logger to capture logs.
         logger.parent = logging.root
-        ev_run = EvalRun.get_instance()
-        mock_response = MagicMock()
-        mock_response.status_code = 418
-        with open(os.path.join(tmp_path, EvalRun.EVALUATION_ARTIFACT), 'w') as fp:
-            json.dump({'f1': 0.5}, fp)
-        os.makedirs(os.path.join(tmp_path, 'internal_dir'), exist_ok=True)
-        with open(os.path.join(tmp_path, 'internal_dir', 'test.json'), 'w') as fp:
-            json.dump({'internal_f1': 0.6}, fp)
-        with patch('promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry', return_value=mock_response):
+        with EvalRun(
+            run_name='test',
+            tracking_uri=tracking_uri,
+            subscription_id=project_scope["subscription_id"],
+            group_name=project_scope["resource_group_name"],
+            workspace_name=project_scope["project_name"],
+            ml_client=azure_ml_client
+        ) as ev_run:
+            mock_response = MagicMock()
+            mock_response.status_code = 418
+            with open(os.path.join(tmp_path, EvalRun.EVALUATION_ARTIFACT), 'w') as fp:
+                json.dump({'f1': 0.5}, fp)
+            os.makedirs(os.path.join(tmp_path, 'internal_dir'), exist_ok=True)
+            with open(os.path.join(tmp_path, 'internal_dir', 'test.json'), 'w') as fp:
+                json.dump({'internal_f1': 0.6}, fp)
+            with patch('promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry', return_value=mock_response):
+                ev_run.log_artifact(tmp_path)
+                assert any(
+                    lg_rec.levelno == logging.WARNING for lg_rec in caplog.records), "The error log was not captured!"
+            caplog.clear()
             ev_run.log_artifact(tmp_path)
-            assert any(
-                lg_rec.levelno == logging.WARNING for lg_rec in caplog.records), "The error log was not captured!"
-        caplog.clear()
-        ev_run.log_artifact(tmp_path)
         self._assert_no_errors_for_module(caplog.records, EvalRun.__module__)
 
     @pytest.mark.skip(reason="Test runs individually but not when run with entire suite.")
@@ -160,7 +172,7 @@ class TestMetricsUpload(object):
             evaluators={"f1": f1_score_eval},
             azure_ai_project=project_scope,
         )
-        self._assert_no_errors_for_module(caplog.records, (EvalRun.__name__, EvalRun.__module__))
+        self._assert_no_errors_for_module(caplog.records, (ev_utils.__name__, EvalRun.__module__))
 
     @pytest.mark.skip(reason="Test runs individually but not when run with entire suite.")
     @pytest.mark.usefixtures("vcr_recording")

--- a/src/promptflow-evals/tests/evals/unittests/test_eval_run.py
+++ b/src/promptflow-evals/tests/evals/unittests/test_eval_run.py
@@ -10,14 +10,7 @@ import pytest
 
 import promptflow.evals.evaluate._utils as ev_utils
 from promptflow.azure._utils._token_cache import ArmTokenCache
-from promptflow.evals.evaluate._eval_run import EvalRun, Singleton, RunStatus
-
-
-@pytest.fixture
-def setup_data():
-    """Make sure, we will destroy the EvalRun instance as it is singleton."""
-    yield
-    Singleton._instances.clear()
+from promptflow.evals.evaluate._eval_run import EvalRun, RunStatus
 
 
 def generate_mock_token():
@@ -30,57 +23,59 @@ def generate_mock_token():
 class TestEvalRun:
     """Unit tests for the eval-run object."""
 
+    def _get_mock_create_resonse(self, status=200):
+        """Return the mock create request"""
+        mock_response = MagicMock()
+        mock_response.status_code = status
+        if status != 200:
+            mock_response.text = "Mock error"
+        else:
+            mock_response.json.return_value = {
+                "run": {
+                    "info": {
+                        "run_id": str(uuid4()),
+                        "experiment_id": str(uuid4()),
+                        "run_name": str(uuid4())
+                    }
+                }
+            }
+        return mock_response
+
+    def _get_mock_end_response(self, status=200):
+        """Get the mock end run response."""
+        mock_response = MagicMock()
+        mock_response.status_code = status
+        mock_response.text = 'Everything good' if status == 200 else 'Everything bad'
+        return mock_response
+
     @pytest.mark.parametrize(
         "status,should_raise", [("KILLED", False), ("WRONG_STATUS", True), ("FINISHED", False), ("FAILED", False)]
     )
-    def test_end_raises(self, token_mock, setup_data, status, should_raise, caplog):
+    def test_end_raises(self, token_mock, status, should_raise, caplog):
         """Test that end run raises exception if incorrect status is set."""
         mock_session = MagicMock()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
-        mock_session.request.return_value = mock_response
+        mock_session.request.return_value = self._get_mock_create_resonse()
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
-            run = EvalRun(
+            with EvalRun(
                 run_name=None,
                 tracking_uri="www.microsoft.com",
                 subscription_id="mock",
                 group_name="mock",
                 workspace_name="mock",
                 ml_client=MagicMock(),
-            )
-            run.start_run()
-            if should_raise:
-                with pytest.raises(ValueError) as cm:
+            ) as run:
+                if should_raise:
+                    with pytest.raises(ValueError) as cm:
+                        run.end_run(status)
+                    assert status in cm.value.args[0]
+                else:
                     run.end_run(status)
-                assert status in cm.value.args[0]
-            else:
-                run.end_run(status)
-                assert len(caplog.records) == 0
+                    assert len(caplog.records) == 0
 
-    def test_run_logs_if_terminated(self, token_mock, setup_data, caplog):
+    def test_run_logs_if_terminated(self, token_mock, caplog):
         """Test that run warn user if we are trying to terminate it twice."""
         mock_session = MagicMock()
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
-        mock_session.request.return_value = mock_response
+        mock_session.request.return_value = self._get_mock_create_resonse()
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
             logger = logging.getLogger(EvalRun.__module__)
             # All loggers, having promptflow. prefix will have "promptflow" logger
@@ -101,43 +96,30 @@ class TestEvalRun:
             assert len(caplog.records) == 1
             assert "Unable to stop run because it was already terminated." in caplog.records[0].message
 
-    def test_end_logs_if_fails(self, token_mock, setup_data, caplog):
+    def test_end_logs_if_fails(self, token_mock, caplog):
         """Test that if the terminal status setting was failed, it is logged."""
         mock_session = MagicMock()
-        mock_response_start = MagicMock()
-        mock_response_start.status_code = 200
-        mock_response_start.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
-        mock_response_end = MagicMock()
-        mock_response_end.status_code = 500
-        mock_session.request.side_effect = [mock_response_start, mock_response_end]
+        mock_session.request.side_effect = [self._get_mock_create_resonse(),
+                                            self._get_mock_end_response(500)]
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
             logger = logging.getLogger(EvalRun.__module__)
             # All loggers, having promptflow. prefix will have "promptflow" logger
             # as a parent. This logger does not propagate the logs and cannot be
             # captured by caplog. Here we will skip this logger to capture logs.
             logger.parent = logging.root
-            run = EvalRun(
+            with EvalRun(
                 run_name=None,
                 tracking_uri="www.microsoft.com",
                 subscription_id="mock",
                 group_name="mock",
                 workspace_name="mock",
                 ml_client=MagicMock(),
-            )
-            run.start_run()
-            run.end_run("FINISHED")
+            ):
+                pass
             assert len(caplog.records) == 1
             assert "Unable to terminate the run." in caplog.records[0].message
 
-    def test_start_run_fails(self, token_mock, setup_data, caplog):
+    def test_start_run_fails(self, token_mock, caplog):
         """Test that there are log messges if run was not started."""
         mock_session = MagicMock()
         mock_response_start = MagicMock()
@@ -180,116 +162,44 @@ class TestEvalRun:
             assert "Unable to stop run because the run failed to start." in caplog.records[0].message
             caplog.clear()
 
-    @pytest.mark.parametrize("destroy_run,runs_are_the_same", [(False, True), (True, False)])
     @patch("promptflow.evals.evaluate._eval_run.requests.Session")
-    def test_singleton(self, mock_session_cls, token_mock, setup_data, destroy_run, runs_are_the_same):
-        """Test that the EvalRun is actually a singleton."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.side_effect = [
-            {
-                "run": {
-                    "info": {
-                        "run_id": str(uuid4()),
-                        "experiment_id": str(uuid4()),
-                        "run_name": str(uuid4())
-                    }
-                }
-            },
-            {
-                "run": {
-                    "info": {
-                        "run_id": str(uuid4()),
-                        "experiment_id": str(uuid4()),
-                        "run_name": str(uuid4())
-                    }
-                }
-            },
-        ]
-        mock_session = MagicMock()
-        mock_session.request.return_value = mock_response
-        mock_session_cls.return_value = mock_session
-        run = EvalRun(
-            run_name="run",
-            tracking_uri="www.microsoft.com",
-            subscription_id="mock",
-            group_name="mock",
-            workspace_name="mock",
-            ml_client=MagicMock(),
-        )
-        id1 = id(run)
-        run.start_run()
-        if destroy_run:
-            run.end_run("FINISHED")
-        id2 = id(
-            EvalRun(
-                run_name="run",
-                tracking_uri="www.microsoft.com",
-                subscription_id="mock",
-                group_name="mock",
-                workspace_name="mock",
-                ml_client=MagicMock(),
-            )
-        )
-        assert (id1 == id2) == runs_are_the_same
-
-    @patch("promptflow.evals.evaluate._eval_run.requests.Session")
-    def test_run_name(self, mock_session_cls, token_mock, setup_data):
+    def test_run_name(self, mock_session_cls, token_mock):
         """Test that the run name is the same as ID if name is not given."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
         mock_session = MagicMock()
+        mock_response = self._get_mock_create_resonse()
         mock_session.request.return_value = mock_response
         mock_session_cls.return_value = mock_session
-        run = EvalRun(
+        with EvalRun(
             run_name=None,
             tracking_uri="www.microsoft.com",
             subscription_id="mock",
             group_name="mock",
             workspace_name="mock",
             ml_client=MagicMock(),
-        )
-        run.start_run()
+        ) as run:
+            pass
         assert run.info.run_id == mock_response.json.return_value['run']['info']['run_id']
         assert run.info.experiment_id == mock_response.json.return_value[
             'run']['info']['experiment_id']
         assert run.info.run_name == mock_response.json.return_value['run']['info']["run_name"]
 
     @patch("promptflow.evals.evaluate._eval_run.requests.Session")
-    def test_run_with_name(self, mock_session_cls, token_mock, setup_data):
+    def test_run_with_name(self, mock_session_cls, token_mock):
         """Test that the run name is not the same as id if it is given."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": 'test'
-                }
-            }
-        }
+        mock_response = self._get_mock_create_resonse()
+        mock_response.json.return_value['run']['info']['run_name'] = 'test'
         mock_session = MagicMock()
         mock_session.request.return_value = mock_response
         mock_session_cls.return_value = mock_session
-        run = EvalRun(
+        with EvalRun(
             run_name="test",
             tracking_uri="www.microsoft.com",
             subscription_id="mock",
             group_name="mock",
             workspace_name="mock",
             ml_client=MagicMock(),
-        )
-        run.start_run()
+        ) as run:
+            pass
         assert run.info.run_id == mock_response.json.return_value['run']['info']['run_id']
         assert run.info.experiment_id == mock_response.json.return_value[
             'run']['info']['experiment_id']
@@ -297,23 +207,13 @@ class TestEvalRun:
         assert run.info.run_name != run.info.run_id
 
     @patch("promptflow.evals.evaluate._eval_run.requests.Session")
-    def test_get_urls(self, mock_session_cls, token_mock, setup_data):
+    def test_get_urls(self, mock_session_cls, token_mock):
         """Test getting url-s from eval run."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
+        mock_response = self._get_mock_create_resonse()
         mock_session = MagicMock()
         mock_session.request.return_value = mock_response
         mock_session_cls.return_value = mock_session
-        run = EvalRun(
+        with EvalRun(
             run_name="test",
             tracking_uri=(
                 "https://region.api.azureml.ms/mlflow/v2.0/subscriptions"
@@ -325,8 +225,8 @@ class TestEvalRun:
             group_name="mock-rg-region",
             workspace_name="mock-ws-region",
             ml_client=MagicMock(),
-        )
-        run.start_run()
+        ) as run:
+            pass
         assert run.get_run_history_uri() == (
             "https://region.api.azureml.ms/history/v1.0/subscriptions"
             "/000000-0000-0000-0000-0000000/resourceGroups/mock-rg-region"
@@ -356,30 +256,27 @@ class TestEvalRun:
             ('log_metric', 'save metrics')
         ]
     )
-    def test_log_artifacts_logs_error(self, token_mock, setup_data, tmp_path, caplog, log_function, expected_str):
+    def test_log_artifacts_logs_error(self, token_mock, tmp_path, caplog, log_function, expected_str):
         """Test that the error is logged."""
         mock_session = MagicMock()
-        mock_create_response = MagicMock()
-        mock_create_response.status_code = 200
-        mock_create_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
         mock_response = MagicMock()
         mock_response.status_code = 404
         mock_response.text = "Mock not found error."
-
         if log_function == "log_artifact":
             with open(os.path.join(tmp_path, "test.json"), "w") as fp:
                 json.dump({"f1": 0.5}, fp)
-        mock_session.request.side_effect = [mock_create_response, mock_response]
+        mock_session.request.side_effect = [
+            self._get_mock_create_resonse(),
+            mock_response,
+            self._get_mock_end_response()
+        ]
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
-            run = EvalRun(
+            logger = logging.getLogger(EvalRun.__module__)
+            # All loggers, having promptflow. prefix will have "promptflow" logger
+            # as a parent. This logger does not propagate the logs and cannot be
+            # captured by caplog. Here we will skip this logger to capture logs.
+            logger.parent = logging.root
+            with EvalRun(
                 run_name="test",
                 tracking_uri=(
                     "https://region.api.azureml.ms/mlflow/v2.0/subscriptions"
@@ -391,23 +288,16 @@ class TestEvalRun:
                 group_name="mock-rg-region",
                 workspace_name="mock-ws-region",
                 ml_client=MagicMock(),
-            )
-            run.start_run()
-
-            logger = logging.getLogger(EvalRun.__module__)
-            # All loggers, having promptflow. prefix will have "promptflow" logger
-            # as a parent. This logger does not propagate the logs and cannot be
-            # captured by caplog. Here we will skip this logger to capture logs.
-            logger.parent = logging.root
-            fn = getattr(run, log_function)
-            if log_function == 'log_artifact':
-                with open(os.path.join(tmp_path, EvalRun.EVALUATION_ARTIFACT), 'w') as fp:
-                    fp.write('42')
-                kwargs = {'artifact_folder': tmp_path}
-            else:
-                kwargs = {'key': 'f1', 'value': 0.5}
-            with patch('promptflow.evals.evaluate._eval_run.BlobServiceClient', return_value=MagicMock()):
-                fn(**kwargs)
+            ) as run:
+                fn = getattr(run, log_function)
+                if log_function == 'log_artifact':
+                    with open(os.path.join(tmp_path, EvalRun.EVALUATION_ARTIFACT), 'w') as fp:
+                        fp.write('42')
+                    kwargs = {'artifact_folder': tmp_path}
+                else:
+                    kwargs = {'key': 'f1', 'value': 0.5}
+                with patch('promptflow.evals.evaluate._eval_run.BlobServiceClient', return_value=MagicMock()):
+                    fn(**kwargs)
         assert len(caplog.records) == 1
         assert mock_response.text in caplog.records[0].message
         assert "404" in caplog.records[0].message
@@ -421,30 +311,19 @@ class TestEvalRun:
         ]
     )
     def test_wrong_artifact_path(
-            self,
-            token_mock,
-            tmp_path,
-            caplog,
-            dir_exists,
-            dir_empty,
-            expected_error,
-            setup_data):
+        self,
+        token_mock,
+        tmp_path,
+        caplog,
+        dir_exists,
+        dir_empty,
+        expected_error,
+    ):
         """Test that if artifact path is empty, or dies not exist we are logging the error."""
-        mock_response = MagicMock()
-        mock_response.status_code = 200
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
         mock_session = MagicMock()
-        mock_session.request.return_value = mock_response
+        mock_session.request.return_value = self._get_mock_create_resonse()
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
-            run = EvalRun(
+            with EvalRun(
                 run_name="test",
                 tracking_uri=(
                     "https://region.api.azureml.ms/mlflow/v2.0/subscriptions"
@@ -456,22 +335,21 @@ class TestEvalRun:
                 group_name="mock-rg-region",
                 workspace_name="mock-ws-region",
                 ml_client=MagicMock(),
-            )
-            run.start_run()
-            logger = logging.getLogger(EvalRun.__module__)
-            # All loggers, having promptflow. prefix will have "promptflow" logger
-            # as a parent. This logger does not propagate the logs and cannot be
-            # captured by caplog. Here we will skip this logger to capture logs.
-            logger.parent = logging.root
-            artifact_folder = tmp_path if dir_exists else "wrong_path_567"
-            if not dir_empty:
-                with open(os.path.join(tmp_path, "test.txt"), 'w') as fp:
-                    fp.write("42")
-            run.log_artifact(artifact_folder)
+            ) as run:
+                logger = logging.getLogger(EvalRun.__module__)
+                # All loggers, having promptflow. prefix will have "promptflow" logger
+                # as a parent. This logger does not propagate the logs and cannot be
+                # captured by caplog. Here we will skip this logger to capture logs.
+                logger.parent = logging.root
+                artifact_folder = tmp_path if dir_exists else "wrong_path_567"
+                if not dir_empty:
+                    with open(os.path.join(tmp_path, "test.txt"), 'w') as fp:
+                        fp.write("42")
+                run.log_artifact(artifact_folder)
             assert len(caplog.records) == 1
             assert expected_error in caplog.records[0].message
 
-    def test_log_metrics_and_instance_results_logs_error(self, token_mock, caplog, setup_data):
+    def test_log_metrics_and_instance_results_logs_error(self, token_mock, caplog):
         """Test that we are logging the error when there is no trace destination."""
         logger = logging.getLogger(ev_utils.__name__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
@@ -488,29 +366,28 @@ class TestEvalRun:
         assert len(caplog.records) == 1
         assert "Unable to log traces as trace destination was not defined." in caplog.records[0].message
 
-    def test_run_broken_if_no_tracking_uri(self, token_mock, setup_data, caplog):
+    def test_run_broken_if_no_tracking_uri(self, token_mock, caplog):
         """Test that if no tracking URI is provirded, the run is being marked as broken."""
         logger = logging.getLogger(ev_utils.__name__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
         # as a parent. This logger does not propagate the logs and cannot be
         # captured by caplog. Here we will skip this logger to capture logs.
         logger.parent = logging.root
-        run = EvalRun(
+        with EvalRun(
             run_name=None,
             tracking_uri=None,
             subscription_id='mock',
             group_name='mock',
             workspace_name='mock',
             ml_client=MagicMock()
-        )
-        run.start_run()
-        assert len(caplog.records) == 1
-        assert "The results will be saved locally, but will not be logged to Azure." in caplog.records[0].message
-        with patch('promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry') as mock_request:
-            run.log_artifact('mock_dir')
-            run.log_metric('foo', 42)
-            run.write_properties_to_run_history({'foo': 'bar'})
-        mock_request.assert_not_called()
+        ) as run:
+            assert len(caplog.records) == 1
+            assert "The results will be saved locally, but will not be logged to Azure." in caplog.records[0].message
+            with patch('promptflow.evals.evaluate._eval_run.EvalRun.request_with_retry') as mock_request:
+                run.log_artifact('mock_dir')
+                run.log_metric('foo', 42)
+                run.write_properties_to_run_history({'foo': 'bar'})
+            mock_request.assert_not_called()
 
     @pytest.mark.parametrize('status_code,pf_run', [
         (401, False),
@@ -518,26 +395,15 @@ class TestEvalRun:
         (401, True),
         (200, True),
     ])
-    def test_lifecycle(self, token_mock, status_code, pf_run, setup_data):
+    def test_lifecycle(self, token_mock, status_code, pf_run):
         """Test the run statuses throughout its life cycle."""
         pf_run_mock = None
         if pf_run:
             pf_run_mock = MagicMock()
             pf_run_mock.name = 'mock_pf_run'
             pf_run_mock._experiment_name = 'mock_pf_experiment'
-        mock_response = MagicMock()
-        mock_response.status_code = status_code
-        mock_response.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
         mock_session = MagicMock()
-        mock_session.request.return_value = mock_response
+        mock_session.request.return_value = self._get_mock_create_resonse(status_code)
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
             run = EvalRun(
                 run_name="test",
@@ -565,7 +431,7 @@ class TestEvalRun:
             else:
                 assert run.status == RunStatus.BROKEN, f'Get {run.status}, expected {RunStatus.BROKEN}'
 
-    def test_local_lifecycle(self, token_mock, setup_data):
+    def test_local_lifecycle(self, token_mock):
         """Test that the local run have correct statuses."""
         run = EvalRun(
             run_name=None,
@@ -582,27 +448,19 @@ class TestEvalRun:
         assert run.status == RunStatus.BROKEN, f'Get {run.status}, expected {RunStatus.BROKEN}'
 
     @pytest.mark.parametrize('status_code', [200, 401])
-    def test_write_properties(self, token_mock, setup_data, caplog, status_code):
+    def test_write_properties(self, token_mock, caplog, status_code):
         """Test writing properties to the evaluate run."""
-        mock_start = MagicMock()
-        mock_start.status_code = 200
-        mock_start.text = 'Mock error'
-        mock_start.json.return_value = {
-            "run": {
-                "info": {
-                    "run_id": str(uuid4()),
-                    "experiment_id": str(uuid4()),
-                    "run_name": str(uuid4())
-                }
-            }
-        }
         mock_write = MagicMock()
         mock_write.status_code = status_code
         mock_write.text = 'Mock error'
         mock_session = MagicMock()
-        mock_session.request.side_effect = [mock_start, mock_write]
+        mock_session.request.side_effect = [
+            self._get_mock_create_resonse(),
+            mock_write,
+            self._get_mock_end_response()
+        ]
         with patch("promptflow.evals.evaluate._eval_run.requests.Session", return_value=mock_session):
-            run = EvalRun(
+            with EvalRun(
                 run_name="test",
                 tracking_uri=(
                     "https://region.api.azureml.ms/mlflow/v2.0/subscriptions"
@@ -614,9 +472,8 @@ class TestEvalRun:
                 group_name="mock-rg-region",
                 workspace_name="mock-ws-region",
                 ml_client=MagicMock(),
-            )
-            run.start_run()
-            run.write_properties_to_run_history({'foo': 'bar'})
+            ) as run:
+                run.write_properties_to_run_history({'foo': 'bar'})
         if status_code != 200:
             assert len(caplog.records) == 1
             assert 'Fail writing properties' in caplog.records[0].message
@@ -624,25 +481,26 @@ class TestEvalRun:
         else:
             assert len(caplog.records) == 0
 
-    def test_write_properties_to_run_history_logs_error(self, token_mock, caplog, setup_data):
+    def test_write_properties_to_run_history_logs_error(self, token_mock, caplog):
         """Test that we are logging the error when there is no trace destination."""
         logger = logging.getLogger(EvalRun.__module__)
         # All loggers, having promptflow. prefix will have "promptflow" logger
         # as a parent. This logger does not propagate the logs and cannot be
         # captured by caplog. Here we will skip this logger to capture logs.
         logger.parent = logging.root
-        run = EvalRun(
+        with EvalRun(
             run_name=None,
             tracking_uri=None,
             subscription_id='mock',
             group_name='mock',
             workspace_name='mock',
             ml_client=MagicMock()
-        )
-        run.start_run()
-        run.write_properties_to_run_history({'foo': 'bar'})
-        assert len(caplog.records) == 2
+        ) as run:
+            run.write_properties_to_run_history({'foo': 'bar'})
+        assert len(caplog.records) == 3
+        assert "tracking_uri was not provided," in caplog.records[0].message
         assert "Unable to write properties because the run failed to start." in caplog.records[1].message
+        assert "Unable to stop run because the run failed to start." in caplog.records[2].message
 
     @pytest.mark.parametrize(
         'function_literal,args',
@@ -652,7 +510,7 @@ class TestEvalRun:
             ('log_artifact', ('mock_folder',))
         ]
     )
-    def test_raises_if_not_started(self, token_mock, setup_data, function_literal, args):
+    def test_raises_if_not_started(self, token_mock, function_literal, args):
         """Test that all public functions are raising exception if run is not started."""
         run = EvalRun(
             run_name=None,

--- a/src/promptflow-evals/tests/evals/unittests/test_eval_run.py
+++ b/src/promptflow-evals/tests/evals/unittests/test_eval_run.py
@@ -66,10 +66,10 @@ class TestEvalRun:
             ) as run:
                 if should_raise:
                     with pytest.raises(ValueError) as cm:
-                        run.end_run(status)
+                        run._end_run(status)
                     assert status in cm.value.args[0]
                 else:
-                    run.end_run(status)
+                    run._end_run(status)
                     assert len(caplog.records) == 0
 
     def test_run_logs_if_terminated(self, token_mock, caplog):
@@ -90,9 +90,9 @@ class TestEvalRun:
                 workspace_name="mock",
                 ml_client=MagicMock(),
             )
-            run.start_run()
-            run.end_run("KILLED")
-            run.end_run("KILLED")
+            run._start_run()
+            run._end_run("KILLED")
+            run._end_run("KILLED")
             assert len(caplog.records) == 1
             assert "Unable to stop run because it was already terminated." in caplog.records[0].message
 
@@ -140,7 +140,7 @@ class TestEvalRun:
                 workspace_name="mock",
                 ml_client=MagicMock(),
             )
-            run.start_run()
+            run._start_run()
             assert len(caplog.records) == 1
             assert "500" in caplog.records[0].message
             assert mock_response_start.text in caplog.records[0].message
@@ -157,7 +157,7 @@ class TestEvalRun:
             assert "Unable to log metric because the run failed to start." in caplog.records[0].message
             caplog.clear()
             # End run
-            run.end_run("FINISHED")
+            run._end_run("FINISHED")
             assert len(caplog.records) == 1
             assert "Unable to stop run because the run failed to start." in caplog.records[0].message
             caplog.clear()
@@ -420,12 +420,12 @@ class TestEvalRun:
                 promptflow_run=pf_run_mock
             )
             assert run.status == RunStatus.NOT_STARTED, f'Get {run.status}, expected {RunStatus.NOT_STARTED}'
-            run.start_run()
+            run._start_run()
             if status_code == 200 or pf_run:
                 assert run.status == RunStatus.STARTED, f'Get {run.status}, expected {RunStatus.STARTED}'
             else:
                 assert run.status == RunStatus.BROKEN, f'Get {run.status}, expected {RunStatus.BROKEN}'
-            run.end_run("FINISHED")
+            run._end_run("FINISHED")
             if status_code == 200 or pf_run:
                 assert run.status == RunStatus.TERMINATED, f'Get {run.status}, expected {RunStatus.TERMINATED}'
             else:
@@ -442,9 +442,9 @@ class TestEvalRun:
             ml_client=MagicMock()
         )
         assert run.status == RunStatus.NOT_STARTED, f'Get {run.status}, expected {RunStatus.NOT_STARTED}'
-        run.start_run()
+        run._start_run()
         assert run.status == RunStatus.BROKEN, f'Get {run.status}, expected {RunStatus.BROKEN}'
-        run.end_run("FINISHED")
+        run._end_run("FINISHED")
         assert run.status == RunStatus.BROKEN, f'Get {run.status}, expected {RunStatus.BROKEN}'
 
     @pytest.mark.parametrize('status_code', [200, 401])
@@ -510,7 +510,7 @@ class TestEvalRun:
             ('log_artifact', ('mock_folder',))
         ]
     )
-    def test_raises_if_not_started(self, token_mock, function_literal, args):
+    def test_raises_if_not_started(self, token_mock, caplog, function_literal, args):
         """Test that all public functions are raising exception if run is not started."""
         run = EvalRun(
             run_name=None,


### PR DESCRIPTION
# Description

In this PR we are doing three things:
1. Making evaluator run a context manager
2. Moving function, writing properties to the run history to the evaluation run as a method
3. Removing code to keep evaluator run as a singletone as we, generally, do not need it.
4. Doing some unittest refactoring and adding/removing appropriate tests.
See work item 3334452.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](../CONTRIBUTING.md).**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
