### PR TITLE
Preserve equals signs in prefixed argument values

### DIFF
--- a/src/promptflow-parallel/promptflow/parallel/_config/parser.py
+++ b/src/promptflow-parallel/promptflow/parallel/_config/parser.py
@@ -85,7 +85,7 @@ def _parse_prefixed_args(args: List[str], prefix: str) -> Dict[str, str]:
     for _, arg in enumerate(args):
         if arg.startswith(prefix):
             if "=" in arg:
-                arg_name, arg_value = arg.split("=")
+                arg_name, arg_value = arg.split("=", 1)
                 if len(arg_name) > len(prefix):
                     parsed[arg_name[len(prefix) :]] = arg_value
             elif pre_arg_name is None:

--- a/src/promptflow-parallel/tests/parallel/unittests/_config/test_parse.py
+++ b/src/promptflow-parallel/tests/parallel/unittests/_config/test_parse.py
@@ -51,3 +51,9 @@ def test_parse_correct_type():
     assert config.debug_output_dir == Path("/test_debug")
     assert config.logging_level == "INFO"
     assert not config.is_debug_enabled
+
+
+def test_parse_input_value_preserves_equals_signs():
+    config = parse(["--pf_input_token=SGVsbG8gV29ybGQ="])
+
+    assert config.input_mapping == {"token": "SGVsbG8gV29ybGQ="}


### PR DESCRIPTION
Closes #4174\n\nSummary:\n- Split prefixed arguments at the first equals sign only.\n- Add a regression test for values containing equals signs.\n\nTests:\n- Python syntax compilation passed.