### PR TITLE
prompty: fix parsing of tool_calls when array in arguments

### DIFF
--- a/src/promptflow-core/promptflow/core/_prompty_utils.py
+++ b/src/promptflow-core/promptflow/core/_prompty_utils.py
@@ -654,7 +654,7 @@ def try_parse_tool_call_id_and_content(role_prompt):
 def try_parse_tool_calls(role_prompt):
     # customer can add ## in front of tool_calls for markdown highlight.
     # and we still support tool_calls without ## prefix for backward compatibility.
-    pattern = r"\n*#{0,2}\s*tool_calls\s*:\s*\n+\s*(\[.*?\])"
+    pattern = r"\n*#{0,2}\s*tool_calls\s*:\s*\n+\s*(\[.*?\])\s*$"
     match = re.search(pattern, role_prompt, re.DOTALL)
     if match:
         try:


### PR DESCRIPTION
# Description

Current regex for parsing of tool_calls breaks if there is an array in the arguments (as it has a ']').
Consume up to end of block so it only matches the closing ']' and not any intermediate ones.


# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [ ] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
