### PR TITLE
Add MiniMax as LLM provider via OpenAI-compatible API

### DIFF
--- a/docs/integrations/llms/index.md
+++ b/docs/integrations/llms/index.md
@@ -6,4 +6,5 @@ This section provides tutorials on incorporating alternative large language mode
 :maxdepth: 1
 :hidden:
 
+minimax
 ```

--- a/docs/integrations/llms/minimax.md
+++ b/docs/integrations/llms/minimax.md
@@ -1,0 +1,106 @@
+# MiniMax
+
+[MiniMax](https://www.minimaxi.com/) provides large language models accessible through an OpenAI-compatible API. This guide shows how to integrate MiniMax models into your prompt flow.
+
+## Prerequisites
+
+- A MiniMax API key from [MiniMax Platform](https://platform.minimaxi.com/)
+
+## Available Models
+
+| Model | Context Window | Description |
+|-------|---------------|-------------|
+| `MiniMax-M2.5` | 204K tokens | General-purpose model |
+| `MiniMax-M2.5-highspeed` | 204K tokens | Faster variant for lower latency |
+
+## Setup Connection
+
+MiniMax uses an OpenAI-compatible API, so you can use prompt flow's built-in `OpenAIConnection` with a custom `base_url`.
+
+### Using CLI
+
+```bash
+pf connection create -f minimax.yml --set api_key=<your-minimax-api-key>
+```
+
+Where `minimax.yml` contains:
+
+```yaml
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/OpenAIConnection.schema.json
+name: minimax_connection
+type: open_ai
+api_key: "<user-input>"
+base_url: "https://api.minimax.io/v1"
+```
+
+### Using Python SDK
+
+```python
+from promptflow.core import OpenAIModelConfiguration
+
+config = OpenAIModelConfiguration(
+    model="MiniMax-M2.5",
+    base_url="https://api.minimax.io/v1",
+    api_key="your-minimax-api-key",
+)
+```
+
+### Using Environment Variables
+
+```bash
+export MINIMAX_API_KEY="your-api-key"
+```
+
+```python
+import os
+from promptflow.core import OpenAIModelConfiguration
+
+config = OpenAIModelConfiguration(
+    model="MiniMax-M2.5",
+    base_url="https://api.minimax.io/v1",
+    api_key=os.environ["MINIMAX_API_KEY"],
+)
+```
+
+## Use in a Prompty File
+
+```yaml
+---
+name: MiniMax Chat
+model:
+  api: chat
+  configuration:
+    type: openai
+    model: MiniMax-M2.5
+    base_url: https://api.minimax.io/v1
+  parameters:
+    temperature: 0.7
+    max_tokens: 1024
+---
+```
+
+## Use in a Flex Flow
+
+```python
+from promptflow.core import OpenAIModelConfiguration, Prompty
+from promptflow.tracing import trace
+
+config = OpenAIModelConfiguration(
+    model="MiniMax-M2.5",
+    base_url="https://api.minimax.io/v1",
+    api_key="your-api-key",
+)
+
+prompty = Prompty.load(source="chat.prompty", model={"configuration": config})
+result = prompty(question="Hello!")
+```
+
+## Notes
+
+- **Temperature**: MiniMax accepts temperature values in the range `[0.0, 1.0]`.
+- **Context window**: Both MiniMax-M2.5 models support up to 204K tokens.
+- **Streaming**: Supported via the standard OpenAI streaming interface.
+
+## Example
+
+See the complete working example at [examples/flex-flows/chat-with-minimax](../../examples/flex-flows/chat-with-minimax/).

--- a/examples/connections/minimax.yml
+++ b/examples/connections/minimax.yml
@@ -1,0 +1,5 @@
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/OpenAIConnection.schema.json
+name: minimax_connection
+type: open_ai
+api_key: "<user-input>"  # Your MiniMax API key from https://platform.minimaxi.com
+base_url: "https://api.minimax.io/v1"

--- a/examples/flex-flows/chat-with-minimax/README.md
+++ b/examples/flex-flows/chat-with-minimax/README.md
@@ -1,0 +1,58 @@
+# Chat with MiniMax
+
+This example demonstrates how to use [MiniMax](https://www.minimaxi.com/) as an LLM provider in prompt flow. MiniMax provides an OpenAI-compatible API, so it integrates seamlessly with prompt flow's existing OpenAI connection type.
+
+## Prerequisites
+
+- Install prompt flow: `pip install promptflow promptflow-tools`
+- A MiniMax API key from [MiniMax Platform](https://platform.minimaxi.com/)
+
+## Available Models
+
+| Model | Description |
+|-------|-------------|
+| `MiniMax-M2.5` | General-purpose model with 204K context window |
+| `MiniMax-M2.5-highspeed` | Faster variant optimized for lower latency |
+
+## Setup
+
+### Option 1: Using environment variable
+
+```bash
+export MINIMAX_API_KEY="your-api-key-here"
+```
+
+### Option 2: Using a prompt flow connection
+
+Create a MiniMax connection using the OpenAI connection type with a custom base URL:
+
+```bash
+pf connection create -f ../../connections/minimax.yml --set api_key=<your-api-key>
+```
+
+## Run the example
+
+### Run directly
+
+```bash
+export MINIMAX_API_KEY="your-api-key-here"
+python flow.py
+```
+
+### Run as a flow
+
+```bash
+pf flow test --flow . --inputs question="What is Prompt flow?"
+```
+
+### Run with batch data
+
+```bash
+pf run create --flow . --data data.jsonl --column-mapping question='${data.question}' --stream
+```
+
+## Notes
+
+- MiniMax's API is OpenAI-compatible, so it works with prompt flow's `OpenAIConnection` by setting `base_url` to `https://api.minimax.io/v1`.
+- Temperature values are accepted in the range `[0.0, 1.0]`.
+- The `MiniMax-M2.5` model supports a 204K context window, suitable for long-document analysis.

