### PR TITLE
ci: pin AliSajid/random-wait-action to a full commit SHA

### DIFF
--- a/.github/workflows/samples_configuration.yml
+++ b/.github/workflows/samples_configuration.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_connections.yml
+++ b/.github/workflows/samples_connections.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_connections_connection.yml
+++ b/.github/workflows/samples_connections_connection.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flex_flows_basic.yml
+++ b/.github/workflows/samples_flex_flows_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_chat_async_stream.yml
+++ b/.github/workflows/samples_flex_flows_chat_async_stream.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_chat_basic.yml
+++ b/.github/workflows/samples_flex_flows_chat_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_chat_minimal.yml
+++ b/.github/workflows/samples_flex_flows_chat_minimal.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_chat_stream.yml
+++ b/.github/workflows/samples_flex_flows_chat_stream.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_chat_with_functions.yml
+++ b/.github/workflows/samples_flex_flows_chat_with_functions.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_eval_checklist.yml
+++ b/.github/workflows/samples_flex_flows_eval_checklist.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_eval_code_quality.yml
+++ b/.github/workflows/samples_flex_flows_eval_code_quality.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flex_flows_eval_criteria_with_langchain.yml
+++ b/.github/workflows/samples_flex_flows_eval_criteria_with_langchain.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flexflows_basic_flexflowquickstart.yml
+++ b/.github/workflows/samples_flexflows_basic_flexflowquickstart.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flexflows_basic_flexflowquickstartazure.yml
+++ b/.github/workflows/samples_flexflows_basic_flexflowquickstartazure.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flexflows_chatasyncstream_chatstreamwithasyncflexflow.yml
+++ b/.github/workflows/samples_flexflows_chatasyncstream_chatstreamwithasyncflexflow.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflow.yml
+++ b/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflow.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflowazure.yml
+++ b/.github/workflows/samples_flexflows_chatbasic_chatwithclassbasedflowazure.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flexflows_chatstream_chatstreamwithflexflow.yml
+++ b/.github/workflows/samples_flexflows_chatstream_chatstreamwithflexflow.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flexflows_evalcriteriawithlangchain_langchaineval.yml
+++ b/.github/workflows/samples_flexflows_evalcriteriawithlangchain_langchaineval.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chat_basic.yml
+++ b/.github/workflows/samples_flows_chat_chat_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chat_math_variant.yml
+++ b/.github/workflows/samples_flows_chat_chat_math_variant.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chat_with_image.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_image.yml
@@ -70,7 +70,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chat_with_pdf.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_pdf.yml
@@ -78,7 +78,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
+++ b/.github/workflows/samples_flows_chat_chat_with_wikipedia.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdf.yml
+++ b/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdf.yml
@@ -70,7 +70,7 @@ jobs:
             pf connection create --file azure_openai.yml --set api_key=$AOAI_API_KEY api_base=$AOAI_API_ENDPOINT
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdfazure.yml
+++ b/.github/workflows/samples_flows_chat_chatwithpdf_chatwithpdfazure.yml
@@ -70,7 +70,7 @@ jobs:
             pf connection create --file azure_openai.yml --set api_key=$AOAI_API_KEY api_base=$AOAI_API_ENDPOINT
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_flows_chat_use_functions_with_chat_models.yml
+++ b/.github/workflows/samples_flows_chat_use_functions_with_chat_models.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_basic.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_chat_math.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_classification_accuracy.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_entity_match_rate.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_groundedness.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_multi_turn_metrics.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_multi_turn_metrics.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_perceived_intelligence.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_qna_non_rag.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_qna_non_rag.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_qna_rag_metrics.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_qna_rag_metrics.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_single_turn_metrics.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_single_turn_metrics.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_evaluation_eval_summarization.yml
+++ b/.github/workflows/samples_flows_evaluation_eval_summarization.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_autonomous_agent.yml
+++ b/.github/workflows/samples_flows_standard_autonomous_agent.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_basic.yml
+++ b/.github/workflows/samples_flows_standard_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_builtin_llm.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: pf connection create --file examples/connections/azure_openai.yml --set api_key=${{ secrets.AOAI_API_KEY_TEST }} api_base=${{ secrets.AOAI_API_ENDPOINT_TEST }}
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_basic_with_connection.yml
+++ b/.github/workflows/samples_flows_standard_basic_with_connection.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: pf connection create --file examples/connections/azure_openai.yml --set api_key=${{ secrets.AOAI_API_KEY_TEST }} api_base=${{ secrets.AOAI_API_ENDPOINT_TEST }}
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_if_else.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
+++ b/.github/workflows/samples_flows_standard_conditional_flow_for_switch.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
+++ b/.github/workflows/samples_flows_standard_customer_intent_extraction.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_describe_image.yml
+++ b/.github/workflows/samples_flows_standard_describe_image.yml
@@ -70,7 +70,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_additional_includes.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: pf connection create --file examples/connections/azure_openai.yml --set api_key=${{ secrets.AOAI_API_KEY_TEST }} api_base=${{ secrets.AOAI_API_ENDPOINT_TEST }}
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
+++ b/.github/workflows/samples_flows_standard_flow_with_symlinks.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: pf connection create --file examples/connections/azure_openai.yml --set api_key=${{ secrets.AOAI_API_KEY_TEST }} api_base=${{ secrets.AOAI_API_ENDPOINT_TEST }}
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_gen_docstring.yml
+++ b/.github/workflows/samples_flows_standard_gen_docstring.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_maths_to_code.yml
+++ b/.github/workflows/samples_flows_standard_maths_to_code.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_named_entity_recognition.yml
+++ b/.github/workflows/samples_flows_standard_named_entity_recognition.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_question_simulation.yml
+++ b/.github/workflows/samples_flows_standard_question_simulation.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_flows_standard_web_classification.yml
+++ b/.github/workflows/samples_flows_standard_web_classification.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_getstarted_flowasfunction.yml
+++ b/.github/workflows/samples_getstarted_flowasfunction.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create new Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}" name=new_ai_connection
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_getstarted_quickstart.yml
+++ b/.github/workflows/samples_getstarted_quickstart.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_getstarted_quickstartazure.yml
+++ b/.github/workflows/samples_getstarted_quickstartazure.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_prompty_basic.yml
+++ b/.github/workflows/samples_prompty_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_prompty_basic_promptyquickstart.yml
+++ b/.github/workflows/samples_prompty_basic_promptyquickstart.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_prompty_chat_basic.yml
+++ b/.github/workflows/samples_prompty_chat_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_prompty_chatbasic_chatwithprompty.yml
+++ b/.github/workflows/samples_prompty_chatbasic_chatwithprompty.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_prompty_eval_apology.yml
+++ b/.github/workflows/samples_prompty_eval_apology.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_prompty_eval_basic.yml
+++ b/.github/workflows/samples_prompty_eval_basic.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_prompty_format_output.yml
+++ b/.github/workflows/samples_prompty_format_output.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_prompty_formatoutput_promptyoutputformat.yml
+++ b/.github/workflows/samples_prompty_formatoutput_promptyoutputformat.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_runflowwithpipeline_pipeline.yml
+++ b/.github/workflows/samples_runflowwithpipeline_pipeline.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_runmanagement_cloudrunmanagement.yml
+++ b/.github/workflows/samples_runmanagement_cloudrunmanagement.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_runmanagement_runmanagement.yml
+++ b/.github/workflows/samples_runmanagement_runmanagement.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_cascading_inputs_tool_showcase.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_llm_tool_showcase.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_package_tool_showcase.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_custom_strong_type_connection_script_tool_showcase.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
+++ b/.github/workflows/samples_tools_use_cases_dynamic_list_input_tool_showcase.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tracing_autogengroupchat_traceautogengroupchat.yml
+++ b/.github/workflows/samples_tracing_autogengroupchat_traceautogengroupchat.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_tracing_customotlpcollector_otlptracecollector.yml
+++ b/.github/workflows/samples_tracing_customotlpcollector_otlptracecollector.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_tracing_langchain_tracelangchain.yml
+++ b/.github/workflows/samples_tracing_langchain_tracelangchain.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_tracing_llm_tracellm.yml
+++ b/.github/workflows/samples_tracing_llm_tracellm.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Aoai Connection
         run: pf connection create -f ${{ github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ secrets.AOAI_API_KEY_TEST }}" api_base="${{ secrets.AOAI_API_ENDPOINT_TEST }}"
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 1
           maximum: 99

