### PR TITLE
fix(azure): handle DatastoreType ImportError from azure-ai-ml>=1.33.0

### DIFF
--- a/src/promptflow-azure/promptflow/azure/_storage/blob/client.py
+++ b/src/promptflow-azure/promptflow/azure/_storage/blob/client.py
@@ -6,7 +6,16 @@ from typing import Callable, Tuple
 
 from azure.ai.ml import MLClient
 from azure.ai.ml._azure_environments import _get_storage_endpoint_from_metadata
-from azure.ai.ml._restclient.v2022_10_01.models import DatastoreType
+try:
+    from azure.ai.ml._restclient.v2022_10_01.models import DatastoreType
+except ImportError:
+    # azure-ai-ml >= 1.33.0 removed this private versioned restclient module.
+    # Define the needed constants locally; the string values are part of the
+    # stable Azure REST API and have not changed.
+    class DatastoreType:  # type: ignore[no-redef]
+        AZURE_BLOB = "AzureBlob"
+        AZURE_DATA_LAKE_GEN2 = "AzureDataLakeGen2"
+        AZURE_FILE = "AzureFile"
 from azure.ai.ml.constants._common import LONG_URI_FORMAT, STORAGE_ACCOUNT_URLS
 from azure.ai.ml.entities._credentials import AccountKeyConfiguration
 from azure.ai.ml.entities._datastore.datastore import Datastore

--- a/src/promptflow-azure/promptflow/azure/operations/_artifact_utilities.py
+++ b/src/promptflow-azure/promptflow/azure/operations/_artifact_utilities.py
@@ -13,7 +13,16 @@ from typing import Dict, Optional, TypeVar, Union
 from azure.ai.ml._artifacts._blob_storage_helper import BlobStorageClient
 from azure.ai.ml._artifacts._gen2_storage_helper import Gen2StorageClient
 from azure.ai.ml._azure_environments import _get_storage_endpoint_from_metadata
-from azure.ai.ml._restclient.v2022_10_01.models import DatastoreType
+try:
+    from azure.ai.ml._restclient.v2022_10_01.models import DatastoreType
+except ImportError:
+    # azure-ai-ml >= 1.33.0 removed this private versioned restclient module.
+    # Define the needed constants locally; the string values are part of the
+    # stable Azure REST API and have not changed.
+    class DatastoreType:  # type: ignore[no-redef]
+        AZURE_BLOB = "AzureBlob"
+        AZURE_DATA_LAKE_GEN2 = "AzureDataLakeGen2"
+        AZURE_FILE = "AzureFile"
 from azure.ai.ml._scope_dependent_operations import OperationScope
 from azure.ai.ml._utils._arm_id_utils import (
     AMLNamedArmId,


### PR DESCRIPTION
# Description

`azure-ai-ml` 1.33.0 removed the private module `azure.ai.ml._restclient.v2022_10_01`, causing a `ModuleNotFoundError` when importing `DatastoreType` in two files:
- `promptflow/azure/_storage/blob/client.py`
- `promptflow/azure/operations/_artifact_utilities.py`

**Fix:** wrap the import in a `try/except ImportError` and fall back to a locally-defined `DatastoreType` class. The string values are stable Azure REST API constants unchanged across versions.

Fixes #4176.

# All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**