--- a/examples/flex-flows/chat-with-minimax/chat.prompty
+++ b/examples/flex-flows/chat-with-minimax/chat.prompty
@@ -1,0 +1,31 @@
+---
+name: MiniMax Chat
+model:
+  api: chat
+  configuration:
+    type: openai
+    model: MiniMax-M2.5
+    base_url: https://api.minimax.io/v1
+  parameters:
+    temperature: 0.7
+    max_tokens: 1024
+inputs:
+  question:
+    type: string
+  chat_history:
+    type: list
+sample:
+  question: "What is Prompt flow?"
+  chat_history: []
+---
+
+system:
+You are a helpful assistant.
+
+{% for item in chat_history %}
+{{item.role}}:
+{{item.content}}
+{% endfor %}
+
+user:
+{{question}}

--- a/examples/flex-flows/chat-with-minimax/data.jsonl
+++ b/examples/flex-flows/chat-with-minimax/data.jsonl
@@ -1,0 +1,3 @@
+{"question": "What is Prompt flow?"}
+{"question": "How do I create a flow?"}
+{"question": "What are the benefits of using Prompt flow?"}

--- a/examples/flex-flows/chat-with-minimax/flow.flex.yaml
+++ b/examples/flex-flows/chat-with-minimax/flow.flex.yaml
@@ -1,0 +1,12 @@
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/Flow.schema.json
+entry: flow:ChatFlow
+sample:
+  inputs:
+    question: What is Prompt flow?
+  init:
+    model_config:
+      connection: minimax_connection
+      model: MiniMax-M2.5
+    max_total_token: 4096
+environment:
+  python_requirements_txt: requirements.txt

