### PR TITLE
ci: pin all GitHub Actions to full commit SHAs to prevent supply-chain attacks

### DIFF
--- a/.github/workflows/build_doc_ci.yml
+++ b/.github/workflows/build_doc_ci.yml
@@ -28,7 +28,7 @@ jobs:
     name: Build Doc
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
 
@@ -61,7 +61,7 @@ jobs:
     name: Build Link Check
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
         with:
           submodules: true
 

--- a/.github/workflows/build_msi_installer.yml
+++ b/.github/workflows/build_msi_installer.yml
@@ -46,12 +46,12 @@ jobs:
           echo "set_msi_private_version: ${{ inputs.set_msi_private_version }}"
 
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: true
 
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.1
+        uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506 # v1.1
 
       - name: Install WIX Toolset
         shell:  pwsh
@@ -181,7 +181,7 @@ jobs:
           msbuild /t:rebuild /p:Configuration=Release /p:Platform=x64 promptflow.wixproj
         shell: pwsh
 
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}

--- a/.github/workflows/check_enforcer.yml
+++ b/.github/workflows/check_enforcer.yml
@@ -11,7 +11,7 @@ jobs:
       checks: read
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
       - run: env | sort >> $GITHUB_OUTPUT

--- a/.github/workflows/create_promptflow_release_branch.yml
+++ b/.github/workflows/create_promptflow_release_branch.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
       - name: create branch
         run: |
           set -x -e

--- a/.github/workflows/create_promptflow_release_tag.yml
+++ b/.github/workflows/create_promptflow_release_tag.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: create branch
         run: |
@@ -66,7 +66,7 @@ jobs:
 
       - name: create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -77,7 +77,7 @@ jobs:
           prerelease: false
 
       - name: upload asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: 3.9
 

--- a/.github/workflows/flowdag_schema_check.yml
+++ b/.github/workflows/flowdag_schema_check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - run: env | sort >> $GITHUB_OUTPUT
       - name: Python Setup - ubuntu-latest - Python Version 3.9
         uses: "./.github/actions/step_create_python_environment"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: apply a label to pull request from fork
       if: ${{ github.event.pull_request.head.repo.full_name != 'microsoft/promptflow' }}
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
       with:
         script: |
           github.rest.issues.addLabels({

--- a/.github/workflows/promptflow-core-test.yml
+++ b/.github/workflows/promptflow-core-test.yml
@@ -37,11 +37,11 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         run: |
           poetry install -E executor-service --with ci,test
@@ -56,7 +56,7 @@ jobs:
           echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
       - name: Azure login (non pull_request workflow)
         if: github.event_name != 'pull_request'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -75,7 +75,7 @@ jobs:
         run: poetry run pytest ./tests/core --cov=promptflow --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -96,11 +96,11 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         run: |
           poetry install -E azureml-serving --with ci,test
@@ -112,7 +112,7 @@ jobs:
           echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
       - name: Azure login (non pull_request workflow)
         if: github.event_name != 'pull_request'
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -131,7 +131,7 @@ jobs:
         run: poetry run pytest ./tests/azureml-serving --cov=promptflow --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -147,16 +147,16 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           path: artifacts
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           check_name: promptflow-core test result
           comment_title: promptflow-core test result
           files: "artifacts/**/test-results.xml"  # align with `--junit-xml` in pyproject.toml
 #     TODO: Enable coverage check after core test fully setup
-#      - uses: irongut/CodeCoverageSummary@v1.3.0
+#      - uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
 #        with:
 #          filename: "artifacts/report-ubuntu-latest-py3.9/coverage.xml"
 #          badge: true

--- a/.github/workflows/promptflow-evals-e2e-test-azure.yml
+++ b/.github/workflows/promptflow-evals-e2e-test-azure.yml
@@ -30,15 +30,15 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set test mode
         # Always run in replay mode for now until we figure out the test resource to run live mode
         run: echo "PROMPT_FLOW_TEST_MODE=replay" >> $GITHUB_ENV
         #run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         run: poetry install --only test
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -58,7 +58,7 @@ jobs:
       - name: generate end-to-end test config from secret
         run: echo '${{ secrets.PF_EVALS_E2E_TEST_CONFIG }}' >> connections.json
         working-directory: ${{ env.WORKING_DIRECTORY }}
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.PF_EVALS_SP_CLIENT_ID }}
           tenant-id: ${{ secrets.PF_EVALS_SP_TENANT_ID }}
@@ -70,7 +70,7 @@ jobs:
           poetry run python ../../scripts/code_qa/report_to_app_insights.py --activity e2e_tests_azure --junit-xml test-results.xml --git-hub-action-run-id ${{ github.run_id }} --git-hub-workflow ${{ github.workflow }} --git-hub-action ${{ github.action }} --git-branch ${{ github.ref }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -86,15 +86,15 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           path: artifacts
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           check_name: promptflow-evals test result
           comment_title: promptflow-evals test result
           files: "artifacts/**/test-results.xml"  # align with `--junit-xml` in pyproject.toml
-      - uses: irongut/CodeCoverageSummary@v1.3.0
+      - uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: "artifacts/report-ubuntu-latest-py3.11/coverage.xml"
           badge: true

--- a/.github/workflows/promptflow-evals-e2e-test-local.yml
+++ b/.github/workflows/promptflow-evals-e2e-test-local.yml
@@ -30,15 +30,15 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set test mode
         # Always run in replay mode for now until we figure out the test resource to run live mode
         run: echo "PROMPT_FLOW_TEST_MODE=replay" >> $GITHUB_ENV
         #run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         run: poetry install --only test
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -57,7 +57,7 @@ jobs:
       - name: generate end-to-end test config from secret
         run: echo '${{ secrets.PF_EVALS_E2E_TEST_CONFIG }}' >> connections.json
         working-directory: ${{ env.WORKING_DIRECTORY }}
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.PF_EVALS_SP_CLIENT_ID }}
           tenant-id: ${{ secrets.PF_EVALS_SP_TENANT_ID }}
