### PR TITLE
Fixed TypeError in Tracing issue with tokens that are dicts

### DIFF
--- a/src/promptflow-tracing/CHANGELOG.md
+++ b/src/promptflow-tracing/CHANGELOG.md
@@ -1,6 +1,6 @@
 # promptflow-tracing package
 
-## v1.16.1 (2024.12.14)
+## v1.16.3 (2024.12.14)
 
 - Fix token count issue when the value is None or it is a Dict
 

--- a/src/promptflow-tracing/CHANGELOG.md
+++ b/src/promptflow-tracing/CHANGELOG.md
@@ -1,5 +1,9 @@
 # promptflow-tracing package
 
+## v1.16.1 (2024.12.14)
+
+- Fix token count issue when the value is None or it is a Dict
+
 ## v1.16.1 (2024.10.8)
 
 - Fix token count issue when the value is None.


### PR DESCRIPTION
# Description

In the latest version of OpenAI some keys have tokens that are not ints. This is causing TypeErrors like 
`TypeError: unsupported operand type(s) for +: 'int' and 'dict'`
This aims to handle None types and Dicts better in tracing.

Should resolve bug #3834 

# All Promptflow Contribution checklist:
- [X] **The pull request does not introduce [breaking changes].**
- [X] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [X] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [X] **I confirm that all new dependencies are compatible with the MIT license.**
- [X] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [X] Title of the pull request is clear and informative.
- [X] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [X] Pull request includes test coverage for the included changes.
