### PR TITLE
Fix bug in token usage merging logic for promptflow-tracing SDK

### DIFF
--- a/src/promptflow-tracing/CHANGELOG.md
+++ b/src/promptflow-tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # promptflow-tracing package
 
+## v1.16.1 (2024.10.8)
+
+- Fix token count issue when the value is None.
+
 ## v1.10.0 (2024.04.26)
 
 ### Features Added

--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -143,6 +143,8 @@ class TokenCollector:
                     merged_tokens = {
                         key: self._span_id_to_tokens[parent_span_id].get(key, 0) + tokens.get(key, 0)
                         for key in set(self._span_id_to_tokens[parent_span_id]) | set(tokens)
+                        if isinstance(self._span_id_to_tokens[parent_span_id].get(key, 0), int)
+                        and isinstance(tokens.get(key, 0), int)
                     }
                     self._span_id_to_tokens[parent_span_id] = merged_tokens
                 else:

--- a/src/promptflow-tracing/promptflow/tracing/_trace.py
+++ b/src/promptflow-tracing/promptflow/tracing/_trace.py
@@ -141,10 +141,9 @@ class TokenCollector:
             with self._lock:
                 if parent_span_id in self._span_id_to_tokens:
                     merged_tokens = {
-                        key: self._span_id_to_tokens[parent_span_id].get(key, 0) + tokens.get(key, 0)
+                        # When token count is None for some reason, we should default to 0.
+                        key: (self._span_id_to_tokens[parent_span_id].get(key, 0) or 0) + (tokens.get(key, 0) or 0)
                         for key in set(self._span_id_to_tokens[parent_span_id]) | set(tokens)
-                        if isinstance(self._span_id_to_tokens[parent_span_id].get(key, 0), int)
-                        and isinstance(tokens.get(key, 0), int)
                     }
                     self._span_id_to_tokens[parent_span_id] = merged_tokens
                 else:


### PR DESCRIPTION
# Description

The token calculation logic in promptflow-tracing merges two dictionaries related to token usage.
i.e. Given these two dictionaries:
```json
{ "completion_tokens": 146, "prompt_tokens": 166, "total_tokens": 312 }
```
```json
{ "completion_tokens": 10, "prompt_tokens": 10, "total_tokens": 20 }
```
The merged result will be:
```json
{ "completion_tokens": 156, "prompt_tokens": 176, "total_tokens": 332 }
```

However, for some customized models, there might be more additional fields populated in the dictionaries, like:
```json
{ "completion_tokens": 146, "prompt_tokens": 166, "total_tokens": 312, "completion_tokens_details": null }
```
Which causes the merging logic crash:

![image](https://github.com/user-attachments/assets/c1777ebf-db00-4c3c-a449-7a72274ffc0c)

This PR is to fix the issue. It converts `null`s to `0`s to avoid Python from raising errors.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
