### PR TITLE
fix(parallel): add maxsplit=1 to prevent ValueError on values containing '='

### DIFF
--- a/src/promptflow-parallel/promptflow/parallel/_config/parser.py
+++ b/src/promptflow-parallel/promptflow/parallel/_config/parser.py
@@ -85,7 +85,7 @@ def _parse_prefixed_args(args: List[str], prefix: str) -> Dict[str, str]:
     for _, arg in enumerate(args):
         if arg.startswith(prefix):
             if "=" in arg:
-                arg_name, arg_value = arg.split("=")
+                arg_name, arg_value = arg.split("=", 1)
                 if len(arg_name) > len(prefix):
                     parsed[arg_name[len(prefix) :]] = arg_value
             elif pre_arg_name is None:

--- a/src/promptflow-parallel/tests/parallel/unittests/_config/test_parse.py
+++ b/src/promptflow-parallel/tests/parallel/unittests/_config/test_parse.py
@@ -3,7 +3,7 @@
 # ---------------------------------------------------------
 from pathlib import Path
 
-from promptflow.parallel._config.parser import parse
+from promptflow.parallel._config.parser import _parse_prefixed_args, parse
 
 
 def test_parse_correct_type():
@@ -51,3 +51,9 @@ def test_parse_correct_type():
     assert config.debug_output_dir == Path("/test_debug")
     assert config.logging_level == "INFO"
     assert not config.is_debug_enabled
+
+
+def test_parse_prefixed_args_value_with_equals():
+    # Values containing '=' (e.g. base64 padding) must not crash with ValueError.
+    result = _parse_prefixed_args(["--pf_input_token=SGVsbG8gV29ybGQ="], "--pf_input_")
+    assert result == {"token": "SGVsbG8gV29ybGQ="}


### PR DESCRIPTION
## What's broken

`_parse_prefixed_args()` in `src/promptflow-parallel/promptflow/parallel/_config/parser.py` crashes with `ValueError: too many values to unpack (expected 2)` whenever an argument value contains the `=` character. This affects base64-encoded values (which use `=` as padding), URLs with query strings, and any other value embedding `=`. For example, passing `--pf_input_token=SGVsbG8gV29ybGQ=` (base64 for "Hello World") raises the error immediately.

## Why it happens

Line 88 calls `arg.split("=")` with no `maxsplit`, so a value like `name=base64==` splits into three elements and the two-variable unpack fails.

## Fix

Changed `arg.split("=")` to `arg.split("=", 1)` so only the first `=` is used as the name/value delimiter. The rest of the string is preserved intact as the value.

## Test

Added `test_parse_prefixed_args_value_with_equals` to `tests/parallel/unittests/_config/test_parse.py`. It passes a base64-padded token argument and asserts the full value (including trailing `=`) is parsed correctly without raising.

Fixes #4174