### PR TITLE
docs: add DaoXE OpenAI-compatible endpoint guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ For OpenAI key, establish a connection by running the command, using the `openai
 pf connection create --file ./my_chatbot/openai.yaml --set api_key=<your_api_key> --name open_ai_connection
 ```
 
+For OpenAI-compatible gateways, reuse the OpenAI connection and set `base_url`. For example, [DaoXE](https://daoxe.com) exposes an OpenAI-compatible Chat Completions endpoint at `https://daoxe.com/v1` (DaoXE is multi-protocol and also supports OpenAI Responses and Anthropic Messages for other clients; prompt flow uses the OpenAI connection path here). Use an exact model ID from your DaoXE account catalog. DaoXE is not available in mainland China.
+
+```sh
+pf connection create --file ./my_chatbot/openai.yaml --set api_key=<your_daoxe_api_key> base_url=https://daoxe.com/v1 --name open_ai_connection
+```
+
 For Azure OpenAI key, establish the connection by running the command, using the `azure_openai.yaml` file:
 
 ```sh

--- a/docs/how-to-guides/manage-connections.md
+++ b/docs/how-to-guides/manage-connections.md
@@ -223,6 +223,8 @@ Supported types are as follows:
 
 For example, with `OPENAI_API_KEY` set to environment, an `OpenAIConnection` object can be loaded with `OpenAIConnection.from_env()`.
 
+To point the same OpenAI connection at an OpenAI-compatible gateway, also set `OPENAI_BASE_URL`. For example, [DaoXE](https://daoxe.com) uses `https://daoxe.com/v1` for Chat Completions (multi-model multi-protocol gateway; account-scoped model IDs; not available in mainland China). See [DaoXE integration](../integrations/llms/daoxe.md).
+
 ## Authenticate with Microsoft Entra ID
 [Microsoft Entra ID](https://learn.microsoft.com/entra/fundamentals/whatis) is a cloud-based identity and access management service that enables your employees access external resources.
 

--- a/docs/integrations/llms/daoxe.md
+++ b/docs/integrations/llms/daoxe.md
@@ -1,0 +1,129 @@
+# Use DaoXE with prompt flow
+
+[DaoXE](https://daoxe.com) is a multi-model multi-protocol API gateway. For prompt flow, use the **OpenAI connection** against DaoXE's OpenAI-compatible Chat Completions endpoint:
+
+- Base URL: `https://daoxe.com/v1`
+- Auth: API key from your DaoXE account
+- Model: an **exact** model ID from your account catalog (`GET /v1/models`), not a static public list
+
+DaoXE also exposes OpenAI Responses and Anthropic Messages (Claude protocol) for other clients. This page covers the OpenAI-compatible path that prompt flow's `OpenAIConnection` / prompty `type: openai` configuration already supports.
+
+> DaoXE is **not available in mainland China**.
+
+## Prerequisites
+
+```sh
+pip install promptflow promptflow-tools
+```
+
+Create a DaoXE API key at [daoxe.com](https://daoxe.com) and list models available to your key:
+
+```sh
+curl -sS https://daoxe.com/v1/models \
+  -H "Authorization: Bearer $DAOXE_API_KEY"
+```
+
+## Create an OpenAI connection with DaoXE base URL
+
+Reuse the generated `openai.yaml` from `pf flow init` (or any OpenAI connection YAML) and override `api_key` and `base_url`:
+
+```sh
+pf flow init --flow ./my_chatbot --type chat
+
+pf connection create --file ./my_chatbot/openai.yaml \
+  --set api_key=<your_daoxe_api_key> base_url=https://daoxe.com/v1 \
+  --name open_ai_connection
+```
+
+In the flow's LLM / chat node, keep `connection: open_ai_connection` and set the model field (for example `model` / `deployment_name`, depending on the node schema) to an exact DaoXE model ID from your account.
+
+## Environment variables
+
+With `promptflow>=1.8.0` you can load an `OpenAIConnection` from the environment without writing a local connection DB entry:
+
+```sh
+export OPENAI_API_KEY=<your_daoxe_api_key>
+export OPENAI_BASE_URL=https://daoxe.com/v1
+```
+
+| Connection Type | Field | Environment variable |
+| --- | --- | --- |
+| OpenAIConnection | api_key | `OPENAI_API_KEY` |
+| OpenAIConnection | base_url | `OPENAI_BASE_URL` |
+
+## Prompty configuration
+
+```yaml
+---
+name: DaoXE Chat
+description: Chat via DaoXE OpenAI-compatible endpoint
+model:
+  api: chat
+  configuration:
+    type: openai
+    model: <exact-model-id-from-your-daoxe-account>
+    api_key: ${env:OPENAI_API_KEY}
+    base_url: ${env:OPENAI_BASE_URL}
+  parameters:
+    max_tokens: 256
+    temperature: 0.2
+inputs:
+  question:
+    type: string
+sample:
+  question: Say hello in one short sentence.
+---
+system:
+You are a helpful assistant.
+
+user:
+{{question}}
+```
+
+Or override at load time:
+
+```python
+from promptflow.core import Prompty, OpenAIModelConfiguration
+
+configuration = OpenAIModelConfiguration(
+    model="<exact-model-id-from-your-daoxe-account>",
+    base_url="https://daoxe.com/v1",
+    api_key="${env:OPENAI_API_KEY}",
+)
+prompty = Prompty.load(
+    source="path/to/chat.prompty",
+    model={"configuration": configuration, "parameters": {"max_tokens": 256}},
+)
+```
+
+## Smoke test with the OpenAI Python client
+
+Before running a full flow, verify credentials and model ID:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["OPENAI_API_KEY"],
+    base_url=os.environ.get("OPENAI_BASE_URL", "https://daoxe.com/v1"),
+)
+
+resp = client.chat.completions.create(
+    model=os.environ["DAOXE_MODEL"],  # exact ID from your catalog
+    messages=[{"role": "user", "content": "Reply with the single word: pong"}],
+    max_tokens=16,
+)
+print(resp.choices[0].message.content)
+```
+
+## Notes
+
+- Prefer models that support the features your flow needs (tools, JSON mode, long context) as shown for your account.
+- DaoXE model IDs and availability are account-scoped; always resolve them live.
+- Multi-protocol note: prompt flow integration here is **Chat Completions** only. Anthropic Messages / Responses are for other stacks.
+- Sample clients and setup notes: [DaoXE-AI](https://github.com/seven7763/DaoXE-AI)
+
+## Disclosure
+
+This page is contributed by a DaoXE maintainer.

--- a/docs/integrations/llms/index.md
+++ b/docs/integrations/llms/index.md
@@ -6,4 +6,5 @@ This section provides tutorials on incorporating alternative large language mode
 :maxdepth: 1
 :hidden:
 
+daoxe
 ```


### PR DESCRIPTION
## Summary
- Document [DaoXE](https://daoxe.com) as an OpenAI-compatible connection option for prompt flow (`base_url=https://daoxe.com/v1`).
- Add an Alternative LLMs page under `docs/integrations/llms/` with connection, prompty, env-var, and smoke-test examples.
- Link the gateway from the connections how-to when configuring `OPENAI_BASE_URL`.

## Notes
- **Docs-only** — no code, dependency, or API surface changes.
- DaoXE is a multi-model multi-protocol API gateway. This PR only covers the OpenAI Chat Completions path that prompt flow already supports via `OpenAIConnection` / prompty `type: openai`. DaoXE also exposes OpenAI Responses and Anthropic Messages for other clients.
- Model IDs are **account-scoped** — examples use placeholders / env vars, not a hardcoded catalog.
- DaoXE is **not available in mainland China**.
- Disclosure: contributed by a DaoXE maintainer.

## Validation
- Diff is markdown only under README + docs.
- Follows the same OpenAI-compatible `base_url` pattern as existing connection docs.

## Contribution checklist
- [x] The pull request does not introduce breaking changes.
- [x] Docs-only (CHANGELOG not required for external gateway docs example).
- [x] I have read the contribution guidelines.
- [x] No new dependencies.