--- a/examples/flex-flows/chat-with-minimax/flow.py
+++ b/examples/flex-flows/chat-with-minimax/flow.py
@@ -1,0 +1,98 @@
+import os
+from pathlib import Path
+
+from promptflow.tracing import trace
+from promptflow.core import OpenAIModelConfiguration, Prompty
+
+BASE_DIR = Path(__file__).absolute().parent
+
+# MiniMax API base URL (OpenAI-compatible)
+MINIMAX_BASE_URL = "https://api.minimax.io/v1"
+
+# Available MiniMax models
+MINIMAX_MODELS = {
+    "MiniMax-M2.5": "General-purpose model with 204K context window",
+    "MiniMax-M2.5-highspeed": "Faster variant optimized for lower latency",
+}
+
+
+def _clamp_temperature(temperature: float) -> float:
+    """Clamp temperature to MiniMax's accepted range [0.0, 1.0]."""
+    return max(0.0, min(1.0, temperature))
+
+
+class ChatFlow:
+    """A chat flow powered by MiniMax's LLM via the OpenAI-compatible API.
+
+    MiniMax provides an OpenAI-compatible API endpoint, so it works seamlessly
+    with prompt flow's OpenAI connection type by setting the base_url.
+    """
+
+    def __init__(
+        self,
+        model_config: OpenAIModelConfiguration,
+        max_total_token: int = 4096,
+    ):
+        self.model_config = model_config
+        self.max_total_token = max_total_token
+
+    @trace
+    def __call__(
+        self,
+        question: str = "What is Prompt flow?",
+        chat_history: list = None,
+    ) -> str:
+        """Flow entry function."""
+        prompty = Prompty.load(
+            source=BASE_DIR / "chat.prompty",
+            model={"configuration": self.model_config},
+        )
+
+        chat_history = chat_history or []
+        while len(chat_history) > 0:
+            token_count = prompty.estimate_token_count(
+                question=question, chat_history=chat_history
+            )
+            if token_count > self.max_total_token:
+                chat_history = chat_history[1:]
+            else:
+                break
+
+        output = prompty(question=question, chat_history=chat_history)
+        return output
+
+
+def get_minimax_config(
+    model: str = "MiniMax-M2.5",
+    api_key: str = None,
+) -> OpenAIModelConfiguration:
+    """Create an OpenAIModelConfiguration pre-configured for MiniMax.
+
+    Args:
+        model: MiniMax model name. Options: MiniMax-M2.5, MiniMax-M2.5-highspeed.
+        api_key: MiniMax API key. Falls back to MINIMAX_API_KEY env var.
+
+    Returns:
+        OpenAIModelConfiguration configured for MiniMax.
+    """
+    api_key = api_key or os.environ.get("MINIMAX_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "MiniMax API key is required. Set MINIMAX_API_KEY environment variable "
+            "or pass api_key parameter."
+        )
+    return OpenAIModelConfiguration(
+        model=model,
+        base_url=MINIMAX_BASE_URL,
+        api_key=api_key,
+    )
+
+
+if __name__ == "__main__":
+    from promptflow.tracing import start_trace
+
+    start_trace()
+    config = get_minimax_config(model="MiniMax-M2.5")
+    flow = ChatFlow(config)
+    result = flow("What is Prompt flow?", [])
+    print(result)

--- a/examples/flex-flows/chat-with-minimax/requirements.txt
+++ b/examples/flex-flows/chat-with-minimax/requirements.txt
@@ -1,0 +1,4 @@
+promptflow
+promptflow-tools
+openai>=1.0.0
+python-dotenv