@@ -72,7 +72,7 @@ jobs:
           poetry run python ../../scripts/code_qa/report_to_app_insights.py --activity e2e_tests_local --junit-xml test-results.xml --git-hub-action-run-id ${{ github.run_id }} --git-hub-workflow ${{ github.workflow }} --git-hub-action ${{ github.action }} --git-branch ${{ github.ref }}
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -88,15 +88,15 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           path: artifacts
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           check_name: promptflow-evals test result
           comment_title: promptflow-evals test result
           files: "artifacts/**/test-results.xml"  # align with `--junit-xml` in pyproject.toml
-      - uses: irongut/CodeCoverageSummary@v1.3.0
+      - uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: "artifacts/report-ubuntu-latest-py3.11/coverage.xml"
           badge: true

--- a/.github/workflows/promptflow-evals-installation-test.yml
+++ b/.github/workflows/promptflow-evals-installation-test.yml
@@ -18,12 +18,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: snok/install-poetry@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: build
       run: poetry build
       working-directory: ${{ env.WORKING_DIRECTORY }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
       with:
         name: promptflow-evals
         path: ${{ env.WORKING_DIRECTORY }}/dist/promptflow_evals-*.whl
@@ -41,8 +41,8 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: promptflow-evals
           path: ${{ env.WORKING_DIRECTORY }}

--- a/.github/workflows/promptflow-evals-performance-test.yml
+++ b/.github/workflows/promptflow-evals-performance-test.yml
@@ -31,11 +31,11 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         run: poetry install --only test
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -57,7 +57,7 @@ jobs:
       - name: generate end-to-end test config from secret
         run: echo '${{ secrets.PF_EVALS_E2E_TEST_CONFIG }}' >> connections.json
         working-directory: ${{ env.WORKING_DIRECTORY }}
-      - uses: azure/login@v1
+      - uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.PF_EVALS_SP_CLIENT_ID }}
           tenant-id: ${{ secrets.PF_EVALS_SP_TENANT_ID }}

--- a/.github/workflows/promptflow-evals-unit-test.yml
+++ b/.github/workflows/promptflow-evals-unit-test.yml
@@ -26,11 +26,11 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         run: poetry install --only test
         working-directory: ${{ env.WORKING_DIRECTORY }}
@@ -53,7 +53,7 @@ jobs:
             poetry run pytest -m unittest --cov=promptflow --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --cov-fail-under=58
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -69,15 +69,15 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           path: artifacts
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           check_name: promptflow-evals test result
           comment_title: promptflow-evals test result
           files: "artifacts/**/test-results.xml"  # align with `--junit-xml` in pyproject.toml
-      - uses: irongut/CodeCoverageSummary@v1.3.0
+      - uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: "artifacts/report-ubuntu-latest-py3.9/coverage.xml"
           badge: true

--- a/.github/workflows/promptflow-executor-e2e-test.yml
+++ b/.github/workflows/promptflow-executor-e2e-test.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0
@@ -53,7 +53,7 @@ jobs:
         scriptPath: ${{ env.testWorkingDirectory }}
     - name: Upload Wheel
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: wheel
         path: |
@@ -73,7 +73,7 @@ jobs:
     - name: Set test mode
       run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0
@@ -84,7 +84,7 @@ jobs:
       with:
         pythonVersion: 3.9
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
         name: wheel
         path: artifacts
@@ -107,7 +107,7 @@ jobs:
         pip install .
       working-directory: ${{ env.RECORD_DIRECTORY }}
     - name: Azure Login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
         tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
       with:
         targetFolder: ${{ env.testWorkingDirectory }}
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@410541432439795d30db6501fb1d8178eb41e502 # v1
       id: cpu-cores
     - name: Run Coverage Test
       shell: pwsh
@@ -138,7 +138,7 @@ jobs:
           --disable-cov-branch
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: Test Results (Python 3.9) (OS ${{ matrix.os }})
         path: |
@@ -156,7 +156,7 @@ jobs:
     if: always()
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0

--- a/.github/workflows/promptflow-executor-unit-test.yml
+++ b/.github/workflows/promptflow-executor-unit-test.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0
@@ -51,7 +51,7 @@ jobs:
         scriptPath: ${{ env.testWorkingDirectory }}
     - name: Upload Wheel
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: wheel
         path: |
@@ -70,7 +70,7 @@ jobs:
     - name: Set test mode
       run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0
@@ -86,7 +86,7 @@ jobs:
       with:
         pythonVersion: 3.9
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
         name: wheel
         path: artifacts
@@ -109,7 +109,7 @@ jobs:
         pip install .
       working-directory: ${{ env.RECORD_DIRECTORY }}
     - name: Azure Login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
         tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -119,7 +119,7 @@ jobs:
       with:
         targetFolder: ${{ env.testWorkingDirectory }}
     - name: Get number of CPU cores