--- a/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
+++ b/.github/workflows/samples_tutorials_e2e_development_chat_with_pdf.yml
@@ -84,7 +84,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_azure_app_service.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_create_service_with_flow.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_distribute_flow_as_executable_app.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_flow_deploy_docker.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_docker.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
+++ b/.github/workflows/samples_tutorials_flow_deploy_kubernetes.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
+++ b/.github/workflows/samples_tutorials_flow_fine_tuning_evaluation_promptflow_quality_improvement.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/.github/workflows/samples_tutorials_tracing.yml
+++ b/.github/workflows/samples_tutorials_tracing.yml
@@ -68,7 +68,7 @@ jobs:
             sed -i -e "s/\${azure_open_ai_connection.api_key}/${{ secrets.AOAI_API_KEY_TEST }}/g" -e "s/\${azure_open_ai_connection.api_base}/$gpt_base/g" run.yml
           fi
       - name: Random Wait
-        uses: AliSajid/random-wait-action@main
+        uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
         with:
           minimum: 0
           maximum: 99

--- a/scripts/readme/ghactions_driver/workflow_steps/step_azure_login.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_steps/step_azure_login.yml.jinja2
@@ -1,5 +1,5 @@
 - name: Random Wait
-  uses: AliSajid/random-wait-action@main
+  uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
   with:
     minimum: 0
     maximum: 99

--- a/scripts/readme/ghactions_driver/workflow_templates/autogen_workflow.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_templates/autogen_workflow.yml.jinja2
@@ -39,7 +39,7 @@ steps:
   - name: Create Aoai Connection
     run: pf connection create -f ${{ '{{' }} github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ '{{' }} secrets.AOAI_API_KEY_TEST }}" api_base="${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}"
   - name: Random Wait
