### PR TITLE
fix(local_storage): silence FutureWarning from fillna on numeric output columns

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py
@@ -513,6 +513,7 @@ class LocalStorageOperations(AbstractBatchRunStorage):
             # if all line runs are failed, no need to fill
             if len(outputs) > 0:
                 outputs = self._outputs_padding(outputs, inputs[LINE_NUMBER].tolist())
+                outputs = outputs.astype(object)
                 outputs.fillna(value="(Failed)", inplace=True)  # replace nan with explicit prompt
                 outputs = outputs.set_index(LINE_NUMBER)
         return inputs, outputs

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py
@@ -34,3 +34,22 @@ class TestLocalStorageOperations:
         assert df_with_padding.iloc[0].to_dict() == {LINE_NUMBER: 1, "col": "a"}
         assert df_with_padding.iloc[1].to_dict() == {LINE_NUMBER: 2, "col": "b"}
         assert df_with_padding.iloc[2].to_dict() == {LINE_NUMBER: 4, "col": ""}
+
+    def test_outputs_padding_numeric_column_no_future_warning(self) -> None:
+        # Regression for issue #2702: fillna("(Failed)") on a numeric (float64) column
+        # raised FutureWarning in newer pandas.  Casting to object dtype first silences it.
+        data = [
+            {LINE_NUMBER: 1, "score": 0.9},
+            {LINE_NUMBER: 2, "score": 0.8},
+        ]
+        df = pd.DataFrame(data)  # "score" column is float64
+
+        df_with_padding = LocalStorageOperations._outputs_padding(df, inputs_line_numbers=[0, 1, 2, 3])
+        with pytest.warns(None) as warning_list:
+            result = df_with_padding.astype(object)
+            result.fillna(value="(Failed)", inplace=True)
+        assert len(warning_list) == 0, "No FutureWarning should be raised after astype(object)"
+        assert result.iloc[0]["score"] == "(Failed)"
+        assert result.iloc[1]["score"] == 0.9
+        assert result.iloc[2]["score"] == 0.8
+        assert result.iloc[3]["score"] == "(Failed)"


### PR DESCRIPTION
**Please describe the purpose of this pull request.**

Fixes #2702 — `load_inputs_and_outputs` emits a pandas `FutureWarning` whenever a flow run has failed lines and the outputs DataFrame contains numeric columns (e.g. `float64` scores):

```
FutureWarning: Setting an item of incompatible dtype is deprecated and will raise an error
in a future version of pandas. Value '(Failed)' has dtype incompatible with float64
```

**Root cause:** `outputs.fillna(value="(Failed)", inplace=True)` attempts to store a string into float64/int64 columns.  In pandas ≥ 2.1 this triggers a `FutureWarning`; in a future major release it will become an error.

**Fix:** Cast the DataFrame to `object` dtype with `astype(object)` before calling `fillna`.  An `object`-dtype DataFrame accepts any Python value in any cell, so the subsequent `fillna` inserts the `"(Failed)"` string cleanly, without type coercion or downcasting.

## Summary

- `src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py`:  
  add `outputs = outputs.astype(object)` immediately before the `fillna` call (1 line inserted)
- `src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py`:  
  add `test_outputs_padding_numeric_column_no_future_warning` that constructs a float64 DataFrame, pads it, and asserts the `astype(object).fillna(...)` pattern raises zero `FutureWarning`s

**How to test**

```bash
# Standalone verification (no database / Azure credentials required)
python3 -c "
import pandas as pd, warnings
LINE_NUMBER = '_line_number'
data = [{LINE_NUMBER: 1, 'score': 0.9}, {LINE_NUMBER: 2, 'score': 0.8}]
outputs = pd.DataFrame(data)
pad = pd.DataFrame({LINE_NUMBER: [0, 3]})
outputs = pd.concat([outputs, pad], ignore_index=True).sort_values(LINE_NUMBER).reset_index(drop=True)
with warnings.catch_warnings(record=True) as w:
    warnings.simplefilter('always')
    outputs = outputs.astype(object)
    outputs.fillna(value='(Failed)', inplace=True)
    fw = [x for x in w if issubclass(x.category, FutureWarning)]
    assert len(fw) == 0, fw
assert outputs.iloc[0]['score'] == '(Failed)'
assert outputs.iloc[1]['score'] == 0.9
print('=== LOCAL_TEST_PASSED ===')
"
```

```
=== LOCAL_TEST_PASSED ===
```

**Have you tested this PR?**

```
$ python3 -m black --line-length=120 --check \
    src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py \
    src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py
All done! ✨ 🍰 ✨
2 files would be left unchanged.

$ python3 -m flake8 --max-line-length=120 \
    src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py
(no output — clean)
```

**Related issues or PRs**

Fixes #2702

**Is your PR over 500 lines of code?**

No — 2 files changed, 20 insertions(+).

**Additional context**

AI disclosure (per Microsoft open-source guidelines): this PR was authored with AI assistance (Claude Code) and reviewed for correctness. The change is a single-line insertion (`outputs = outputs.astype(object)`) in a pandas DataFrame method call — trivially verifiable from the diff.