### PR TITLE
fix(context_utils): serialise _change_working_dir with a threading.Lock

### DIFF
--- a/src/promptflow-core/promptflow/_utils/context_utils.py
+++ b/src/promptflow-core/promptflow/_utils/context_utils.py
@@ -7,19 +7,30 @@ please avoid using them in service code!!!"""
 import contextlib
 import os
 import sys
+import threading
+
+# os.chdir is process-global; serialise concurrent uses so that threads in the
+# line-execution process pool cannot observe each other's intermediate cwd state.
+# See https://github.com/microsoft/promptflow/issues/3553
+_working_dir_lock = threading.Lock()
 
 
 @contextlib.contextmanager
 def _change_working_dir(path, mkdir=True):
-    """Context manager for changing the current working directory"""
-    saved_path = os.getcwd()
+    """Context manager for changing the current working directory.
+
+    Uses a module-level lock to prevent concurrent threads from observing
+    each other's intermediate ``os.chdir`` state.
+    """
     if mkdir:
         os.makedirs(path, exist_ok=True)
-    os.chdir(str(path))
-    try:
-        yield
-    finally:
-        os.chdir(saved_path)
+    with _working_dir_lock:
+        saved_path = os.getcwd()
+        os.chdir(str(path))
+        try:
+            yield
+        finally:
+            os.chdir(saved_path)
 
 
 @contextlib.contextmanager

--- a/src/promptflow/tests/executor/unittests/_utils/test_context_utils.py
+++ b/src/promptflow/tests/executor/unittests/_utils/test_context_utils.py
@@ -1,0 +1,58 @@
+# ---------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# ---------------------------------------------------------
+import os
+import tempfile
+import threading
+
+import pytest
+
+from promptflow._utils.context_utils import _change_working_dir
+
+
+class TestChangeWorkingDir:
+    def test_basic(self, tmp_path):
+        original = os.getcwd()
+        with _change_working_dir(tmp_path, mkdir=False):
+            assert os.getcwd() == str(tmp_path)
+        assert os.getcwd() == original
+
+    def test_restores_on_exception(self, tmp_path):
+        original = os.getcwd()
+        with pytest.raises(RuntimeError):
+            with _change_working_dir(tmp_path, mkdir=False):
+                raise RuntimeError("boom")
+        assert os.getcwd() == original
+
+    def test_mkdir(self, tmp_path):
+        new_dir = tmp_path / "nested" / "dir"
+        assert not new_dir.exists()
+        with _change_working_dir(new_dir):
+            assert new_dir.exists()
+
+    def test_thread_safety_no_cwd_leakage(self, tmp_path):
+        """Regression test for https://github.com/microsoft/promptflow/issues/3553.
+
+        Concurrent threads must not observe each other's intermediate os.chdir state.
+        Each thread changes to its own directory and verifies getcwd() inside the
+        context manager matches what it set — not another thread's directory.
+        """
+        dirs = [tmp_path / f"dir_{i}" for i in range(10)]
+        for d in dirs:
+            d.mkdir()
+
+        errors = []
+
+        def worker(target_dir):
+            with _change_working_dir(target_dir, mkdir=False):
+                observed = os.getcwd()
+                if observed != str(target_dir):
+                    errors.append(f"expected {target_dir}, got {observed}")
+
+        threads = [threading.Thread(target=worker, args=(d,)) for d in dirs]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Thread-safety violations: {errors}"


### PR DESCRIPTION
Fixes #3553

`_change_working_dir` uses `os.chdir()` which is process-global. When the line-execution process pool spawns workers while the parent thread is mid-chdir for a different flow, workers inherit the wrong directory and fail with "Flow path ... does not exist".

Added a module-level `threading.Lock` that serialises the getcwd/chdir/yield/chdir sequence. Race confirmed without the lock, eliminated with it. 4 tests added, all passing, pre-commit clean.