### PR TITLE
Fix Serialize Iterator for chat history in Interactive Mode

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_orchestrator/utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_orchestrator/utils.py
@@ -492,7 +492,7 @@ def _safe_join(generator_output):
 def resolve_generator(flow_result, generator_record):
     # resolve generator in flow result
     for k, v in flow_result.run_info.output.items():
-        if isinstance(v, GeneratorType):
+        if isinstance(v, (GeneratorType, IteratorProxy)):
             flow_output = _safe_join(
                 resolve_generator_output_with_cache(v, generator_record, generator_key=f"run.outputs.{k}")
             )
@@ -505,7 +505,7 @@ def resolve_generator(flow_result, generator_record):
 
     # resolve generator in node outputs
     for node_name, node in flow_result.node_run_infos.items():
-        if isinstance(node.output, GeneratorType):
+        if isinstance(node.output, (GeneratorType, IteratorProxy)):
             node_output = _safe_join(
                 resolve_generator_output_with_cache(
                     node.output, generator_record, generator_key=f"nodes.{node_name}.output"

--- a/src/promptflow/CHANGELOG.md
+++ b/src/promptflow/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [promptflow-azure] Fixed `Connection aborted` error for local to cloud run when registering the run to cloud.
 - [promptflow-core] Fixed openai error handler not functioning for `AsyncPrompty`.
 - [promptflow-devkit] Fixed trace view can't display boolean output.
+- [promptflow-devkit] Fixed not serialize chat history output in interactive mode
 
 ## v1.14.0 (2024.07.25)
 ### Improvements


### PR DESCRIPTION
# Description

See #3645
The output of type IteratorProxy needs to be resolved for string to be put in history (I followed print_chat_output check). When I added this check --interactive can now see history normally.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team
## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
