### PR TITLE
chore: Remove unused/redendant requirements.txt

### DIFF
--- a/src/promptflow-recording/requirements.txt
+++ b/src/promptflow-recording/requirements.txt
@@ -1,2 +1,0 @@
-promptflow-tracing
-vcr


### PR DESCRIPTION
# Description

This pull request removes the `requirements.txt` in the root of the promptflow-recordings package.

This file:
* Includes a package that doesn't exist (`vcr`)
* Appears to be redundant with the pyproject.toml

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [ ] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
