### PR TITLE
fix(devkit): avoid dtype warning for failed outputs

### DIFF
--- a/src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py
+++ b/src/promptflow-devkit/promptflow/_sdk/operations/_local_storage_operations.py
@@ -504,6 +504,13 @@ class LocalStorageOperations(AbstractBatchRunStorage):
         res = res.sort_values(by=LINE_NUMBER, ascending=True)
         return res
 
+    @staticmethod
+    def _fill_failed_outputs(df: "DataFrame") -> "DataFrame":
+        output_columns = [column for column in df.columns if column != LINE_NUMBER]
+        df = df.copy()
+        df[output_columns] = df[output_columns].astype(object)
+        return df.fillna(value="(Failed)")
+
     def load_inputs_and_outputs(self) -> Tuple["DataFrame", "DataFrame"]:
         if not self._sdk_inputs_path.is_file() or not self._sdk_output_path.is_file():
             inputs, outputs = self._collect_io_from_debug_info()
@@ -513,7 +520,7 @@ class LocalStorageOperations(AbstractBatchRunStorage):
             # if all line runs are failed, no need to fill
             if len(outputs) > 0:
                 outputs = self._outputs_padding(outputs, inputs[LINE_NUMBER].tolist())
-                outputs.fillna(value="(Failed)", inplace=True)  # replace nan with explicit prompt
+                outputs = self._fill_failed_outputs(outputs)  # replace nan with explicit prompt
                 outputs = outputs.set_index(LINE_NUMBER)
         return inputs, outputs
 

--- a/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py
+++ b/src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py
@@ -2,6 +2,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # ---------------------------------------------------------
 
+import warnings
+
 import pandas as pd
 import pytest
 
@@ -34,3 +36,18 @@ class TestLocalStorageOperations:
         assert df_with_padding.iloc[0].to_dict() == {LINE_NUMBER: 1, "col": "a"}
         assert df_with_padding.iloc[1].to_dict() == {LINE_NUMBER: 2, "col": "b"}
         assert df_with_padding.iloc[2].to_dict() == {LINE_NUMBER: 4, "col": ""}
+
+    def test_outputs_padding_fill_failed_without_dtype_warning(self) -> None:
+        data = [
+            {LINE_NUMBER: 1, "score": 0.5},
+        ]
+        df = pd.DataFrame(data)
+
+        df_with_padding = LocalStorageOperations._outputs_padding(df, inputs_line_numbers=[0, 1])
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            df_with_padding = LocalStorageOperations._fill_failed_outputs(df_with_padding)
+
+        assert len(caught_warnings) == 0
+        assert df_with_padding.iloc[0].to_dict() == {LINE_NUMBER: 0, "score": "(Failed)"}
+        assert df_with_padding.iloc[1].to_dict() == {LINE_NUMBER: 1, "score": 0.5}


### PR DESCRIPTION
## Summary
- Fill missing failed output values after converting output columns to object dtype.
- Preserve the line-number column while avoiding pandas incompatible-dtype FutureWarning.
- Add a regression test for numeric output columns with padded failed rows.

## Root cause
When `_outputs_padding` adds missing output rows, numeric output columns contain `NaN`. Filling the whole dataframe with the string `"(Failed)"` attempts to write a string into a float column, which triggers pandas' incompatible-dtype FutureWarning and will become an error in a future pandas release.

Fixes #2702

## Validation
- `src/promptflow-evals/.venv/bin/python -m pytest src/promptflow-devkit/tests/sdk_cli_test/unittests/test_local_storage_operations.py -q` (2 passed)
