### PR TITLE
fix(evals): open data file with utf-8-sig to support BOM-encoded jsonl inputs

### DIFF
--- a/src/promptflow-evals/promptflow/evals/evaluate/_evaluate.py
+++ b/src/promptflow-evals/promptflow/evals/evaluate/_evaluate.py
@@ -192,7 +192,10 @@ def _validate_and_load_data(target, data, evaluators, output_path, azure_ai_proj
             raise ValueError("evaluation_name must be a string.")
 
     try:
-        initial_data_df = pd.read_json(data, lines=True)
+        # Open with utf-8-sig to transparently strip the BOM when present (utf-8-sig
+        # also reads plain UTF-8 files correctly, so this is backwards-compatible).
+        with open(data, encoding="utf-8-sig") as _f:
+            initial_data_df = pd.read_json(_f, lines=True)
     except Exception as e:
         raise ValueError(
             f"Failed to load data from {data}. Please validate it is a valid jsonl data. Error: {str(e)}."


### PR DESCRIPTION
## Fixes

Fixes #3670.

`_validate_and_load_data` passes the raw `data` path string to `pd.read_json(data, lines=True)`.
`pd.read_json` uses the system default encoding when opening files, which is UTF-8 on most
systems but does **not** strip a UTF-8 BOM (`\xef\xbb\xbf`). A JSONL file written with
`utf-8-sig` encoding (BOM-prefixed UTF-8) causes `pd.read_json` to emit `ValueError: Expected
object or value` because the BOM sits in front of the first `{`.

## Fix

Open the data file explicitly with `encoding="utf-8-sig"` and pass the resulting file object
to `pd.read_json`. Python's `utf-8-sig` codec:

- Strips the BOM when present (handles `utf-8-sig` clients).
- Reads plain UTF-8 files unchanged (backwards-compatible).

```python
# Before:
initial_data_df = pd.read_json(data, lines=True)

# After:
with open(data, encoding="utf-8-sig") as _f:
    initial_data_df = pd.read_json(_f, lines=True)
```

The error message and the surrounding `try/except` are unchanged; the only difference is
how the file is opened.

## Reproduction

```python
import json, pathlib, tempfile
from promptflow.evals.evaluate import evaluate

# Create a BOM-prefixed JSONL file
with tempfile.NamedTemporaryFile(mode='w', encoding='utf-8-sig', suffix='.jsonl', delete=False) as f:
    json.dump({"question": "What is 2+2?"}, f)
    path = f.name

# Before fix: ValueError: Failed to load data from …
# After fix:  loads successfully
```

Closes #3670.
