### PR TITLE
fix key for FastapiContextDataProvider context data provider

### DIFF
--- a/src/promptflow-core/promptflow/core/_serving/v2/routers/score.py
+++ b/src/promptflow-core/promptflow/core/_serving/v2/routers/score.py
@@ -37,7 +37,7 @@ def get_score_router(logger):
             logger.info("Start loading request data...")
             data = load_request_data(app.flow, raw_data, logger)
         # set context data
-        _request_ctx_var.get()["data"] = data
+        _request_ctx_var.get()["input_data"] = data
         _request_ctx_var.get()["flow_id"] = app.flow.id or app.flow.name
         run_id = _request_ctx_var.get().get("req_id", None)
         # TODO: refine this once we can directly set the input/output log level to DEBUG in flow_invoker.


### PR DESCRIPTION
# Description

Hello,
with v2 fastapi + managed online endpoint with AML, the data collector can't write anything because in `FlowMonitor` input_data are requested with `input_data = self.context_data_provider.get_request_data()`.  This method looks for a key called `input_data` in `FastapiContextDataProvider`. 
But the value of this key is `None` because we don't set it correctly in `get_score_router()` (see changes is PR).

Maybe i'm wrong ?
