### PR TITLE
Fix Test Case by Replacing `text-ada-001` with `gpt-35-turbo-instruct`

### DIFF
--- a/src/promptflow-tracing/tests/e2etests/simple_functions.py
+++ b/src/promptflow-tracing/tests/e2etests/simple_functions.py
@@ -153,7 +153,7 @@ def render(template, **kwargs):
 def prompt_tpl_completion(connection: dict, prompt_tpl: str, stream: bool = False, **kwargs):
     client = AzureOpenAI(**connection)
     prompt = render(prompt_tpl, **kwargs)
-    response = client.completions.create(model="text-ada-001", prompt=prompt, stream=stream)
+    response = client.completions.create(model="gpt-35-turbo-instruct", prompt=prompt, stream=stream)
 
     if stream:
 

--- a/src/promptflow-tracing/tests/e2etests/test_tracing.py
+++ b/src/promptflow-tracing/tests/e2etests/test_tracing.py
@@ -114,7 +114,6 @@ class TestTracing:
         span_list = exporter.get_finished_spans()
         self.validate_span_list(span_list, expected_span_length)
 
-    @pytest.mark.skip(reason="TODO: Fix this test in following PRs.")
     @pytest.mark.parametrize(
         "func, inputs, expected_span_length",
         [


### PR DESCRIPTION
# Description

This pull request addresses the issue of the skipped test case due to the retirement of the `text-ada-001` model after June 14. The following changes have been made to ensure the test case works correctly:
- Removed the skip mark from the test case.
- Replaced the `text-ada-001` model with the `gpt-35-turbo-instruct` model to make the AOAI endpoint functional for the test case.

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [X] **I confirm that all new dependencies are compatible with the MIT license.**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