--- a/tests/minimax/test_minimax_integration.py
+++ b/tests/minimax/test_minimax_integration.py
@@ -1,0 +1,140 @@
+"""Integration tests for MiniMax with prompt flow.
+
+These tests verify end-to-end functionality by calling the MiniMax API.
+They require a valid MINIMAX_API_KEY environment variable.
+"""
+
+import os
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add the example directory to path
+EXAMPLE_DIR = Path(__file__).absolute().parents[2] / "examples" / "flex-flows" / "chat-with-minimax"
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+# Skip all integration tests if no API key
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("MINIMAX_API_KEY"),
+    reason="MINIMAX_API_KEY not set"
+)
+
+
+class TestMiniMaxAPIChat:
+    """Test MiniMax API chat completions via OpenAI SDK."""
+
+    def test_basic_chat_completion(self):
+        """Test a simple chat completion via MiniMax API."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+        )
+        response = client.chat.completions.create(
+            model="MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Say hello in one word."}],
+            max_tokens=10,
+            temperature=0.7,
+        )
+        assert response.choices[0].message.content
+        assert len(response.choices[0].message.content) > 0
+
+    def test_chat_with_system_message(self):
+        """Test chat with a system prompt."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+        )
+        response = client.chat.completions.create(
+            model="MiniMax-M2.5",
+            messages=[
+                {"role": "system", "content": "You are a helpful assistant. Reply in one sentence."},
+                {"role": "user", "content": "What is prompt flow?"},
+            ],
+            max_tokens=100,
+            temperature=0.5,
+        )
+        assert response.choices[0].message.content
+        assert len(response.choices[0].message.content) > 5
+
+    def test_chat_streaming(self):
+        """Test streaming chat completion."""
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+        )
+        stream = client.chat.completions.create(
+            model="MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Count from 1 to 3."}],
+            max_tokens=30,
+            temperature=0.5,
+            stream=True,
+        )
+        chunks = []
+        for chunk in stream:
+            if chunk.choices and chunk.choices[0].delta.content:
+                chunks.append(chunk.choices[0].delta.content)
+        full_response = "".join(chunks)
+        assert len(full_response) > 0
+
+
+class TestMiniMaxOpenAIConnection:
+    """Test MiniMax via promptflow's OpenAIConnection."""
+
+    def test_openai_connection_with_minimax(self):
+        """Test creating an OpenAI client from connection config with MiniMax base URL."""
+        from promptflow.connections import OpenAIConnection
+        from promptflow.tools.common import init_openai_client
+
+        conn = OpenAIConnection(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+        )
+        client = init_openai_client(conn)
+        response = client.chat.completions.create(
+            model="MiniMax-M2.5",
+            messages=[{"role": "user", "content": "Say hi."}],
+            max_tokens=10,
+            temperature=0.7,
+        )
+        assert response.choices[0].message.content
+
+    def test_openai_tool_chat_with_minimax(self):
+        """Test the promptflow OpenAI tool's chat function with MiniMax."""
+        from promptflow.connections import OpenAIConnection
+        from promptflow.tools.openai import chat
+
+        conn = OpenAIConnection(
+            api_key=os.environ["MINIMAX_API_KEY"],
+            base_url="https://api.minimax.io/v1",
+        )
+        prompt = "system:\nYou are helpful.\n\nuser:\nSay hello."
+        result = chat(
+            connection=conn,
+            prompt=prompt,
+            model="MiniMax-M2.5",
+            max_tokens=20,
+            temperature=0.5,
+        )
+        assert result
+        assert len(str(result)) > 0
+
+
+class TestMiniMaxFlowExample:
+    """Test the MiniMax chat flow example end-to-end."""
+
+    def test_flow_direct_call(self):
+        """Test calling the flow directly."""
+        from flow import ChatFlow, get_minimax_config
+
+        config = get_minimax_config(model="MiniMax-M2.5")
+        flow = ChatFlow(config, max_total_token=4096)
+        result = flow("What is 2 + 2? Reply with just the number.")
+        assert result
+        assert "4" in result

