### PR TITLE
promptflow-core: export error exception types

### DIFF
--- a/src/promptflow-core/promptflow/core/__init__.py
+++ b/src/promptflow-core/promptflow/core/__init__.py
@@ -13,6 +13,7 @@ from promptflow.core._model_configuration import (
     ModelConfiguration,
     OpenAIModelConfiguration,
 )
+import promptflow.core._errors as errors
 
 from ._version import __version__
 
@@ -30,5 +31,6 @@ __all__ = [
     "ModelConfiguration",
     "OpenAIModelConfiguration",
     "AzureOpenAIModelConfiguration",
+    "errors",
     "__version__",
 ]

--- a/src/promptflow-core/promptflow/core/_errors.py
+++ b/src/promptflow-core/promptflow/core/_errors.py
@@ -234,6 +234,11 @@ class WrappedOpenAIError(UserErrorException):
     @property
     def message(self):
         return str(to_openai_error_message(self._ex))
+    
+    @property
+    def inner_exception(self):
+        """Get the inner exception."""
+        return self._ex
 
     @property
     def error_codes(self):


### PR DESCRIPTION
# Description

A user's flex flow is not able to catch specific errors as Exception types are not exported.

Solves #3814

Adds inner exception information for wrapped OpenAI errors to have access to all detailed error info
# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [ ] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