-    uses: AliSajid/random-wait-action@main
+    uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
     with:
       minimum: 1
       maximum: 99

--- a/scripts/readme/ghactions_driver/workflow_templates/basic_workflow.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_templates/basic_workflow.yml.jinja2
@@ -34,7 +34,7 @@ steps:
   - name: Create Aoai Connection
     run: pf connection create -f ${{ '{{' }} github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ '{{' }} secrets.AOAI_API_KEY_TEST }}" api_base="${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}"
   - name: Random Wait
-    uses: AliSajid/random-wait-action@main
+    uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
     with:
       minimum: 1
       maximum: 99

--- a/scripts/readme/ghactions_driver/workflow_templates/flow_as_function.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_templates/flow_as_function.yml.jinja2
@@ -20,7 +20,7 @@ steps:
   - name: Create new Aoai Connection
     run: pf connection create -f ${{ '{{' }} github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ '{{' }} secrets.AOAI_API_KEY_TEST }}" api_base="${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}" name=new_ai_connection
   - name: Random Wait
-    uses: AliSajid/random-wait-action@main
+    uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
     with:
       minimum: 1
       maximum: 99

--- a/scripts/readme/ghactions_driver/workflow_templates/pdf_workflow.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_templates/pdf_workflow.yml.jinja2
@@ -49,7 +49,7 @@ steps:
         pf connection create --file azure_openai.yml --set api_key=$AOAI_API_KEY api_base=$AOAI_API_ENDPOINT
       fi
   - name: Random Wait
-    uses: AliSajid/random-wait-action@main
+    uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
     with:
       minimum: 1
       maximum: 99

--- a/scripts/readme/ghactions_driver/workflow_templates/workflow_config_json.yml.jinja2
+++ b/scripts/readme/ghactions_driver/workflow_templates/workflow_config_json.yml.jinja2
@@ -24,7 +24,7 @@ steps:
   - name: Create Aoai Connection
     run: pf connection create -f ${{ '{{' }} github.workspace }}/examples/connections/azure_openai.yml --set api_key="${{ '{{' }} secrets.AOAI_API_KEY_TEST }}" api_base="${{ '{{' }} secrets.AOAI_API_ENDPOINT_TEST }}"
   - name: Random Wait
-    uses: AliSajid/random-wait-action@main
+    uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
     with:
       minimum: 1
       maximum: 99


### PR DESCRIPTION
## Summary

One third-party GitHub Action in this repo is referenced by a mutable
**branch** ref instead of a tag or commit SHA:

```yaml
- name: Random Wait
  uses: AliSajid/random-wait-action@main
```

This appears in `scripts/readme/ghactions_driver/workflow_steps/step_azure_login.yml.jinja2`
and 5 more Jinja2 templates under `scripts/readme/ghactions_driver/workflow_templates/`,
and is generated into 84 checked-in workflow files under `.github/workflows/`
(the `samples_*` workflows).

## Why this is worth a separate look from #4214/#4207

I know GitHub Actions pinning is already an active effort here (#4214 open,
#4207/#4190 closed). I checked their diffs first and none of them touch this
reference — their tooling looks to have matched version-tag-style refs
(`@v1`, `@v2`, `@v4`, ...), and `@main` doesn't match that shape since it's
not a version tag at all.

That actually makes it the single riskiest pin in the whole workflow set:
a tag at least requires the upstream maintainer (or a compromised account)
to deliberately retarget it, but a branch head moves on *every* commit to
that branch, with zero action required on the attacker's side beyond
pushing to `main`. Several of the workflows that use this step run with
`id-token: write` and Azure OIDC federated-credential secrets
(`AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/`AZURE_SUBSCRIPTION_ID`,
`AOAI_API_KEY_TEST`), so any step in that job — this one included — can
mint a token for `api://AzureADTokenExchange` for the duration of the run.

This is the same risk class described in the GitHub Actions security
hardening guide and referenced in #4214/#4190 (tj-actions/changed-files,
codfish/semantic-release-action).

## What changed

Pinned to the commit currently tagged `v2.12.0` on that action's repo,
with a version comment, matching the `<sha> # <tag>` convention already
used by #4214/#4207 for the other actions in this repo:

```yaml
uses: AliSajid/random-wait-action@933d3635c56777d240b67abe794f1a5f7bdfd063 # v2.12.0
```

Applied to:
- the 6 Jinja2 templates (the actual source of truth, generated via
  `python3 readme.py`)
- the 84 already-generated `.github/workflows/samples_*.yml` files, so the
  checked-in files stay consistent with what regeneration would produce

No other lines were touched — every changed file is a single-line diff
(90 files, 90 insertions, 90 deletions). Verified all 120 workflow YAML
files still parse after the change (`yaml.safe_load` over every file in
`.github/workflows/`).

## Is this safe to merge?

Yes. `933d3635c56777d240b67abe794f1a5f7bdfd063` is the exact commit the
`v2.12.0` tag and (at the time of writing) the `main` branch both point to,
confirmed via the GitHub API — no behavioral change. The action's inputs
(`minimum`, `maximum`) are unchanged in that version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)