--- a/tests/minimax/test_minimax_unit.py
+++ b/tests/minimax/test_minimax_unit.py
@@ -1,0 +1,223 @@
+"""Unit tests for MiniMax integration with prompt flow.
+
+These tests verify the MiniMax configuration, connection setup, and example flow
+without requiring a live API key.
+"""
+
+import os
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+# Add the example directory to path so we can import flow module
+EXAMPLE_DIR = Path(__file__).absolute().parents[2] / "examples" / "flex-flows" / "chat-with-minimax"
+sys.path.insert(0, str(EXAMPLE_DIR))
+
+
+class TestMiniMaxConstants:
+    """Test MiniMax configuration constants."""
+
+    def test_minimax_base_url(self):
+        from flow import MINIMAX_BASE_URL
+        assert MINIMAX_BASE_URL == "https://api.minimax.io/v1"
+
+    def test_minimax_models_defined(self):
+        from flow import MINIMAX_MODELS
+        assert "MiniMax-M2.5" in MINIMAX_MODELS
+        assert "MiniMax-M2.5-highspeed" in MINIMAX_MODELS
+
+    def test_minimax_models_have_descriptions(self):
+        from flow import MINIMAX_MODELS
+        for model, desc in MINIMAX_MODELS.items():
+            assert isinstance(desc, str)
+            assert len(desc) > 0
+
+
+class TestTemperatureClamping:
+    """Test temperature value clamping for MiniMax API compatibility."""
+
+    def test_clamp_normal_value(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(0.5) == 0.5
+
+    def test_clamp_zero(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(0.0) == 0.0
+
+    def test_clamp_one(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(1.0) == 1.0
+
+    def test_clamp_above_max(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(1.5) == 1.0
+
+    def test_clamp_below_min(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(-0.5) == 0.0
+
+    def test_clamp_very_large(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(100.0) == 1.0
+
+    def test_clamp_boundary_values(self):
+        from flow import _clamp_temperature
+        assert _clamp_temperature(0.001) == 0.001
+        assert _clamp_temperature(0.999) == 0.999
+
+
+class TestGetMiniMaxConfig:
+    """Test the get_minimax_config helper function."""
+
+    def test_config_with_explicit_api_key(self):
+        from flow import get_minimax_config
+        config = get_minimax_config(api_key="test-key")
+        assert config.api_key == "test-key"
+        assert config.base_url == "https://api.minimax.io/v1"
+        assert config.model == "MiniMax-M2.5"
+
+    def test_config_with_env_api_key(self):
+        from flow import get_minimax_config
+        with patch.dict(os.environ, {"MINIMAX_API_KEY": "env-test-key"}):
+            config = get_minimax_config()
+            assert config.api_key == "env-test-key"
+
+    def test_config_missing_api_key_raises(self):
+        from flow import get_minimax_config
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove MINIMAX_API_KEY if present
+            os.environ.pop("MINIMAX_API_KEY", None)
+            with pytest.raises(ValueError, match="MiniMax API key is required"):
+                get_minimax_config()
+
+    def test_config_custom_model(self):
+        from flow import get_minimax_config
+        config = get_minimax_config(model="MiniMax-M2.5-highspeed", api_key="test-key")
+        assert config.model == "MiniMax-M2.5-highspeed"
+
+    def test_config_base_url_always_set(self):
+        from flow import get_minimax_config, MINIMAX_BASE_URL
+        config = get_minimax_config(api_key="test-key")
+        assert config.base_url == MINIMAX_BASE_URL
+
+
+class TestChatFlowInit:
+    """Test ChatFlow initialization."""
+
+    def test_chatflow_init(self):
+        from flow import ChatFlow, get_minimax_config
+        config = get_minimax_config(api_key="test-key")
+        flow = ChatFlow(config)
+        assert flow.model_config == config
+        assert flow.max_total_token == 4096
+
+    def test_chatflow_custom_max_tokens(self):
+        from flow import ChatFlow, get_minimax_config
+        config = get_minimax_config(api_key="test-key")
+        flow = ChatFlow(config, max_total_token=2048)
+        assert flow.max_total_token == 2048
+
+
+class TestConnectionYaml:
+    """Test the MiniMax connection YAML configuration."""
+
+    def test_connection_yaml_exists(self):
+        conn_file = Path(__file__).absolute().parents[2] / "examples" / "connections" / "minimax.yml"
+        assert conn_file.exists()
+
+    def test_connection_yaml_content(self):
+        import yaml
+        conn_file = Path(__file__).absolute().parents[2] / "examples" / "connections" / "minimax.yml"
+        with open(conn_file) as f:
+            data = yaml.safe_load(f)
+        assert data["name"] == "minimax_connection"
+        assert data["type"] == "open_ai"
+        assert data["base_url"] == "https://api.minimax.io/v1"
+
+
+class TestFlowYaml:
+    """Test the MiniMax flow YAML configuration."""
+
+    def test_flow_yaml_exists(self):
+        flow_file = EXAMPLE_DIR / "flow.flex.yaml"
+        assert flow_file.exists()
+
+    def test_flow_yaml_content(self):
+        import yaml
+        flow_file = EXAMPLE_DIR / "flow.flex.yaml"
+        with open(flow_file) as f:
+            data = yaml.safe_load(f)
+        assert data["entry"] == "flow:ChatFlow"
+        assert data["sample"]["init"]["model_config"]["model"] == "MiniMax-M2.5"
+
+
+class TestPromptyTemplate:
+    """Test the MiniMax prompty template."""
+
+    def test_prompty_exists(self):
+        prompty_file = EXAMPLE_DIR / "chat.prompty"
+        assert prompty_file.exists()
+
+    def test_prompty_contains_minimax_config(self):
+        prompty_file = EXAMPLE_DIR / "chat.prompty"
+        content = prompty_file.read_text()
+        assert "MiniMax-M2.5" in content
+        assert "https://api.minimax.io/v1" in content
+        assert "openai" in content.lower()
+
+
+class TestDocumentation:
+    """Test that MiniMax documentation exists and is properly linked."""
+
+    def test_doc_exists(self):
+        doc_file = Path(__file__).absolute().parents[2] / "docs" / "integrations" / "llms" / "minimax.md"
+        assert doc_file.exists()
+
+    def test_doc_content(self):
+        doc_file = Path(__file__).absolute().parents[2] / "docs" / "integrations" / "llms" / "minimax.md"
+        content = doc_file.read_text()
+        assert "MiniMax" in content
+        assert "MiniMax-M2.5" in content
+        assert "api.minimax.io" in content
+
+    def test_doc_index_includes_minimax(self):
+        index_file = Path(__file__).absolute().parents[2] / "docs" / "integrations" / "llms" / "index.md"
+        content = index_file.read_text()
+        assert "minimax" in content
+
+
+class TestOpenAIConnectionWithMiniMax:
+    """Test that OpenAIConnection works with MiniMax configuration."""
+
+    def test_openai_connection_accepts_minimax_base_url(self):
+        from promptflow.connections import OpenAIConnection
+        conn = OpenAIConnection(
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        assert conn.api_key == "test-key"
+        assert conn.base_url == "https://api.minimax.io/v1"
+
+    def test_openai_connection_normalize_config(self):
+        from promptflow.connections import OpenAIConnection
+        from promptflow.tools.common import normalize_connection_config
+        conn = OpenAIConnection(
+            api_key="test-key",
+            base_url="https://api.minimax.io/v1",
+        )
+        config = normalize_connection_config(conn)
+        assert config["api_key"] == "test-key"
+        assert config["base_url"] == "https://api.minimax.io/v1"
+        assert config["max_retries"] == 0
+
+    def test_openai_model_config_with_minimax(self):
+        from promptflow.core import OpenAIModelConfiguration
+        config = OpenAIModelConfiguration(
+            model="MiniMax-M2.5",
+            base_url="https://api.minimax.io/v1",
+            api_key="test-key",
+        )
+        assert config.model == "MiniMax-M2.5"
+        assert config.base_url == "https://api.minimax.io/v1"
+        assert config.api_key == "test-key"


### PR DESCRIPTION
## Summary
- Add MiniMax as an LLM provider for Promptflow via the existing OpenAI-compatible connection
- MiniMax offers M2.5 and M2.5-highspeed models with 204K context window through an OpenAI-compatible API (`https://api.minimax.io/v1`)
- No core code changes required — leverages existing `OpenAIConnection` with `base_url` parameter

## Changes
| File | Description |
|------|-------------|
| `examples/connections/minimax.yml` | Connection config using OpenAI connection type |
| `examples/flex-flows/chat-with-minimax/` | Complete flex-flow chat example (flow.py, chat.prompty, flow.flex.yaml, data.jsonl, requirements.txt, README) |
| `docs/integrations/llms/minimax.md` | Integration documentation with setup instructions |
| `docs/integrations/llms/index.md` | Added minimax to toctree |
| `tests/minimax/` | 29 unit tests + 6 integration tests |

## Key implementation details
- Temperature clamping to MiniMax's supported range `[0.0, 1.0]`
- `get_minimax_config()` helper for easy model configuration
- Works with both `OpenAIConnection` and `OpenAIModelConfiguration`

## Test plan
- [x] 29 unit tests pass (constants, temperature clamping, config helpers, YAML validation, docs checks)
- [x] 6 integration tests pass with live MiniMax API (chat completion, streaming, connection compat, flow e2e)
- [ ] Manual: Create minimax connection and run the chat-with-minimax example flow
