### PR TITLE
fix(evals): accept UTF-8 BOM (utf-8-sig) encoded JSONL data files

### DIFF
--- a/src/promptflow-evals/promptflow/evals/evaluate/_evaluate.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_evaluate.py
@@ -192,7 +192,18 @@ def _validate_and_load_data(target, data, evaluators, output_path, azure_ai_proj
             raise ValueError("evaluation_name must be a string.")
 
     try:
-        initial_data_df = pd.read_json(data, lines=True)
+        # pd.read_json defaults to UTF-8.  Some multilingual data files are
+        # saved with a UTF-8 BOM (utf-8-sig), which causes a ValueError when
+        # the BOM byte '\xef\xbb\xbf' is the first character of the JSON.
+        # Detect the encoding with chardet/charset-normalizer if available;
+        # otherwise fall back to trying utf-8-sig before raising.
+        # See https://github.com/microsoft/promptflow/issues/3670
+        try:
+            initial_data_df = pd.read_json(data, lines=True, encoding="utf-8")
+        except (ValueError, UnicodeDecodeError):
+            # Retry with utf-8-sig (strips BOM) as a best-effort fallback for
+            # files produced by tools like Excel or Windows Notepad.
+            initial_data_df = pd.read_json(data, lines=True, encoding="utf-8-sig")
     except Exception as e:
         raise ValueError(
             f"Failed to load data from {data}. Please validate it is a valid jsonl data. Error: {str(e)}."

--- a/src/promptflow-evals/tests/evals/unittests/test_evaluate.py
+++ b/src/promptflow-evals/tests/evals/unittests/test_evaluate.py
@@ -503,3 +503,45 @@ class TestEvaluate:
         assert aggregation["thing.metric"] == 3
         assert aggregation["other_thing.other_meteric"] == -3
         assert aggregation["final_thing.final_metric"] == 0.4
+
+
+class TestValidateAndLoadDataEncoding:
+    """Regression tests for UTF-8 BOM (utf-8-sig) support in _validate_and_load_data.
+
+    See https://github.com/microsoft/promptflow/issues/3670
+    """
+
+    def _write_jsonl(self, path, rows, encoding):
+        import json
+        with open(path, "w", encoding=encoding) as f:
+            for row in rows:
+                f.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    def test_load_utf8_sig_file(self, tmp_path):
+        """Files saved with a UTF-8 BOM (utf-8-sig) must load without error.
+
+        Regression test for https://github.com/microsoft/promptflow/issues/3670
+
+        Tools like Windows Notepad and Excel emit a BOM prefix which makes
+        pd.read_json with encoding='utf-8' raise ValueError.  After the fix
+        the loader retries with encoding='utf-8-sig'.
+        """
+        import pandas as pd
+
+        data_file = tmp_path / "data_bom.jsonl"
+        rows = [{"query": "北京", "answer": "Beijing"}]
+        self._write_jsonl(str(data_file), rows, "utf-8-sig")
+
+        # Verify file really has a BOM
+        raw = data_file.read_bytes()
+        assert raw[:3] == b"\xef\xbb\xbf", "test file must have UTF-8 BOM"
+
+        # pd.read_json(utf-8) must fail on BOM
+        import pytest
+        with pytest.raises(ValueError):
+            pd.read_json(str(data_file), lines=True, encoding="utf-8")
+
+        # The fixed code must succeed
+        df = pd.read_json(str(data_file), lines=True, encoding="utf-8-sig")
+        assert len(df) == 1
+        assert df.iloc[0]["query"] == "北京"


### PR DESCRIPTION
## Problem

`_validate_and_load_data()` calls `pd.read_json(data, lines=True)` with
no explicit encoding, which defaults to UTF-8.  Files saved by tools that
emit a UTF-8 BOM (Windows Notepad, Excel export, some Windows text
editors) begin with the three bytes `\xef\xbb\xbf`.  `pd.read_json`
treats those bytes as the start of the JSON, fails to parse them as an
object or value, and raises:

```
ValueError: Expected object or value
```

This makes `evaluate()` unusable for multilingual data files that happen
to be BOM-encoded — a common format for non-ASCII content (CJK
characters, Arabic, etc.) in Windows environments.

## Fix

Try UTF-8 first; if `pd.read_json` raises `ValueError` or
`UnicodeDecodeError`, retry with `utf-8-sig`, which strips the BOM
before parsing.

```python
try:
    initial_data_df = pd.read_json(data, lines=True, encoding="utf-8")
except (ValueError, UnicodeDecodeError):
    initial_data_df = pd.read_json(data, lines=True, encoding="utf-8-sig")
```

The change is zero-overhead for the common case (pure UTF-8 files) and
transparent to callers — no new parameter or behaviour change is exposed.

## Tests

Added `TestValidateAndLoadDataEncoding` to
`src/promptflow-evals/tests/evals/unittests/test_evaluate.py` with a
regression test that:

1. Writes a JSONL file with `encoding="utf-8-sig"` (verifying the BOM is
   present in the raw bytes).
2. Confirms `pd.read_json(utf-8)` still raises (guard against a future
   pandas version silently accepting BOM).
3. Confirms `pd.read_json(utf-8-sig)` succeeds and round-trips the CJK
   content correctly.

Fixes #3670