### PR TITLE
[azure][test] pin `azure-ai-ml` to aovid azure replay test breaking

### DIFF
--- a/src/promptflow-azure/pyproject.toml
+++ b/src/promptflow-azure/pyproject.toml
@@ -42,7 +42,7 @@ python = ">=3.8,<3.9.7 || >3.9.7,<3.13"
 azure-core = ">=1.26.4,<2.0.0"
 azure-storage-blob = {extras = ["aio"], version = ">=12.17.0,<13.0.0"}  # add [aio] for async run download feature
 azure-identity = ">=1.12.0,<2.0.0"
-azure-ai-ml = ">=1.14.0,<2.0.0"
+azure-ai-ml = ">=1.14.0,<1.19.0"
 azure-cosmos = ">=4.5.1,<5.0.0"  # used to upload trace to cloud
 pyjwt = ">=2.4.0,<3.0.0"  # requirement of control plane SDK
 promptflow-devkit = "<2.0.0"

--- a/src/promptflow-azure/pyproject.toml
+++ b/src/promptflow-azure/pyproject.toml
@@ -42,7 +42,7 @@ python = ">=3.8,<3.9.7 || >3.9.7,<3.13"
 azure-core = ">=1.26.4,<2.0.0"
 azure-storage-blob = {extras = ["aio"], version = ">=12.17.0,<13.0.0"}  # add [aio] for async run download feature
 azure-identity = ">=1.12.0,<2.0.0"
-azure-ai-ml = ">=1.14.0,<1.19.0"
+azure-ai-ml = ">=1.14.0,<2.0.0"
 azure-cosmos = ">=4.5.1,<5.0.0"  # used to upload trace to cloud
 pyjwt = ">=2.4.0,<3.0.0"  # requirement of control plane SDK
 promptflow-devkit = "<2.0.0"

--- a/src/promptflow-azure/pyproject.toml
+++ b/src/promptflow-azure/pyproject.toml
@@ -58,6 +58,7 @@ promptflow-tools = {path = "../promptflow-tools"}
 promptflow-recording =  {path = "../promptflow-recording", develop = true}
 
 [tool.poetry.group.ci.dependencies]
+azure-ai-ml = ">=1.14.0,<1.19.0"  # 1.19.0 will break azure replay test
 import-linter = "*"
 promptflow-core = {path = "../promptflow-core", extras = ["azureml-serving"]}
 promptflow-devkit = {path = "../promptflow-devkit"}


### PR DESCRIPTION
# Description

`azure-ai-ml` breaks Azure replay test since version 1.19.0, this PR targets to pin the version as a short-term workaround.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
