### PR TITLE
docs: replace deprecated text-davinci-003 examples

### DIFF
--- a/docs/cloud/azureai/use-flow-in-azure-ml-pipeline.md
+++ b/docs/cloud/azureai/use-flow-in-azure-ml-pipeline.md
@@ -57,7 +57,7 @@ nodes:
     path: hello.py
   inputs:
     prompt: ${hello_prompt.output}
-    deployment_name: text-davinci-003
+    deployment_name: gpt-35-turbo
     max_tokens: "120"
 ```
 
@@ -239,7 +239,7 @@ jobs:
       data: ${{parent.inputs.data}}
       url: "${data.url}"
       connections.summarize_text_content.connection: azure_open_ai_connection
-      connections.summarize_text_content.deployment_name: text-davinci-003
+      connections.summarize_text_content.deployment_name: gpt-35-turbo
       environment_variables.AZURE_OPENAI_API_KEY: ${my_connection.api_key}
       environment_variables.AZURE_OPENAI_API_BASE: ${my_connection.api_base}
 ...
@@ -271,7 +271,7 @@ def pipeline_func_with_flow(data):
         connections={
             "summarize_text_content": {
                 "connection": "azure_open_ai_connection",
-                "deployment_name": "text-davinci-003",
+                "deployment_name": "gpt-35-turbo",
             },
         },
         environment_variables={

--- a/docs/how-to-guides/develop-a-dag-flow/develop-standard-flow.md
+++ b/docs/how-to-guides/develop-a-dag-flow/develop-standard-flow.md
@@ -178,7 +178,7 @@ by `${prepare_examples.output}` and `${summarize_text_content.output}`.
     type: code
     path: classify_with_llm.jinja2
   inputs:
-    deployment_name: text-davinci-003
+    deployment_name: gpt-35-turbo
     suffix: ""
     max_tokens: 128
     temperature: 0.2
@@ -218,7 +218,7 @@ You can link `examples` to the `evidence` output of upstream `covert_to_dict` no
     type: code
     path: classify_with_llm.jinja2
   inputs:
-    deployment_name: text-davinci-003
+    deployment_name: gpt-35-turbo
     suffix: ""
     max_tokens: 128
     temperature: 0.2

--- a/docs/how-to-guides/tune-prompts-with-variants.md
+++ b/docs/how-to-guides/tune-prompts-with-variants.md
@@ -32,7 +32,7 @@ node_variants:
             type: code
             path: summarize_text_content.jinja2
           inputs:
-            deployment_name: text-davinci-003
+            deployment_name: gpt-35-turbo
             max_tokens: '128'
             temperature: '0.2'
             text: ${fetch_text_content_from_url.output}
@@ -47,7 +47,7 @@ node_variants:
             type: code
             path: summarize_text_content__variant_1.jinja2
           inputs:
-            deployment_name: text-davinci-003
+            deployment_name: gpt-35-turbo
             max_tokens: '256'
             temperature: '0.3'
             text: ${fetch_text_content_from_url.output}


### PR DESCRIPTION
## Summary
- replace deprecated `text-davinci-003` deployment examples with `gpt-35-turbo`
- update the affected how-to and Azure ML pipeline docs called out in the contribution request

Closes #2198
