### PR TITLE
docs: fix promptflow docstring typos

### DIFF
--- a/src/promptflow-core/promptflow/_core/flow_execution_context.py
+++ b/src/promptflow-core/promptflow/_core/flow_execution_context.py
@@ -206,7 +206,7 @@ class FlowExecutionContext(ThreadLocalSingleton):
             raise ToolExecutionError(node_name=node_name, module=module) from e
 
     def bypass_node(self, node: Node):
-        """Update teh bypassed node run info."""
+        """Update the bypassed node run info."""
         node_run_id = self._generate_node_run_id(node)
         flow_logger.info(f"Bypassing node {node.name}. node run id: {node_run_id}")
         parent_run_id = f"{self._run_id}_{self._line_number}" if self._line_number is not None else self._run_id

--- a/src/promptflow-core/promptflow/executor/_service/contracts/batch_request.py
+++ b/src/promptflow-core/promptflow/executor/_service/contracts/batch_request.py
@@ -11,7 +11,7 @@ from promptflow.executor._service.contracts.execution_request import BaseExecuti
 
 
 class InitializationRequest(BaseExecutionRequest):
-    """Request model for teh batch run initialization."""
+    """Request model for the batch run initialization."""
 
     worker_count: Optional[int] = None
     line_timeout_sec: Optional[int] = LINE_TIMEOUT_SEC


### PR DESCRIPTION
## Problem
Two promptflow docstrings contain the typo `teh`, which shows up in source documentation/help surfaces.

## Solution
Correct `teh` to `the` in the affected docstrings.

## Validation
- `git diff --check`
- `python3 -m py_compile src/promptflow-core/promptflow/_core/flow_execution_context.py src/promptflow-core/promptflow/executor/_service/contracts/batch_request.py`
- Source assertion that the typo no longer appears in the touched files

Confidence: 85/100 (docs/comment typo; directly verifiable and limited to docstrings)