-      uses: SimenB/github-actions-cpu-cores@v1
+      uses: SimenB/github-actions-cpu-cores@410541432439795d30db6501fb1d8178eb41e502 # v1
       id: cpu-cores
     - name: Run Coverage Test
       shell: pwsh
@@ -138,7 +138,7 @@ jobs:
           --disable-cov-branch
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: Test Results (Python 3.9) (OS ${{ matrix.os }})
         path: |
@@ -157,7 +157,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0

--- a/.github/workflows/promptflow-global-config-test.yml
+++ b/.github/workflows/promptflow-global-config-test.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
         fetch-depth: 0
@@ -48,10 +48,10 @@ jobs:
         env | sort >> $GITHUB_OUTPUT
       id: display_env
       shell: bash -el {0}
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ steps.display_env.outputs.pyVersion }}
-    - uses: snok/install-poetry@v1
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: install test dependency group
       working-directory: ${{ env.WORKING_DIRECTORY }}
       run: |
@@ -73,7 +73,7 @@ jobs:
         poetry run pip show promptflow-azure
         poetry run pip show promptflow-tools
     - name: Azure Login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
         tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -94,7 +94,7 @@ jobs:
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: Test Results (Python ${{ steps.display_env.outputs.pyVersion }}) (OS ${{ matrix.os }})
         path: |
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       with:
         ref: ${{ github.event.pull_request.head.sha || github.ref }}
     - name: Publish Test Results

--- a/.github/workflows/promptflow-import-linter.yml
+++ b/.github/workflows/promptflow-import-linter.yml
@@ -17,12 +17,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: 3.11
-    - uses: snok/install-poetry@v1
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: Install all packages
       run: |
         touch src/promptflow-tracing/promptflow/__init__.py

--- a/.github/workflows/promptflow-parallel-e2e-test.yml
+++ b/.github/workflows/promptflow-parallel-e2e-test.yml
@@ -35,15 +35,15 @@ jobs:
       internal
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set test mode
         # Always run in replay mode for now until we figure out the test resource to run live mode
         run: echo "PROMPT_FLOW_TEST_MODE=replay" >> $GITHUB_ENV
         #run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install promptflow packages in editable mode
         run: |
           set -xe
@@ -57,7 +57,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: Test Results (Python ${{ matrix.python-version }}) (OS ${{ matrix.os }})
           path: |
@@ -75,7 +75,7 @@ jobs:
     if: always()
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Publish Test Results
       uses: "./.github/actions/step_publish_test_results"
       with:

--- a/.github/workflows/promptflow-parallel-unit-test.yml
+++ b/.github/workflows/promptflow-parallel-unit-test.yml
@@ -35,15 +35,15 @@ jobs:
       internal
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set test mode
         # Always run in replay mode for now until we figure out the test resource to run live mode
         run: echo "PROMPT_FLOW_TEST_MODE=replay" >> $GITHUB_ENV
         #run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install promptflow packages in editable mode
         run: |
           set -xe
@@ -57,7 +57,7 @@ jobs:
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: Test Results (Python ${{ matrix.python-version }}) (OS ${{ matrix.os }})
           path: |
@@ -75,7 +75,7 @@ jobs:
     if: always()
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Publish Test Results
       uses: "./.github/actions/step_publish_test_results"
       with:

--- a/.github/workflows/promptflow-release-testing-matrix.yml
+++ b/.github/workflows/promptflow-release-testing-matrix.yml
@@ -38,11 +38,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: checkout
-      uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: "3.9"
-    - uses: snok/install-poetry@v1
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - working-directory: ${{ env.TRACING_DIRECTORY }}
       run: poetry build -f wheel
     - working-directory: ${{ env.CORE_DIRECTORY }}
@@ -59,7 +59,7 @@ jobs:
       run: python ./setup.py bdist_wheel
 
     - name: Upload Wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: wheel
         path: |
@@ -87,16 +87,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Display and Set Environment Variables
       run:
         env | sort >> $GITHUB_OUTPUT
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.pythonVersion }}
-    - uses: snok/install-poetry@v1
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
         name: wheel
         path: ${{ env.WORKING_DIRECTORY }}/artifacts
@@ -117,7 +117,7 @@ jobs:
       run: poetry run pytest -m e2etest --tb=short
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: upload coverage report
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
       with:
         name: promptflow_tracing_tests report-${{ matrix.os }}-py${{ matrix.pythonVersion }}
         path: |
@@ -143,18 +143,18 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: wheel
           path: ${{ env.WORKING_DIRECTORY }}/artifacts
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -177,7 +177,7 @@ jobs:
         run: poetry run pytest ./tests/core --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: promptflow_core_tests report-${{ matrix.os }}-py${{ matrix.pythonVersion }}
           path: |
@@ -200,13 +200,13 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: wheel
           path: ${{ env.WORKING_DIRECTORY }}/artifacts
@@ -224,7 +224,7 @@ jobs:
         run: poetry run pytest ./tests/azureml-serving --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: promptflow_core_azureml_serving_tests report-${{ matrix.os }}-py${{ matrix.pythonVersion }}
           path: |
