### PR TITLE
docs: add DaoXE OpenAI-compatible connection example

### DIFF
--- a/docs/concepts/concept-connections.md
+++ b/docs/concepts/concept-connections.md
@@ -20,6 +20,24 @@ Prompt flow provides a variety of pre-built connections, including Azure OpenAI,
 
 By leveraging connections in prompt flow, you can easily establish and manage connections to external APIs and data sources, facilitating efficient data exchange and interaction within their AI applications.
 
+## OpenAI-compatible providers
+
+`OpenAIConnection` can target OpenAI-compatible HTTP APIs by setting `base_url`. Prompt flow still uses the built-in OpenAI connection type and LLM tools; only the endpoint, API key, and model identifier change.
+
+### Example: DaoXE
+
+[DaoXE](https://daoxe.com) is a multi-model, multi-protocol AI API gateway. For OpenAI Chat Completions–compatible clients (including prompt flow's OpenAI connection), use:
+
+| Field | Value |
+| ----- | ----- |
+| `base_url` | `https://daoxe.com/v1` |
+| `api_key` | Your DaoXE API key from the dashboard |
+| Model ID | Use an exact model identifier available on your DaoXE account (account-scoped; do not hard-code a global list) |
+
+DaoXE also exposes other protocols outside this OpenAI connection path (for example OpenAI Responses and Anthropic Messages). Service availability does not include mainland China; check [daoxe.com](https://daoxe.com) for current access and model catalog details.
+
+See [Manage connections](../how-to-guides/manage-connections.md#openai-compatible-endpoint-example-daoxe) for YAML, CLI, and SDK samples.
+
 ## Next steps
 
 - [Create connections](../how-to-guides/manage-connections.md)

--- a/docs/how-to-guides/manage-connections.md
+++ b/docs/how-to-guides/manage-connections.md
@@ -206,7 +206,54 @@ On the VS Code primary sidebar > prompt flow pane. You can find the connections 
 :::
 ::::
 
+## OpenAI-compatible endpoint example (DaoXE)
+
+Prompt flow's `OpenAIConnection` accepts an optional `base_url`. Point it at any OpenAI-compatible Chat Completions endpoint so built-in LLM tools keep working without a custom tool.
+
+### DaoXE connection YAML
+
+```yaml
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/OpenAIConnection.schema.json
+name: daoxe_connection
+type: open_ai
+api_key: "<your-daoxe-api-key>"
+base_url: "https://daoxe.com/v1"
+```
+
+Create the connection with CLI:
+
+```bash
+pf connection create -f daoxe.yml --set api_key=<your-daoxe-api-key>
+# or override base_url explicitly:
+# pf connection create -f ./examples/connections/openai.yml --set api_key=<your-daoxe-api-key> base_url=https://daoxe.com/v1 --name daoxe_connection
+```
+
+### DaoXE connection with SDK
+
+```python
+from promptflow.client import PFClient
+from promptflow.entities import OpenAIConnection
+
+pf = PFClient()
+
+connection = OpenAIConnection(
+    name="daoxe_connection",
+    api_key="<your-daoxe-api-key>",
+    base_url="https://daoxe.com/v1",
+)
+result = pf.connections.create_or_update(connection)
+print(result)
+```
+
+### Notes for DaoXE
+
+- **Base URL:** `https://daoxe.com/v1` (OpenAI-compatible Chat Completions path used by prompt flow).
+- **Model IDs:** account-scoped — pick an exact model ID visible in your DaoXE account or current catalog; do not assume a fixed public list in this doc.
+- **Multi-protocol:** DaoXE is a multi-model, multi-protocol gateway. Besides OpenAI Chat Completions, it also exposes other APIs such as OpenAI Responses and Anthropic Messages. Those paths are outside prompt flow's built-in `OpenAIConnection`; use them with the matching client or a custom Python tool.
+- **Region:** DaoXE does not serve mainland China. Confirm access and pricing on [daoxe.com](https://daoxe.com).
+
 ## Load from environment variables
+
 With `promptflow>=1.8.0`, user is able to load a connection object from os environment variables with `<ConnectionType>.from_env` func.
 Note that the connection object will **NOT BE CREATED** to local database.
 

--- a/examples/connections/README.md
+++ b/examples/connections/README.md
@@ -14,6 +14,8 @@ pip install -r requirements.txt
 # Override keys with --set to avoid yaml file changes
 pf connection create -f custom.yml --set configs.key1='<your_api_key>'
 pf connection create -f azure_openai.yml --set api_key='<your_api_key>'
+# OpenAI-compatible provider example (DaoXE)
+pf connection create -f daoxe.yml --set api_key='<your_daoxe_api_key>'
 ```
 
 - To create a custom connection using an `.env` file, execute following command:

--- a/examples/connections/daoxe.yml
+++ b/examples/connections/daoxe.yml
@@ -1,0 +1,5 @@
+$schema: https://azuremlschemas.azureedge.net/promptflow/latest/OpenAIConnection.schema.json
+name: daoxe_connection
+type: open_ai
+api_key: "<user-input>"  # Your DaoXE API key from https://daoxe.com
+base_url: "https://daoxe.com/v1"


### PR DESCRIPTION
## Description

Add English documentation for using [DaoXE](https://daoxe.com) with prompt flow's existing `OpenAIConnection` (`base_url`).

### Changes
- `docs/concepts/concept-connections.md` — OpenAI-compatible providers overview + DaoXE fields
- `docs/how-to-guides/manage-connections.md` — YAML / CLI / SDK samples
- `examples/connections/daoxe.yml` — sample connection file
- `examples/connections/README.md` — create command for the sample

### DaoXE configuration (prompt flow path)
| Field | Value |
| ----- | ----- |
| `base_url` | `https://daoxe.com/v1` |
| `api_key` | DaoXE dashboard API key |
| Model ID | Account-scoped exact ID from the user's catalog |

Notes included in the docs:
- DaoXE is multi-model and multi-protocol (OpenAI Chat Completions, OpenAI Responses, Anthropic Messages, etc.); this PR only covers the OpenAI connection path prompt flow uses.
- Service does not include mainland China.
- Docs-only; no runtime/API changes.

## All Promptflow Contribution checklist:
- [x] **The pull request does not introduce [breaking changes].**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.** (docs-only example)
- [x] **I have read the [contribution guidelines](https://github.com/microsoft/promptflow/blob/main/CONTRIBUTING.md).**
- [x] **I confirm that all new dependencies are compatible with the MIT license.**
- [ ] **Create an issue and link to the pull request to get dedicated review from promptflow team.**

## Testing Guidelines
- [x] Docs-only change; validated with `git diff --check` and local content review.