### PR TITLE
fix: guard against empty/filtered LLM responses in examples and tests

### DIFF
--- a/examples/flex-flows/basic/llm.py
+++ b/examples/flex-flows/basic/llm.py
@@ -53,6 +53,8 @@ def my_llm_tool(
     )
 
     # get first element because prompt is single.
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content
 
 

--- a/examples/flows/evaluation/eval-multi-turn-metrics-maf/workflow.py
+++ b/examples/flows/evaluation/eval-multi-turn-metrics-maf/workflow.py
@@ -104,6 +104,8 @@ class MultiTurnMetricsExecutor(Executor):
             presence_penalty=0,
             frequency_penalty=0,
         )
+        if not response.choices or response.choices[0].message is None:
+            return ""
         return response.choices[0].message.content or ""
 
     async def _eval_answer_relevance(self, conversation: str) -> Optional[float]:

--- a/examples/flows/evaluation/eval-qna-non-rag-maf/workflow.py
+++ b/examples/flows/evaluation/eval-qna-non-rag-maf/workflow.py
@@ -115,6 +115,8 @@ class QnaNonRagExecutor(Executor):
             temperature=0, top_p=1, max_tokens=1,
             presence_penalty=0, frequency_penalty=0,
         )
+        if not response.choices or response.choices[0].message is None:
+            return ""
         return response.choices[0].message.content or ""
 
     async def _embed(self, text: str) -> List[float]:

--- a/examples/flows/evaluation/eval-qna-rag-metrics-maf/workflow.py
+++ b/examples/flows/evaluation/eval-qna-rag-metrics-maf/workflow.py
@@ -122,6 +122,8 @@ class QnaRagMetricsExecutor(Executor):
             temperature=0, top_p=1, max_tokens=1000,
             presence_penalty=0, frequency_penalty=0,
         )
+        if not response.choices or response.choices[0].message is None:
+            return ""
         return response.choices[0].message.content or ""
 
     async def _eval_groundedness(self, question: str, answer: str, documents: str) -> Optional[dict]:

--- a/examples/flows/evaluation/eval-single-turn-metrics-maf/workflow.py
+++ b/examples/flows/evaluation/eval-single-turn-metrics-maf/workflow.py
@@ -155,6 +155,8 @@ class SingleTurnMetricsExecutor(Executor):
             messages=[{"role": "system", "content": prompt}],
             temperature=0, top_p=1, presence_penalty=0, frequency_penalty=0,
         )
+        if not response.choices or response.choices[0].message is None:
+            return ""
         return response.choices[0].message.content or ""
 
     async def _embed(self, text: str) -> List[float]:

--- a/examples/flows/standard/gen-docstring/azure_open_ai.py
+++ b/examples/flows/standard/gen-docstring/azure_open_ai.py
@@ -144,6 +144,8 @@ class ChatLLM(AOAI):
             stream=False,
             **kwargs,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         response_role = response.choices[0].message.role
         full_response = response.choices[0].message.content
         self.add_to_conversation(text, "user", conversation_id=conversation_id)
@@ -189,6 +191,8 @@ class ChatLLM(AOAI):
             stream=False,
             **kwargs,
         )
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         response_role = response.choices[0].message.role
         full_response = response.choices[0].message.content
         self.add_to_conversation(text, "user", conversation_id=conversation_id)

--- a/examples/tutorials/tracing/custom-otlp-collector/llm.py
+++ b/examples/tutorials/tracing/custom-otlp-collector/llm.py
@@ -40,6 +40,8 @@ def my_llm_tool(prompt: str, deployment_name: str) -> str:
     )
 
     # get first element because prompt is single.
+    if not response.choices or response.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     return response.choices[0].message.content
 
 

--- a/examples/tutorials/tracing/math_to_code.py
+++ b/examples/tutorials/tracing/math_to_code.py
@@ -69,6 +69,8 @@ def code_gen(client: AzureOpenAI, question: str) -> str:
             {"role": "user", "content": question},
         ],
     )