@@ -250,18 +250,18 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: wheel
           path: ${{ env.WORKING_DIRECTORY }}/artifacts
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -286,7 +286,7 @@ jobs:
         run: poetry run pytest ./tests/sdk_cli_test ./tests/sdk_pfs_test -n auto -m "unittest or e2etest" --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: promptflow_devkit_tests report-${{ matrix.os }}-py${{ matrix.pythonVersion }}
           path: |
@@ -312,18 +312,18 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           name: wheel
           path: ${{ env.WORKING_DIRECTORY }}/artifacts
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -350,7 +350,7 @@ jobs:
         run: poetry run pytest ./tests/sdk_cli_azure_test -n auto -m "unittest or e2etest" --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: promptflow_azure_tests report-${{ matrix.os }}-py${{ matrix.pythonVersion }}
           path: |
@@ -372,7 +372,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Display and Set Environment Variables
       run:
         env | sort >> $GITHUB_OUTPUT
@@ -382,7 +382,7 @@ jobs:
       with:
         pythonVersion: ${{ matrix.pythonVersion }}
     - name: Download Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
       with:
         name: wheel
         path: artifacts
@@ -392,7 +392,7 @@ jobs:
         pip install -e .
       working-directory: ${{ env.RECORD_DIRECTORY }}
     - name: Azure Login
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
         tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -440,7 +440,7 @@ jobs:
           -o "${{ github.workspace }}/test-results-executor-e2e.xml"
     - name: Upload pytest test results (Python ${{ matrix.pythonVersion }}) (OS ${{ matrix.os }})
       if: ${{ always() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: promptflow_executor_tests Test Results (Python ${{ matrix.pythonVersion }}) (OS ${{ matrix.os }})
         path: ${{ github.workspace }}/*.xml
@@ -459,10 +459,10 @@ jobs:
 
     steps:
       - name: Download Artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3
         with:
           path: artifacts
       - name: Publish Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v2
+        uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           files: "artifacts/**/test-*.xml"

--- a/.github/workflows/promptflow-sdk-cli-test.yml
+++ b/.github/workflows/promptflow-sdk-cli-test.yml
@@ -45,11 +45,11 @@ jobs:
       run: |
         echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
         echo "FILE_PATHS=$(if [[ "${{ inputs.filepath }}" == "" ]]; then echo "./tests/sdk_cli_test ./tests/sdk_pfs_test"; else echo ${{ inputs.filepath }}; fi)" >> $GITHUB_ENV
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
       with:
         python-version: ${{ matrix.pythonVersion }}
-    - uses: snok/install-poetry@v1
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: install test dependency group
       run: |
         set -xe
@@ -62,7 +62,7 @@ jobs:
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: Azure login (non pull_request workflow)
       if: github.event_name != 'pull_request'
-      uses: azure/login@v1
+      uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
       with:
         subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
         tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -85,7 +85,7 @@ jobs:
       working-directory: ${{ env.WORKING_DIRECTORY }}
     - name: Upload Test Results
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
       with:
         name: Test Results (Python ${{ matrix.pythonVersion }}) (OS ${{ matrix.os }})
         path: |
@@ -112,7 +112,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Publish Test Results
       uses: "./.github/actions/step_publish_test_results"
       with:

--- a/.github/workflows/promptflow-tracing-e2e-test.yml
+++ b/.github/workflows/promptflow-tracing-e2e-test.yml
@@ -23,12 +23,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: snok/install-poetry@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: build
       run: poetry build
       working-directory: ${{ env.WORKING_DIRECTORY }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
       with:
         name: promptflow-tracing
         path: ${{ env.WORKING_DIRECTORY }}/dist/promptflow_tracing-*.whl
@@ -46,14 +46,14 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: set test mode
         run: echo "PROMPT_FLOW_TEST_MODE=$(if [[ "${{ github.event_name }}" == "pull_request" ]]; then echo replay; else echo live; fi)" >> $GITHUB_ENV
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
-      - uses: actions/download-artifact@v4
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: promptflow-tracing
           path: ${{ env.WORKING_DIRECTORY }}
@@ -74,7 +74,7 @@ jobs:
         run: poetry run pytest -m e2etest --cov=promptflow --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -90,15 +90,15 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           path: artifacts
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           check_name: promptflow-tracing test result
           comment_title: promptflow-tracing test result
           files: "artifacts/**/test-results.xml"  # align with `--junit-xml` in pyproject.toml
-      - uses: irongut/CodeCoverageSummary@v1.3.0
+      - uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: "artifacts/report-ubuntu-latest-py3.9/coverage.xml"
           badge: true

--- a/.github/workflows/promptflow-tracing-unit-test.yml
+++ b/.github/workflows/promptflow-tracing-unit-test.yml
@@ -19,12 +19,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: snok/install-poetry@v1
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+    - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
     - name: build
       run: poetry build
       working-directory: ${{ env.WORKING_DIRECTORY }}
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
       with:
         name: promptflow-tracing
         path: ${{ env.WORKING_DIRECTORY }}/dist/promptflow_tracing-*.whl
@@ -42,12 +42,12 @@ jobs:
         shell: bash
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
-      - uses: actions/download-artifact@v4
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           name: promptflow-tracing
           path: ${{ env.WORKING_DIRECTORY }}
@@ -65,7 +65,7 @@ jobs:
         run: poetry run pytest -m unittest --cov=promptflow --cov-config=pyproject.toml --cov-report=term --cov-report=html --cov-report=xml --tb=short
         working-directory: ${{ env.WORKING_DIRECTORY }}
       - name: upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: report-${{ matrix.os }}-py${{ matrix.python-version }}
           path: |
@@ -81,15 +81,15 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v4
         with:
           path: artifacts
-      - uses: EnricoMi/publish-unit-test-result-action@v2
+      - uses: EnricoMi/publish-unit-test-result-action@d0a4676d0e0b938bc201470d88276b7c74c712b3 # v2
         with:
           check_name: promptflow-tracing test result
           comment_title: promptflow-tracing test result
           files: "artifacts/**/test-results.xml"  # align with `--junit-xml` in pyproject.toml
-      - uses: irongut/CodeCoverageSummary@v1.3.0
+      - uses: irongut/CodeCoverageSummary@51cc3a756ddcd398d447c044c02cb6aa83fdae95 # v1.3.0
         with:
           filename: "artifacts/report-ubuntu-latest-py3.9/coverage.xml"
           badge: true

--- a/.github/workflows/publish_doc.yml
+++ b/.github/workflows/publish_doc.yml
@@ -38,7 +38,7 @@ jobs:
     name: Build
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           submodules: true
 

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -11,14 +11,14 @@ jobs:
 
     steps:
       - name: checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
 
       - name: setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e # v2
         with:
           python-version: 3.9
 
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install pylint and azure-pylint-guidelines-checker
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |

--- a/.github/workflows/samples_configuration.yml
+++ b/.github/workflows/samples_configuration.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -72,7 +72,7 @@ jobs:
           papermill -k python configuration.ipynb configuration.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples

--- a/.github/workflows/samples_connections.yml
+++ b/.github/workflows/samples_connections.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/connections/bash_script.sh

--- a/.github/workflows/samples_connections_connection.yml
+++ b/.github/workflows/samples_connections_connection.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python connection.ipynb connection.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/connections

--- a/.github/workflows/samples_flex_flows_basic.yml
+++ b/.github/workflows/samples_flex_flows_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/basic/bash_script.sh

--- a/.github/workflows/samples_flex_flows_chat_async_stream.yml
+++ b/.github/workflows/samples_flex_flows_chat_async_stream.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/chat-async-stream/bash_script.sh

--- a/.github/workflows/samples_flex_flows_chat_basic.yml
+++ b/.github/workflows/samples_flex_flows_chat_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/chat-basic/bash_script.sh

--- a/.github/workflows/samples_flex_flows_chat_minimal.yml
+++ b/.github/workflows/samples_flex_flows_chat_minimal.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/chat-minimal/bash_script.sh

--- a/.github/workflows/samples_flex_flows_chat_stream.yml
+++ b/.github/workflows/samples_flex_flows_chat_stream.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/chat-stream/bash_script.sh

--- a/.github/workflows/samples_flex_flows_chat_with_functions.yml
+++ b/.github/workflows/samples_flex_flows_chat_with_functions.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/chat-with-functions/bash_script.sh

--- a/.github/workflows/samples_flex_flows_eval_checklist.yml
+++ b/.github/workflows/samples_flex_flows_eval_checklist.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/eval-checklist/bash_script.sh

--- a/.github/workflows/samples_flex_flows_eval_code_quality.yml
+++ b/.github/workflows/samples_flex_flows_eval_code_quality.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/eval-code-quality/bash_script.sh

--- a/.github/workflows/samples_flex_flows_eval_criteria_with_langchain.yml
+++ b/.github/workflows/samples_flex_flows_eval_criteria_with_langchain.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flex-flows/eval-criteria-with-langchain/bash_script.sh

--- a/.github/workflows/samples_flexflows_basic_flexflowquickstart.yml
+++ b/.github/workflows/samples_flexflows_basic_flexflowquickstart.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python flex-flow-quickstart.ipynb flex-flow-quickstart.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/basic

--- a/.github/workflows/samples_flexflows_basic_flexflowquickstartazure.yml
+++ b/.github/workflows/samples_flexflows_basic_flexflowquickstartazure.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -72,7 +72,7 @@ jobs:
           papermill -k python flex-flow-quickstart-azure.ipynb flex-flow-quickstart-azure.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/basic

--- a/.github/workflows/samples_flexflows_chatasyncstream_chatstreamwithasyncflexflow.yml
+++ b/.github/workflows/samples_flexflows_chatasyncstream_chatstreamwithasyncflexflow.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python chat-stream-with-async-flex-flow.ipynb chat-stream-with-async-flex-flow.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/chat-async-stream

--- a/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflow.yml
+++ b/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflow.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python chat-with-class-based-flow.ipynb chat-with-class-based-flow.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/chat-basic

--- a/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflowazure.yml
+++ b/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflowazure.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -72,7 +72,7 @@ jobs:
           papermill -k python chat-with-class-based-flow-azure.ipynb chat-with-class-based-flow-azure.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/chat-basic

--- a/.github/workflows/samples_flexflows_chatstream_chatstreamwithflexflow.yml
+++ b/.github/workflows/samples_flexflows_chatstream_chatstreamwithflexflow.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python chat-stream-with-flex-flow.ipynb chat-stream-with-flex-flow.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/chat-stream

--- a/.github/workflows/samples_flexflows_evalcriteriawithlangchain_langchaineval.yml
+++ b/.github/workflows/samples_flexflows_evalcriteriawithlangchain_langchaineval.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python langchain-eval.ipynb langchain-eval.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flex-flows/eval-criteria-with-langchain

--- a/.github/workflows/samples_flows_chat_chat_basic.yml
+++ b/.github/workflows/samples_flows_chat_chat_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/chat/chat-basic/bash_script.sh

--- a/.github/workflows/samples_flows_chat_chat_math_variant.yml
+++ b/.github/workflows/samples_flows_chat_chat_math_variant.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/chat/chat-math-variant/bash_script.sh

--- a/.github/workflows/samples_flows_chat_chat_with_image.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_image.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -75,7 +75,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -115,7 +115,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/chat/chat-with-image/bash_script.sh

--- a/.github/workflows/samples_flows_chat_chat_with_pdf.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_pdf.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -83,7 +83,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -127,7 +127,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/chat/chat-with-pdf/bash_script.sh

--- a/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/chat/chat-with-wikipedia/bash_script.sh

--- a/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdf.yml
+++ b/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdf.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -97,7 +97,7 @@ jobs:
           papermill -k python chat-with-pdf.ipynb chat-with-pdf.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flows/chat/chat-with-pdf

--- a/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdfazure.yml
+++ b/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdfazure.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -97,7 +97,7 @@ jobs:
           papermill -k python chat-with-pdf-azure.ipynb chat-with-pdf-azure.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/flows/chat/chat-with-pdf

--- a/.github/workflows/samples_flows_chat_use_functions_with_chat_models.yml
+++ b/.github/workflows/samples_flows_chat_use_functions_with_chat_models.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/chat/use_functions_with_chat_models/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_basic.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-basic/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-chat-math/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-classification-accuracy/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-entity-match-rate/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-groundedness/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_multi_turn_metrics.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_multi_turn_metrics.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-multi-turn-metrics/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-perceived-intelligence/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_qna_non_rag.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_qna_non_rag.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-qna-non-rag/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_qna_rag_metrics.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_qna_rag_metrics.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-qna-rag-metrics/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_single_turn_metrics.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_single_turn_metrics.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-single-turn-metrics/bash_script.sh

--- a/.github/workflows/samples_flows_evaluation_eval_summarization.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_summarization.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/evaluation/eval-summarization/bash_script.sh

--- a/.github/workflows/samples_flows_standard_autonomous_agent.yml
+++ b/.github/workflows/samples_flows_standard_autonomous_agent.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/autonomous-agent/bash_script.sh

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/basic/bash_script.sh

--- a/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -76,7 +76,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -120,7 +120,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/basic-with-builtin-llm/bash_script.sh

--- a/.github/workflows/samples_flows_standard_basic_with_connection.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_connection.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -76,7 +76,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -120,7 +120,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/basic-with-connection/bash_script.sh

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/conditional-flow-for-if-else/bash_script.sh

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/conditional-flow-for-switch/bash_script.sh

--- a/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
+++ b/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/customer-intent-extraction/bash_script.sh

--- a/.github/workflows/samples_flows_standard_describe_image.yml
+++ b/.github/workflows/samples_flows_standard_describe_image.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -75,7 +75,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -115,7 +115,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/describe-image/bash_script.sh

--- a/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -76,7 +76,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -120,7 +120,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/flow-with-additional-includes/bash_script.sh

--- a/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -76,7 +76,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -120,7 +120,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/flow-with-symlinks/bash_script.sh

--- a/.github/workflows/samples_flows_standard_gen_docstring.yml
+++ b/.github/workflows/samples_flows_standard_gen_docstring.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/gen-docstring/bash_script.sh

--- a/.github/workflows/samples_flows_standard_maths_to_code.yml
+++ b/.github/workflows/samples_flows_standard_maths_to_code.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/maths-to-code/bash_script.sh

--- a/.github/workflows/samples_flows_standard_named_entity_recognition.yml
+++ b/.github/workflows/samples_flows_standard_named_entity_recognition.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/named-entity-recognition/bash_script.sh

--- a/.github/workflows/samples_flows_standard_question_simulation.yml
+++ b/.github/workflows/samples_flows_standard_question_simulation.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/question-simulation/bash_script.sh

--- a/.github/workflows/samples_flows_standard_web_classification.yml
+++ b/.github/workflows/samples_flows_standard_web_classification.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/flows/standard/web-classification/bash_script.sh

--- a/.github/workflows/samples_getstarted_flowasfunction.yml
+++ b/.github/workflows/samples_getstarted_flowasfunction.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -68,7 +68,7 @@ jobs:
           papermill -k python flow-as-function.ipynb flow-as-function.output.ipynb -p api_key ${{ secrets.AOAI_API_KEY_TEST }} -p api_base ${{ secrets.AOAI_API_ENDPOINT_TEST }} -p api_version 2023-07-01-preview
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/get-started

--- a/.github/workflows/samples_getstarted_quickstart.yml
+++ b/.github/workflows/samples_getstarted_quickstart.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python quickstart.ipynb quickstart.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/get-started

--- a/.github/workflows/samples_getstarted_quickstartazure.yml
+++ b/.github/workflows/samples_getstarted_quickstartazure.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -72,7 +72,7 @@ jobs:
           papermill -k python quickstart-azure.ipynb quickstart-azure.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/get-started

--- a/.github/workflows/samples_prompty_basic.yml
+++ b/.github/workflows/samples_prompty_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/prompty/basic/bash_script.sh

--- a/.github/workflows/samples_prompty_basic_promptyquickstart.yml
+++ b/.github/workflows/samples_prompty_basic_promptyquickstart.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python prompty-quickstart.ipynb prompty-quickstart.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/prompty/basic

--- a/.github/workflows/samples_prompty_chat_basic.yml
+++ b/.github/workflows/samples_prompty_chat_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/prompty/chat-basic/bash_script.sh

--- a/.github/workflows/samples_prompty_chatbasic_chatwithprompty.yml
+++ b/.github/workflows/samples_prompty_chatbasic_chatwithprompty.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python chat-with-prompty.ipynb chat-with-prompty.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/prompty/chat-basic

--- a/.github/workflows/samples_prompty_eval_apology.yml
+++ b/.github/workflows/samples_prompty_eval_apology.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/prompty/eval-apology/bash_script.sh

--- a/.github/workflows/samples_prompty_eval_basic.yml
+++ b/.github/workflows/samples_prompty_eval_basic.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/prompty/eval-basic/bash_script.sh

--- a/.github/workflows/samples_prompty_format_output.yml
+++ b/.github/workflows/samples_prompty_format_output.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/prompty/format-output/bash_script.sh

--- a/.github/workflows/samples_prompty_formatoutput_promptyoutputformat.yml
+++ b/.github/workflows/samples_prompty_formatoutput_promptyoutputformat.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python prompty-output-format.ipynb prompty-output-format.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/prompty/format-output

--- a/.github/workflows/samples_runflowwithpipeline_pipeline.yml
+++ b/.github/workflows/samples_runflowwithpipeline_pipeline.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -72,7 +72,7 @@ jobs:
           papermill -k python pipeline.ipynb pipeline.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/run-flow-with-pipeline

--- a/.github/workflows/samples_runmanagement_cloudrunmanagement.yml
+++ b/.github/workflows/samples_runmanagement_cloudrunmanagement.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Generate config.json for canary workspace (scheduled runs only)
         if: github.event_name == 'schedule'
         run: echo '${{ secrets.TEST_WORKSPACE_CONFIG_JSON_CANARY }}' > ${{ github.workspace }}/examples/config.json
@@ -72,7 +72,7 @@ jobs:
           papermill -k python cloud-run-management.ipynb cloud-run-management.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/run-management

--- a/.github/workflows/samples_runmanagement_runmanagement.yml
+++ b/.github/workflows/samples_runmanagement_runmanagement.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python run-management.ipynb run-management.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/run-management

--- a/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tools/use-cases/cascading-inputs-tool-showcase/bash_script.sh

--- a/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tools/use-cases/custom_llm_tool_showcase/bash_script.sh

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tools/use-cases/custom-strong-type-connection-package-tool-showcase/bash_script.sh

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tools/use-cases/custom-strong-type-connection-script-tool-showcase/bash_script.sh

--- a/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tools/use-cases/dynamic-list-input-tool-showcase/bash_script.sh

--- a/.github/workflows/samples_tracing_autogengroupchat_traceautogengroupchat.yml
+++ b/.github/workflows/samples_tracing_autogengroupchat_traceautogengroupchat.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -87,7 +87,7 @@ jobs:
           papermill -k python trace-autogen-groupchat.ipynb trace-autogen-groupchat.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/tracing/autogen-groupchat

--- a/.github/workflows/samples_tracing_customotlpcollector_otlptracecollector.yml
+++ b/.github/workflows/samples_tracing_customotlpcollector_otlptracecollector.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python otlp-trace-collector.ipynb otlp-trace-collector.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/tracing/custom-otlp-collector

--- a/.github/workflows/samples_tracing_langchain_tracelangchain.yml
+++ b/.github/workflows/samples_tracing_langchain_tracelangchain.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python trace-langchain.ipynb trace-langchain.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/tracing/langchain

--- a/.github/workflows/samples_tracing_llm_tracellm.yml
+++ b/.github/workflows/samples_tracing_llm_tracellm.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -82,7 +82,7 @@ jobs:
           papermill -k python trace-llm.ipynb trace-llm.output.ipynb
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: artifact
           path: examples/tutorials/tracing/llm

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -89,7 +89,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -133,7 +133,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/e2e-development/bash_script.sh
@@ -144,7 +144,7 @@ jobs:
           inlineScript: |
             Disconnect-AzAccount
       - name: Azure Login Again_login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/flow-deploy/azure-app-service/bash_script.sh

--- a/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/flow-deploy/create-service-with-flow/bash_script.sh

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/flow-deploy/distribute-flow-as-executable-app/bash_script.sh

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/flow-deploy/docker/bash_script.sh

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/flow-deploy/kubernetes/bash_script.sh

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/flow-fine-tuning-evaluation/bash_script.sh

--- a/.github/workflows/samples_tutorials_tracing.yml
+++ b/.github/workflows/samples_tutorials_tracing.yml
@@ -26,7 +26,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
         with:
@@ -73,7 +73,7 @@ jobs:
           minimum: 0
           maximum: 99
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -117,7 +117,7 @@ jobs:
           pip list
       - name: Upload artifact
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4
         with:
           name: artifact
           path: examples/tutorials/tracing/bash_script.sh

--- a/.github/workflows/sdk-cli-azure-test-production.yml
+++ b/.github/workflows/sdk-cli-azure-test-production.yml
@@ -54,17 +54,17 @@ jobs:
           echo "FILE_PATHS=$(if [[ "${{ inputs.filepath }}" == "" ]]; then echo "./tests/sdk_cli_test ./tests/sdk_pfs_test"; else echo ${{ inputs.filepath }}; fi)" >> $GITHUB_ENV
 
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Display and Set Environment Variables
         run: env | sort >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}
@@ -93,7 +93,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: Test Results (Python ${{ matrix.pythonVersion }}) (OS ${{ matrix.os }})
           path: |

--- a/.github/workflows/sdk-cli-azure-test-pull-request.yml
+++ b/.github/workflows/sdk-cli-azure-test-pull-request.yml
@@ -41,15 +41,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Display and Set Environment Variables
         run: env | sort >> $GITHUB_OUTPUT
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ matrix.pythonVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
       - name: install test dependency group
         working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
@@ -76,7 +76,7 @@ jobs:
 
       - name: Upload Test Results
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@ff15f0306b3f739f7b6fd43fb5d26cd321bd4de5 # v3
         with:
           name: Test Results (Python ${{ matrix.pythonVersion }}) (OS ${{ matrix.os }})
           path: |
@@ -96,7 +96,7 @@ jobs:
 
     steps:
     - name: checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Publish Test Results
       uses: "./.github/actions/step_publish_test_results"
       with:

--- a/.github/workflows/sdk-cli-perf-monitor-test.yml
+++ b/.github/workflows/sdk-cli-perf-monitor-test.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set Github Run Id to an Environment Variable
         run: echo "GITHUB_RUN_ID=${{ github.run_id }}" >> $GITHUB_ENV
@@ -57,10 +57,10 @@ jobs:
           env | sort >> $GITHUB_OUTPUT
         id: display_env
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: ${{ steps.display_env.outputs.pyVersion }}
-      - uses: snok/install-poetry@v1
+      - uses: snok/install-poetry@a783c322200f0519c7926aa6faa857c4e23e9263 # v1
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true

--- a/.github/workflows/spell_check.yml
+++ b/.github/workflows/spell_check.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Use Node.js 18.x
         uses: actions/setup-node@v3

--- a/.github/workflows/tools_release_tag.yml
+++ b/.github/workflows/tools_release_tag.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           fetch-depth: 0
 
@@ -49,7 +49,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -61,7 +61,7 @@ jobs:
 
       - name: Upload Release Asset
         id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/tools_tests.yml
+++ b/.github/workflows/tools_tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: (ls /.dockerenv && echo Found dockerenv) || (echo No dockerenv)
         # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Setup
@@ -57,7 +57,7 @@ jobs:
           pip list
 
       - name: Azure login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           client-id: ${{ secrets.CLIENT_ID }}
           tenant-id: ${{ secrets.TENANT_ID }}

--- a/.github/workflows/update-ci-runtime.yml
+++ b/.github/workflows/update-ci-runtime.yml
@@ -14,7 +14,7 @@ jobs:
       internal
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Python 3.9 environment
         uses: actions/setup-python@v4
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.9"
 
       - name: Azure Login
-        uses: azure/login@v1
+        uses: azure/login@cb79c773a3cfa27f31f25eb3f677781210c9ce3d # v1
         with:
           subscription-id: ${{secrets.AZURE_SUBSCRIPTION_ID}}
           tenant-id: ${{secrets.AZURE_TENANT_ID}}

--- a/.github/workflows/wheel_distributing.yml
+++ b/.github/workflows/wheel_distributing.yml
@@ -43,7 +43,7 @@ jobs:
           echo "ConfigsFolderPath: ${{ inputs.ConfigsFolderPath }}"
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ github.event_name == 'push' && 'main' || github.event.inputs.branch }}
           submodules: true


