### PR TITLE
don't add empty openai token count values in tracing 

### DIFF
--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -335,9 +335,9 @@ def enrich_span_with_openai_tokens(span, trace_type):
     try:
         tokens = token_collector.try_get_openai_tokens(span.get_span_context().span_id)
         if tokens:
-            span_tokens = {f"__computed__.cumulative_token_count.{k.split('_')[0]}": v for k, v in tokens.items()}
+            span_tokens = {f"__computed__.cumulative_token_count.{k.split('_')[0]}": v for k, v in tokens.items() if v is not None}
             if trace_type in [TraceType.LLM, TraceType.EMBEDDING]:
-                llm_tokens = {f"llm.usage.{k}": v for k, v in tokens.items()}
+                llm_tokens = {f"llm.usage.{k}": v for k, v in tokens.items() if v is not None}
                 span_tokens.update(llm_tokens)
             span.set_attributes(span_tokens)
     except Exception as e:


### PR DESCRIPTION
# Description

Using OpenAI's API outside of Azure, I was sometimes receiving a usage dict that looked like:

```{'completion_tokens': 296, 'prompt_tokens': 1768, 'total_tokens': 2064, 'completion_tokens_details': None}```

The empty key was getting added to the trace and throwing an error later when [adding values](  https://github.com/microsoft/promptflow/blame/14d8164f55b3475a0b05c4e1c979901a3ad91135/src/promptflow-tracing/promptflow/tracing/_trace.py#L144)

This keeps it out with a very minimal change.

# All Promptflow Contribution checklist:
- X **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- X **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- N/A **I confirm that all new dependencies are compatible with the MIT license.**

## General Guidelines and Best Practices
- X Title of the pull request is clear and informative.
- X There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
