### PR TITLE
Add missing os import

### DIFF
--- a/src/promptflow-core/CHANGELOG.md
+++ b/src/promptflow-core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # promptflow-core package
 
+## Unreleased
+
+### Bugs fixed
+
+- Added missing `os` import in `static_web_blueprint.py` ([#4042](https://github.com/microsoft/promptflow/issues/4042)).
+
 ## v1.18.1 (2025.6.10)
 
 ### Bugs fixed

--- a/src/promptflow-core/promptflow/core/_serving/v1/blueprint/static_web_blueprint.py
+++ b/src/promptflow-core/promptflow/core/_serving/v1/blueprint/static_web_blueprint.py
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
-
+import os
 from pathlib import Path
 
 import flask


### PR DESCRIPTION
# Description

Fixes #4042

PR #4013 forgot to import `os` in `static_web_blueprint.py`

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [x] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [x] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [x] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [x] Pull request includes test coverage for the included changes.