### PR DESCRIPTION
## Summary

Pins **415 GitHub Action references** across **118 workflow files** to full immutable commit SHAs.

## Vulnerability

All CI workflows currently use mutable version tags (`@v1`, `@v2`, `@v3`, `@v4`, `@v5`) for GitHub Actions. A compromised action repository (or a tag force-push) could silently deliver malicious code into Microsoft's CI pipeline, with access to Azure credentials (`azure/login`), release publishing tokens, and test secrets.

This is the same attack class used in the [tj-actions/changed-files supply chain compromise (March 2025)](https://www.bleepingcomputer.com/news/security/popular-github-action-tjactionschanged-files-compromised-in-supply-chain-attack/) which affected thousands of repositories.

## Actions pinned

| Action | Tags pinned |
|---|---|
| `actions/checkout` | v2, v3, v4 |
| `actions/setup-python` | v2, v5 |
| `actions/upload-artifact` | v3, v4 |
| `actions/download-artifact` | v3, v4 |
| `actions/github-script` | v7 |
| `actions/create-release` | v1 |
| `actions/upload-release-asset` | v1 |
| `azure/login` | v1 |
| `microsoft/setup-msbuild` | v1.1 |
| `EnricoMi/publish-unit-test-result-action` | v2 |
| `irongut/CodeCoverageSummary` | v1.3.0 |
| `SimenB/github-actions-cpu-cores` | v1 |
| `snok/install-poetry` | v1 |

All pins point to the exact same code as the current tags — **no behaviour change**.

## References
- https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
- https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
- [OpenSSF Scorecard — Pinned-Dependencies](https://securityscorecards.dev/)