### PR TITLE
Fix bug for running single flow nodes with nested dict inputs

### DIFF
--- a/src/promptflow-core/promptflow/executor/_input_assignment_parser.py
+++ b/src/promptflow-core/promptflow/executor/_input_assignment_parser.py
@@ -69,6 +69,8 @@ property_pattern = r"(\w+)|(\['.*?'\])|(\[\d+\])"
 
 def parse_node_property(node_name, node_val, property=""):
     val = node_val
+    if "." in property and property in val.keys():
+        val= val[property]
     property_parts = re.findall(property_pattern, property)
     try:
         for part in property_parts:

--- a/src/promptflow-core/promptflow/executor/_input_assignment_parser.py
+++ b/src/promptflow-core/promptflow/executor/_input_assignment_parser.py
@@ -70,7 +70,7 @@ property_pattern = r"(\w+)|(\['.*?'\])|(\[\d+\])"
 def parse_node_property(node_name, node_val, property=""):
     val = node_val
     if "." in property and property in val.keys():
-        val= val[property]
+        val = val[property]
     property_parts = re.findall(property_pattern, property)
     try:
         for part in property_parts:


### PR DESCRIPTION
# Description

Inputs like ${parent_node.output.result.inner_key} will fail because of how the inputs are currently written to the jsonl inputs file. Eg. 

{"parent_node.output.result.inner_key":{"result":{"inner_key1":"foo","inner_key2":"bar"},"metrics":{"mertric_1":1.2}}

This is different behavior than when running entire flow where the input is always keyed on "parent_node.output.result" rather than "parent_node.output.result.inner_key".

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

Fixes #3882

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ x There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
