### PR TITLE
fix(parallel): allow '=' inside _parse_prefixed_args values

### DIFF
--- a/src/promptflow-parallel/promptflow/parallel/_config/parser.py
+++ b/src/promptflow-parallel/promptflow/parallel/_config/parser.py
@@ -85,7 +85,9 @@ def _parse_prefixed_args(args: List[str], prefix: str) -> Dict[str, str]:
     for _, arg in enumerate(args):
         if arg.startswith(prefix):
             if "=" in arg:
-                arg_name, arg_value = arg.split("=")
+                # maxsplit=1 so values may contain '=' (base64 padding, query
+                # strings, embedded JSON) without ValueError (#4174).
+                arg_name, arg_value = arg.split("=", 1)
                 if len(arg_name) > len(prefix):
                     parsed[arg_name[len(prefix) :]] = arg_value
             elif pre_arg_name is None:

--- a/src/promptflow-parallel/tests/unittests/test_config_parser.py
+++ b/src/promptflow-parallel/tests/unittests/test_config_parser.py
@@ -1,0 +1,28 @@
+import pytest
+
+from promptflow.parallel._config.parser import _parse_prefixed_args
+
+
+def test_parse_prefixed_args_value_with_equals():
+    # Base64 "Hello World" ends with '=' padding
+    parsed = _parse_prefixed_args(
+        ["--pf_input_token=SGVsbG8gV29ybGQ="],
+        "--pf_input_",
+    )
+    assert parsed == {"token": "SGVsbG8gV29ybGQ="}
+
+
+def test_parse_prefixed_args_url_query_string():
+    parsed = _parse_prefixed_args(
+        ["--pf_input_url=https://example.com?a=1&b=2"],
+        "--pf_input_",
+    )
+    assert parsed["url"] == "https://example.com?a=1&b=2"
+
+
+def test_parse_prefixed_args_space_separated():
+    parsed = _parse_prefixed_args(
+        ["--pf_input_arg2", "arg2"],
+        "--pf_input_",
+    )
+    assert parsed == {"arg2": "arg2"}


### PR DESCRIPTION
## Summary
`_parse_prefixed_args()` crashed with:

```
ValueError: too many values to unpack (expected 2)
```

whenever an argument value contained `=` (base64 padding, URL query strings, embedded JSON/key-value pairs).

## Change
Use `str.split("=", 1)` so only the first `=` separates name and value.

## Test plan
- [x] Local unit checks for base64 and query-string values
- [x] Added `src/promptflow-parallel/tests/unittests/test_config_parser.py`

Fixes #4174.
