### PR TITLE
fix: correct typo 'occured' to 'occurred'

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_restclient/flow/models/_models.py
+++ b/src/promptflow-azure/promptflow/azure/_restclient/flow/models/_models.py
@@ -33374,7 +33374,7 @@ class RootError(msrest.serialization.Model):
     :vartype message_parameters: dict[str, str]
     :ivar reference_code: This code can optionally be set by the system generating the error.
      It should be used to classify the problem and identify the module and code area where the
-     failure occured.
+     failure occurred.
     :vartype reference_code: str
     :ivar details_uri: A URI which points to more details about the context of the error.
     :vartype details_uri: str
@@ -33421,7 +33421,7 @@ class RootError(msrest.serialization.Model):
         :paramtype message_parameters: dict[str, str]
         :keyword reference_code: This code can optionally be set by the system generating the error.
          It should be used to classify the problem and identify the module and code area where the
-         failure occured.
+         failure occurred.
         :paramtype reference_code: str
         :keyword details_uri: A URI which points to more details about the context of the error.
         :paramtype details_uri: str

--- a/src/promptflow-azure/promptflow/azure/_restclient/flow/models/_models_py3.py
+++ b/src/promptflow-azure/promptflow/azure/_restclient/flow/models/_models_py3.py
@@ -37762,7 +37762,7 @@ class RootError(msrest.serialization.Model):
     :vartype message_parameters: dict[str, str]
     :ivar reference_code: This code can optionally be set by the system generating the error.
      It should be used to classify the problem and identify the module and code area where the
-     failure occured.
+     failure occurred.
     :vartype reference_code: str
     :ivar details_uri: A URI which points to more details about the context of the error.
     :vartype details_uri: str
@@ -37821,7 +37821,7 @@ class RootError(msrest.serialization.Model):
         :paramtype message_parameters: dict[str, str]
         :keyword reference_code: This code can optionally be set by the system generating the error.
          It should be used to classify the problem and identify the module and code area where the
-         failure occured.
+         failure occurred.
         :paramtype reference_code: str
         :keyword details_uri: A URI which points to more details about the context of the error.
         :paramtype details_uri: str


### PR DESCRIPTION
Fix spelling error 'occured' → 'occurred' in Azure REST client models (4 occurrences across 2 files).