### PR TITLE
chore: Upper-bound opentelemetry-sdk to 1.39.0

### DIFF
--- a/src/promptflow-tracing/pyproject.toml
+++ b/src/promptflow-tracing/pyproject.toml
@@ -36,7 +36,8 @@ packages = [
 [tool.poetry.dependencies]
 python = "<4.0,>=3.9"
 openai = "*"  # API injector for OpenAI traces
-opentelemetry-sdk = ">=1.22.0,<2.0.0"  # Open Telemetry dependency
+# opentelemetry-sdk==1.39.0 includes a breaking change that removes `LogData`
+opentelemetry-sdk = ">=1.22.0,<1.39.0"  # Open Telemetry dependency
 tiktoken = ">=0.4.0"  # get OpenAI token count for streaming scenario
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION

# Description

opentelemetry-sdk includes a breaking change that impacts promptflow-devkit and azure-monitor-opentelemetry-exporter.

This commit was included in the 1.18.2 release but never was committed back to main.

# All Promptflow Contribution checklist:
- [ ] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [ ] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team. Learn more: [suggested workflow](../CONTRIBUTING.md#suggested-workflow).**

## General Guidelines and Best Practices
- [ ] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### Testing Guidelines
- [ ] Pull request includes test coverage for the included changes.