+    if not completion.choices or completion.choices[0].message is None:
+        raise ValueError("LLM returned empty or filtered response")
     raw_code = completion.choices[0].message.content
     result = code_refine(raw_code)
     return result

--- a/src/promptflow-evals/samples/evaluate-target/askwiki/askwiki.py
+++ b/src/promptflow-evals/samples/evaluate-target/askwiki/askwiki.py
@@ -161,6 +161,8 @@ def augmented_qa(question, context):
             model=os.environ.get("AZURE_OPENAI_DEPLOYMENT"), messages=messages, temperature=0.7, max_tokens=800
         )
 
+        if not response.choices or response.choices[0].message is None:
+            raise ValueError("LLM returned empty or filtered response")
         return response.choices[0].message.content
 
 

--- a/src/promptflow-tracing/tests/e2etests/simple_functions.py
+++ b/src/promptflow-tracing/tests/e2etests/simple_functions.py
@@ -83,6 +83,8 @@ def openai_chat(connection: dict, prompt: str, stream: bool = False):
                     yield chunk.choices[0].delta.content or ""
 
         return "".join(generator())
+    if not response.choices or response.choices[0].message is None:
+        return ""
     return response.choices[0].message.content or ""
 
 
@@ -117,6 +119,8 @@ async def openai_chat_async(connection: dict, prompt: str, stream: bool = False)
                     yield chunk.choices[0].delta.content or ""
 
         return "".join([chunk async for chunk in generator()])
+    if not response.choices or response.choices[0].message is None:
+        return ""
     return response.choices[0].message.content or ""
 
 
@@ -195,4 +199,6 @@ def prompt_tpl_chat(connection: dict, prompt_tpl: str, stream: bool = False, **k
                     yield chunk.choices[0].delta.content or ""
 
         return "".join(generator())
+    if not response.choices or response.choices[0].message is None:
+        return ""
     return response.choices[0].message.content or ""


### PR DESCRIPTION
## What

Adds null checks before accessing `choices[0].message` in 10 example/test files.

**Files changed:**
- `examples/flex-flows/basic/llm.py`
- `examples/tutorials/tracing/custom-otlp-collector/llm.py`
- `examples/tutorials/tracing/math_to_code.py`
- `examples/flows/standard/gen-docstring/azure_open_ai.py` (sync + async)
- `examples/flows/evaluation/eval-qna-rag-metrics-maf/workflow.py`
- `examples/flows/evaluation/eval-multi-turn-metrics-maf/workflow.py`
- `examples/flows/evaluation/eval-single-turn-metrics-maf/workflow.py`
- `examples/flows/evaluation/eval-qna-non-rag-maf/workflow.py`
- `src/promptflow-evals/samples/evaluate-target/askwiki/askwiki.py`
- `src/promptflow-tracing/tests/e2etests/simple_functions.py`

## Why

The OpenAI SDK can return two silent failure modes that cause unhandled crashes:

1. **`IndexError`** — `choices` is an empty list (`[]`) when the provider returns no completions
2. **`AttributeError`** — `choices[0].message` is `None` when content is filtered (e.g. Gemini returns HTTP 200 with `PROHIBITED_CONTENT` finish reason). The `or ""` fallback never fires because the crash happens first, on `.content`.

These example files are reference material that developers copy into production code, so fixing them here prevents the pattern from propagating.

## Fix

For raise-on-failure cases:
```python
if not response.choices or response.choices[0].message is None:
    raise ValueError("LLM returned empty or filtered response")
return response.choices[0].message.content
```

For return-empty cases (`_llm_call` in evaluation workflows):
```python
if not response.choices or response.choices[0].message is None:
    return ""
return response.choices[0].message.content or ""
```

Detected by [pact](https://github.com/qizwiz/pact) static analysis.