### PR TITLE
3937 - Parse the current Python version to the Dockerfile in pf build flow

### DIFF
--- a/src/promptflow-devkit/CHANGELOG.md
+++ b/src/promptflow-devkit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # promptflow-devkit package
 
+### Improvements
+- Python version in the conda environment in the deployed docker image is parsed from the environment that calls the build command.
+
+
 ## v1.17.2 (2025.1.23)
 
 ### Improvements

--- a/src/promptflow-devkit/promptflow/_sdk/data/docker/Dockerfile.jinja2
+++ b/src/promptflow-devkit/promptflow/_sdk/data/docker/Dockerfile.jinja2
@@ -23,7 +23,7 @@ COPY ./flow/{{env.conda_file}} /flow/{{env.conda_file}}
 
 RUN conda create -f flow/{{env.conda_file}} -q && \
 {% else %}
-RUN conda create -n {{env.conda_env_name}} python=3.9.16 pip=23.0.1 -q -y && \
+RUN conda create -n {{env.conda_env_name}} python={{env.python_version}} pip=23.0.1 -q -y && \
 {% endif %}
     conda run -n {{env.conda_env_name}} \
 {% if env.python_requirements_txt %}

--- a/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_flow_operations.py
@@ -414,6 +414,8 @@ class FlowOperations(TelemetryMixin):
                 conda_obj = load_yaml(conda_file)
                 if "name" in conda_obj:
                     env_obj["conda_env_name"] = conda_obj["name"]
+        # Set deployed python version to the current python version
+        env_obj["python_version"] = platform.python_version()
 
         return env_obj
 


### PR DESCRIPTION
# Description
Issue: https://github.com/microsoft/promptflow/issues/3937
This PR includes a modification where the python version in the conda environment in the deployed docker image is parsed from the environment that calls the build command.
This way, if the user writes his flows using python 3.12 syntax, breaking changes (linting for example) will not occur after deployment.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
