### PR TITLE
Fix wildcard CORS and auth bypass in Promptflow Service (PFS)

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/_service/apis/connection.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/apis/connection.py
@@ -138,7 +138,7 @@ class ConnectionWithSecret(Resource):
     @api.response(code=200, description="Connection details with secret", model=dict_field)
     @local_user_only
     @api.response(
-        code=403, description="This service is available for local user only, please specify X-Remote-User in headers."
+        code=403, description="This service is available for local user only."
     )
     def get(self, name: str):
         args = working_directory_parser.parse_args()

--- a/src/promptflow-devkit/promptflow/_sdk/_service/apis/telemetry.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/apis/telemetry.py
@@ -152,7 +152,7 @@ class Telemetry(Resource):
     @api.doc(description="Create telemetry record")
     @api.expect(telemetry_model)
     @local_user_only
-    @api.response(code=403, description="Telemetry is disabled or X-Remote-User is not set.")
+    @api.response(code=403, description="Telemetry is disabled or user is not the local user.")
     def post(self):
         from promptflow._sdk._telemetry import get_telemetry_logger, is_telemetry_enabled
         from promptflow._sdk._telemetry.activity import log_activity_end, log_activity_start

--- a/src/promptflow-devkit/promptflow/_sdk/_service/app.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/app.py
@@ -3,6 +3,7 @@
 # ---------------------------------------------------------
 import logging
 import os
+import re
 import threading
 import time
 from logging.handlers import RotatingFileHandler
@@ -43,10 +44,13 @@ def root():
 def create_app():
     app = Flask(__name__)
 
-    # in normal case, we don't need to handle CORS for PFS
-    # as far as we know, local UX development might need to handle this
-    # as there might be different ports in that scenario
-    CORS(app)
+    # Restrict CORS to local origins only to prevent cross-origin attacks from
+    # arbitrary websites while still supporting local UX development scenarios
+    # where the UI may be served on a different port.
+    CORS(app, origins=[
+        re.compile(r"^https?://localhost(:\d+)?$"),
+        re.compile(r"^https?://127\.0\.0\.1(:\d+)?$"),
+    ])
 
     app.add_url_rule("/", view_func=root)
     app.add_url_rule("/heartbeat", view_func=heartbeat)

--- a/src/promptflow-devkit/promptflow/_sdk/_service/utils/utils.py
+++ b/src/promptflow-devkit/promptflow/_sdk/_service/utils/utils.py
@@ -60,8 +60,8 @@ hint_stop_before_upgrade = (
 def local_user_only(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
-        # Get the user name from request.
-        user = request.environ.get("REMOTE_USER") or request.headers.get("X-Remote-User")
+        # Only trust REMOTE_USER from the WSGI server environment, not client-supplied headers.
+        user = request.environ.get("REMOTE_USER")
         if user != getpass.getuser():
             abort(403)
         return func(*args, **kwargs)


### PR DESCRIPTION
## Summary

Two compounding security vulnerabilities in the local Promptflow Service (PFS) that together allow cross-origin credential theft:

### 1. Wildcard CORS (CWE-942)
`CORS(app)` with no origin restrictions allows any website to make cross-origin requests to the local PFS on `127.0.0.1:23333`. This defeats the localhost-binding security boundary.

**Fix:** Restrict CORS origins to `localhost` and `127.0.0.1` only (with any port), preserving local UX development scenarios.

### 2. Authentication bypass via spoofable header (CWE-290)
The `local_user_only` decorator trusts the client-supplied `X-Remote-User` HTTP header. Combined with wildcard CORS, any website can include this header in cross-origin requests to bypass the auth check on `/listsecrets` and steal connection secrets (API keys).

**Fix:** Only trust `REMOTE_USER` from the WSGI server environment, not client-supplied headers.

### Attack scenario
1. Developer has PFS running locally (`pf service start`)
2. Developer visits a malicious/compromised website
3. Website's JavaScript calls `fetch('http://127.0.0.1:23333/v1.0/Connections/my-conn/listsecrets', {headers: {'X-Remote-User': 'targetuser'}})`
4. Wildcard CORS allows the cross-origin request
5. Spoofed header bypasses `local_user_only`
6. Website exfiltrates decrypted API keys

### Files changed
- `app.py` — CORS restricted to local origins
- `utils/utils.py` — Removed `X-Remote-User` header trust
- `apis/connection.py` — Updated 403 response description
- `apis/telemetry.py` — Updated 403 response description