### PR TITLE
fix: support non-UTF-8 encodings in eval data loading

### DIFF
--- a/src/promptflow-core/promptflow/_utils/load_data.py
+++ b/src/promptflow-core/promptflow/_utils/load_data.py
@@ -12,6 +12,17 @@ from promptflow.exceptions import ErrorTarget, UserErrorException
 module_logger = logging.getLogger(__name__)
 
 
+def _detect_encoding(file_path: str) -> str:
+    """Detect BOM markers to identify encoding, defaulting to utf-8."""
+    with open(file_path, "rb") as f:
+        raw = f.read(4)
+    if raw.startswith(b"\xef\xbb\xbf"):
+        return "utf-8-sig"
+    if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
+        return "utf-16"
+    return "utf-8"
+
+
 def _pd_read_file(local_path: str, logger: logging.Logger = None, max_rows_count: int = None) -> "DataFrame":
     import pandas as pd
 
@@ -34,7 +45,8 @@ def _pd_read_file(local_path: str, logger: logging.Logger = None, max_rows_count
     elif local_path.endswith(".json"):
         df = pd.read_json(local_path, dtype=dtype)
     elif local_path.endswith(".jsonl"):
-        df = pd.read_json(local_path, dtype=dtype, lines=True, nrows=max_rows_count)
+        encoding = _detect_encoding(local_path)
+        df = pd.read_json(local_path, dtype=dtype, lines=True, nrows=max_rows_count, encoding=encoding)
     elif local_path.endswith(".tsv"):
         df = pd.read_table(local_path, dtype=dtype, keep_default_na=False, nrows=max_rows_count)
     elif local_path.endswith(".parquet"):

--- a/src/promptflow-evals/promptflow/evals/evaluate/_evaluate.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_evaluate.py
@@ -191,8 +191,35 @@ def _validate_and_load_data(target, data, evaluators, output_path, azure_ai_proj
         if not isinstance(evaluation_name, str):
             raise ValueError("evaluation_name must be a string.")
 
+    def _detect_encoding(file_path: str) -> str:
+        """Detect BOM markers to identify encoding, defaulting to utf-8."""
+        with open(file_path, "rb") as f:
+            raw = f.read(4)
+        if raw.startswith(b"\xef\xbb\xbf"):
+            return "utf-8-sig"
+        if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
+            return "utf-16"
+        return "utf-8"
+
+    _FALLBACK_ENCODINGS = ["utf-8", "utf-8-sig", "latin-1", "cp1252"]
+
     try:
-        initial_data_df = pd.read_json(data, lines=True)
+        detected = _detect_encoding(data) if isinstance(data, str) else "utf-8"
+        encodings = [detected] + [e for e in _FALLBACK_ENCODINGS if e.lower() != detected.lower()]
+        last_error = None
+        for encoding in encodings:
+            try:
+                initial_data_df = pd.read_json(data, lines=True, encoding=encoding)
+                break
+            except Exception as e:
+                last_error = e
+        else:
+            raise ValueError(
+                f"Failed to load data from {data}. Tried encodings: {encodings}. "
+                f"Please validate it is a valid jsonl data. Error: {str(last_error)}."
+            ) from last_error
+    except ValueError:
+        raise
     except Exception as e:
         raise ValueError(
             f"Failed to load data from {data}. Please validate it is a valid jsonl data. Error: {str(e)}."

--- a/src/promptflow-evals/promptflow/evals/evaluate/_utils.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_utils.py
@@ -43,8 +43,33 @@ def extract_workspace_triad_from_trace_provider(trace_provider: str):  # pylint:
 
 
 def load_jsonl(path):
-    with open(path, "r", encoding="utf-8") as f:
-        return [json.loads(line) for line in f.readlines()]
+    """Load jsonl file with BOM detection and fallback encodings."""
+    _FALLBACK_ENCODINGS = ["utf-8", "utf-8-sig", "latin-1", "cp1252"]
+
+    def _detect_encoding(file_path: str) -> str:
+        """Detect BOM markers to identify encoding, defaulting to utf-8."""
+        with open(file_path, "rb") as f:
+            raw = f.read(4)
+        if raw.startswith(b"\xef\xbb\xbf"):
+            return "utf-8-sig"
+        if raw.startswith(b"\xff\xfe") or raw.startswith(b"\xfe\xff"):
+            return "utf-16"
+        return "utf-8"
+
+    last_error = None
+    detected = _detect_encoding(path)
+    encodings = [detected] + [e for e in _FALLBACK_ENCODINGS if e.lower() != detected.lower()]
+    for encoding in encodings:
+        try:
+            with open(path, "r", encoding=encoding) as f:
+                return [json.loads(line) for line in f.readlines()]
+        except (UnicodeDecodeError, json.JSONDecodeError) as e:
+            last_error = e
+            continue
+
+    raise ValueError(
+        f"Failed to load data from {path}. Tried encodings: {encodings}. Error: {str(last_error)}."
+    ) from last_error
 
 
 def _azure_pf_client_and_triad(trace_destination):

--- a/src/promptflow-evals/tests/evals/unittests/data/utf8sig_test_data.jsonl
+++ b/src/promptflow-evals/tests/evals/unittests/data/utf8sig_test_data.jsonl
@@ -1,0 +1,2 @@
+﻿{"question": "\u3053\u3093\u306b\u3061\u306f", "answer": "hello", "ground_truth": "hello"}
+{"question": "caf\u00e9", "answer": "coffee", "ground_truth": "coffee"}

--- a/src/promptflow-evals/tests/evals/unittests/test_evaluate.py
+++ b/src/promptflow-evals/tests/evals/unittests/test_evaluate.py
@@ -123,6 +123,16 @@ class TestEvaluate:
         assert "Failed to load data from " in exc_info.value.args[0]
         assert "Please validate it is a valid jsonl data" in exc_info.value.args[0]
 
+    def test_evaluate_utf8_sig_encoding(self):
+        """Test that utf-8-sig (BOM) encoded jsonl files load correctly. Fixes #3670."""
+        utf8sig_file = _get_file("utf8sig_test_data.jsonl")
+        # Should NOT raise - previously crashed with ValueError: Expected object or value
+        result = evaluate(
+            data=utf8sig_file,
+            evaluators={"f1": F1ScoreEvaluator()},
+        )
+        assert result is not None
+
     def test_evaluate_missing_required_inputs(self, missing_columns_jsonl_file):
         with pytest.raises(ValueError) as exc_info:
             evaluate(data=missing_columns_jsonl_file, evaluators={"g": F1ScoreEvaluator()})


### PR DESCRIPTION
Fixes #3670

The eval SDK only read JSONL files as UTF-8. If your data had a BOM (utf-8-sig) 
— common for multilingual content generated on Windows — it failed immediately 
with `ValueError: Expected object or value`. Not helpful.

The fix adds BOM detection before reading and a fallback chain 
(utf-8 → utf-8-sig → latin-1 → cp1252) so the loader handles real-world 
files without requiring users to re-encode their data.

Three files touched:

- `promptflow/_utils/load_data.py` — `_pd_read_file()` now detects encoding 
  before calling `pd.read_json()` on `.jsonl` files
- `evaluate/_evaluate.py` — `_validate_and_load_data()` gets the same treatment
- `evaluate/_utils.py` — `load_jsonl()` updated with BOM detection + fallback

Added a utf-8-sig encoded test file with multilingual content and a unit test 
that would have caught this from the start.

---

## Checklist
- [x] No breaking changes
- [x] Read the contribution guidelines
- [x] New dependencies are MIT compatible
- [ ] CHANGELOG updated
- [x] Test coverage included for the change