### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/examples/tutorials/tracing/autogen-groupchat/requirements.txt
+++ b/examples/tutorials/tracing/autogen-groupchat/requirements.txt
@@ -1,3 +1,3 @@
 promptflow
-pyautogen>=0.2.9
+ag2>=0.2.9
 pydantic>=2.6.0


### PR DESCRIPTION
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!
