### PR TITLE
Set logger level instead of using debug

### DIFF
--- a/src/promptflow-core/promptflow/_utils/logger_utils.py
+++ b/src/promptflow-core/promptflow/_utils/logger_utils.py
@@ -398,10 +398,10 @@ class LoggerFactory:
             LoggerFactory._existing_loggers.append(logger)
             logger.disabled = LoggerFactory._disabled
         logger.propagate = False
-        # Set default logger level to debug, we are using handler level to control log by default
-        logger.setLevel(logging.DEBUG)
         # Use env var at first, then use verbosity
         verbosity = get_pf_logging_level(default=None) or verbosity
+        # Set default logger level to debug, we are using handler level to control log by default
+        logger.setLevel(verbosity)
         if not LoggerFactory._find_handler(logger, logging.StreamHandler):
             LoggerFactory._add_handler(logger, verbosity, target_stdout)
         # TODO: Find a more elegant way to set the logging level for azure.core.pipeline.policies._universal

--- a/src/promptflow-core/promptflow/_utils/logger_utils.py
+++ b/src/promptflow-core/promptflow/_utils/logger_utils.py
@@ -400,7 +400,6 @@ class LoggerFactory:
         logger.propagate = False
         # Use env var at first, then use verbosity
         verbosity = get_pf_logging_level(default=None) or verbosity
-        # Set default logger level to debug, we are using handler level to control log by default
         logger.setLevel(verbosity)
         if not LoggerFactory._find_handler(logger, logging.StreamHandler):
             LoggerFactory._add_handler(logger, verbosity, target_stdout)


### PR DESCRIPTION
# Description
1. LoggerHandler will control the final output log so we set the logger.level to debug to collect all logs previously
2. The reason to change this is promptflow serving will choose whether to disable logs based on logger.level. 
 https://github.com/microsoft/promptflow/blob/main/src/promptflow-core/promptflow/core/_serving/flow_invoker.py#L191

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [ ] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
